### PR TITLE
Performance: instrumentation, PT/RT internals in the CLI, fewer allocations, assorted wins

### DIFF
--- a/backend/src/Builtins/Builtins.Cli/Libs/Terminal.fs
+++ b/backend/src/Builtins/Builtins.Cli/Libs/Terminal.fs
@@ -7,6 +7,8 @@ open Prelude
 open LibExecution.RuntimeTypes
 open LibExecution.Builtin.Shortcuts
 
+module VT = LibExecution.ValueType
+
 
 /// Restores terminal state if the process exits before Dark can clean up.
 ///
@@ -161,14 +163,14 @@ module DisplayWidth =
 
     total
 
-  /// Clip styled text to `maxWidth` terminal columns, keeping SGR and dropping everything else.
+  /// Clip styled text to `maxWidth` terminal columns, keeping ANSI styling and dropping everything else.
   ///
-  /// Same contract as the Dark implementation this replaces: numeric SGR is retained and costs no columns,
-  /// every other escape and control character is dropped so dynamic content can't move the cursor or change
-  /// modes, and a double-width cluster is never split in half.
+  /// Colour/style escapes (`ESC[...m`) are retained and cost no columns. Every other escape and control
+  /// character is dropped, so dynamic content can't move the cursor or change modes, and a double-width
+  /// cluster is never split in half.
   ///
-  /// Native because the Dark version needs a width call per character. Fine for one prompt row, far too slow
-  /// for a full-screen frame, which is hundreds of clipped spans.
+  /// Native because this needs a display-width lookup per character, and a full-screen frame is hundreds
+  /// of clipped spans.
   let clipToWidth (text : string) (maxWidth : int) : string =
     if maxWidth <= 0 then
       ""
@@ -194,6 +196,81 @@ module DisplayWidth =
             i <- i + cluster.Length
 
       out.ToString()
+
+
+  /// Wrap text into explicit terminal-width rows, preserving any ANSI styling it carries.
+  ///
+  /// "SGR" is the ANSI escape that sets colour and style (`ESC[1;31m` and friends). Those are kept and
+  /// cost zero columns; every other escape and control character is dropped. A grapheme cluster is never
+  /// split, styling active at a wrap is reapplied at the start of the next row (the frame renderer resets
+  /// styling after each row), and an empty input yields one empty row.
+  ///
+  /// Native rather than Dark because it runs on the interactive prompt on *every keystroke*, once per
+  /// character, and each character needs a display-width lookup.
+  let wrapStyled (text : string) (maxWidth : int) : string list =
+    let width = max 1 maxWidth
+    let completed = ResizeArray<string>()
+    let current = System.Text.StringBuilder()
+    let mutable activeStyle = ""
+    let mutable currentWidth = 0
+    let mutable wrapPending = false
+    let mutable i = 0
+
+    while i < text.Length do
+      if text[i] = '\u001b' then
+        let mutable kept = ""
+        let next = skipEscape text i (fun s -> kept <- s)
+        // Mirrors Dark's `nextActiveStyle`: a full reset clears accumulated styling, any other retained
+        // SGR appends to it, and a dropped (non-SGR) escape leaves it alone.
+        if kept = "\u001b[0m" then activeStyle <- ""
+        elif kept <> "" then activeStyle <- activeStyle + kept
+        current.Append(kept) |> ignore<System.Text.StringBuilder>
+        i <- next
+      elif System.Char.IsControl text[i] then
+        i <- i + 1
+      else
+        let cluster = System.Globalization.StringInfo.GetNextTextElement(text, i)
+        let charWidth = clusterWidth cluster
+        let shouldWrap =
+          wrapPending || (currentWidth > 0 && currentWidth + charWidth > width)
+
+        if shouldWrap then
+          completed.Add(current.ToString())
+          current.Clear() |> ignore<System.Text.StringBuilder>
+          current.Append(activeStyle) |> ignore<System.Text.StringBuilder>
+
+        current.Append(cluster) |> ignore<System.Text.StringBuilder>
+        currentWidth <- if shouldWrap then charWidth else currentWidth + charWidth
+        wrapPending <- currentWidth >= width
+        i <- i + cluster.Length
+
+    completed.Add(current.ToString())
+    List.ofSeq completed
+
+  /// Zero-based cursor position immediately after plain text.
+  ///
+  /// A cursor exactly after the final column is reported at column zero of the following row, matching
+  /// terminal wrap behaviour. Plain text only: callers pass an already-stripped prompt prefix, so there
+  /// is no escape handling here.
+  let positionAfter (text : string) (maxWidth : int) : int * int =
+    let width = max 1 maxWidth
+    let mutable row = 0
+    let mutable column = 0
+    let mutable wrapPending = false
+    let mutable i = 0
+
+    while i < text.Length do
+      let cluster = System.Globalization.StringInfo.GetNextTextElement(text, i)
+      let charWidth = clusterWidth cluster
+      let startRow = if wrapPending then row + 1 else row
+      let startColumn = if wrapPending then 0 else column
+      let shouldWrap = startColumn > 0 && startColumn + charWidth > width
+      row <- if shouldWrap then startRow + 1 else startRow
+      column <- if shouldWrap then charWidth else startColumn + charWidth
+      wrapPending <- column >= width
+      i <- i + cluster.Length
+
+    if wrapPending then (row + 1, 0) else (row, column)
 
 
 /// Report raw terminal facts used by Dark's TUI availability policy.
@@ -346,6 +423,49 @@ let fns () : List<BuiltInFn> =
         (function
         | _, vm, _, [ DString text; DInt maxWidth ] ->
           DString(DisplayWidth.clipToWidth text (intToInt32 vm maxWidth)) |> Ply
+        | _ -> incorrectArgs ())
+      sqlSpec = NotQueryable
+      previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
+      deprecated = NotDeprecated }
+
+
+    { name = fn "cliTerminalWrapStyled" 0
+      typeParams = []
+      parameters =
+        [ Param.make "text" TString "One logical row, possibly carrying SGR styling"
+          Param.make "maxWidth" TInt "Terminal columns to wrap at" ]
+      returnType = TList TString
+      description =
+        "Wrap plain or SGR-styled text into terminal-width rows, reapplying active styling after a wrap"
+      fn =
+        (function
+        | _, vm, _, [ DString text; DInt maxWidth ] ->
+          DisplayWidth.wrapStyled text (intToInt32 vm maxWidth)
+          |> List.map DString
+          |> fun rows -> DList(VT.string, rows)
+          |> Ply
+        | _ -> incorrectArgs ())
+      sqlSpec = NotQueryable
+      previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
+      deprecated = NotDeprecated }
+
+
+    { name = fn "cliTerminalPositionAfter" 0
+      typeParams = []
+      parameters =
+        [ Param.make "text" TString "Plain, control-free text"
+          Param.make "maxWidth" TInt "Terminal columns per row" ]
+      returnType = TTuple(TInt, TInt, [])
+      description =
+        "Zero-based (row, column) cursor position immediately after plain text at a given width"
+      fn =
+        (function
+        | _, vm, _, [ DString text; DInt maxWidth ] ->
+          let (row, column) =
+            DisplayWidth.positionAfter text (intToInt32 vm maxWidth)
+          DTuple(row |> bigint |> Dval.int, column |> bigint |> Dval.int, []) |> Ply
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure

--- a/backend/src/Builtins/Builtins.Matter/Libs/PM/Packages.fs
+++ b/backend/src/Builtins/Builtins.Matter/Libs/PM/Packages.fs
@@ -398,7 +398,179 @@ let fns (pm : PT.PackageManager) : List<BuiltInFn> =
       deprecated = NotDeprecated }
 
 
+    { name = fn "pmSearchNames" 0
+      typeParams = []
+      parameters =
+        [ Param.make "branchId" TUuid "Branch to search on"
+          Param.make
+            "query"
+            (TCustomType(NR.ok (PT2DT.Search.SearchQuery.typeName ()), []))
+            "" ]
+      returnType =
+        TTuple(TList TString, TList TString, [ TList TString; TList TString ])
+      description =
+        "Search, returning only names: (direct submodules, types, values, fns). Submodules are already
+         reduced to the direct children of the query's module and sorted."
+      fn =
+        function
+        | _, _, _, [ DUuid branchId; query as DRecord(_, _, _, _fields) ] ->
+          uply {
+            let searchQuery = PT2DT.Search.SearchQuery.fromDT query
+            let! branchChain = Branches.getBranchChain branchId
+            let! results = PMPT.search branchChain searchQuery
+
+            // Mirrors `Query.getDirectSubmodules`: drop the current path, keep the next segment, dedupe,
+            // sort. Reduced here rather than in Dark because at the root of a large store this is hundreds
+            // of module paths collapsing to a handful of names, and the search already has them all.
+            let depth = List.length searchQuery.currentModule
+            // `List.skip` throws past the end; Dark's `List.drop` yields []. Match Dark.
+            let rec dropN n (xs : List<string>) =
+              if n <= 0 then
+                xs
+              else
+                match xs with
+                | [] -> []
+                | _ :: rest -> dropN (n - 1) rest
+            let submodules =
+              results.submodules
+              |> List.choose (fun modulePath ->
+                match dropN depth modulePath with
+                | next :: _ when next <> "" -> Some next
+                | _ -> None)
+              |> List.distinct
+              |> List.sort
+
+            let names (locations : List<PT.LocatedItem<'a>>) =
+              locations |> List.map (fun i -> i.location.name)
+
+            let toDList (xs : List<string>) =
+              xs |> List.map DString |> Dval.list KTString
+
+            return
+              DTuple(
+                toDList submodules,
+                toDList (names results.types),
+                [ toDList (names results.values); toDList (names results.fns) ]
+              )
+          }
+        | _ -> incorrectArgs ()
+      sqlSpec = NotQueryable
+      previewable = Impure
+      capabilities = LibExecution.Capabilities.noCaps
+      deprecated = NotDeprecated }
+
+
+    { name = fn "pmSearchNamesAndHashes" 0
+      typeParams = []
+      parameters =
+        [ Param.make "branchId" TUuid "Branch to search on"
+          Param.make
+            "query"
+            (TCustomType(NR.ok (PT2DT.Search.SearchQuery.typeName ()), []))
+            "" ]
+      returnType =
+        let nameAndHash =
+          TList(TTuple(TString, TCustomType(NR.ok (PT2DT.Hash.typeName ()), []), []))
+        TTuple(TList TString, nameAndHash, [ nameAndHash; nameAndHash ])
+      description =
+        "Search, returning (direct submodules, types, values, fns) as (name, hash) pairs. Like
+         pmSearchNames but keeps each item's hash, which listings need for deprecation marks."
+      fn =
+        function
+        | _, _, _, [ DUuid branchId; query as DRecord(_, _, _, _fields) ] ->
+          uply {
+            let searchQuery = PT2DT.Search.SearchQuery.fromDT query
+            let! branchChain = Branches.getBranchChain branchId
+            let! results = PMPT.search branchChain searchQuery
+
+            let depth = List.length searchQuery.currentModule
+            // `List.skip` throws past the end; Dark's `List.drop` yields []. Match Dark.
+            let rec dropN n (xs : List<string>) =
+              if n <= 0 then
+                xs
+              else
+                match xs with
+                | [] -> []
+                | _ :: rest -> dropN (n - 1) rest
+            let submodules =
+              results.submodules
+              |> List.choose (fun modulePath ->
+                match dropN depth modulePath with
+                | next :: _ when next <> "" -> Some next
+                | _ -> None)
+              |> List.distinct
+              |> List.sort
+
+            let pairKT =
+              KTTuple(VT.string, ValueType.Known(PT2DT.Hash.knownType ()), [])
+
+            let toDList (xs : List<string>) =
+              xs |> List.map DString |> Dval.list KTString
+
+            let pairs
+              (locations : List<PT.LocatedItem<'a>>)
+              (hashOf : 'a -> PT.Hash)
+              =
+              locations
+              |> List.map (fun i ->
+                DTuple(
+                  DString i.location.name,
+                  PT2DT.Hash.toDT (hashOf i.entity),
+                  []
+                ))
+              |> Dval.list pairKT
+
+            return
+              DTuple(
+                toDList submodules,
+                pairs results.types (fun (t : PT.PackageType.PackageType) -> t.hash),
+                [ pairs results.values (fun (v : PT.PackageValue.PackageValue) ->
+                    v.hash)
+                  pairs results.fns (fun (f : PT.PackageFn.PackageFn) -> f.hash) ]
+              )
+          }
+        | _ -> incorrectArgs ()
+      sqlSpec = NotQueryable
+      previewable = Impure
+      capabilities = LibExecution.Capabilities.noCaps
+      deprecated = NotDeprecated }
+
+
     // Location lookups — returns ALL locations for a hash
+    // Hands the compiled instruction stream to Dark so it can be rendered there
+    // (`PrettyPrinter.RuntimeTypes.instructions`). Data only: no formatting happens in F#, because a
+    // disassembly listing is exactly the kind of thing Dark should own. The PT side needs no equivalent
+    // builtin -- `pmGetFn` already returns the tree.
+    { name = fn "pmFnInstructions" 0
+      typeParams = []
+      parameters =
+        [ Param.make "hash" (TCustomType(NR.ok (PT2DT.Hash.typeName ()), [])) "" ]
+      returnType =
+        TypeReference.option (
+          TCustomType(NR.ok (RT2DT.Instructions.typeName ()), [])
+        )
+      description =
+        "Returns the register-machine instructions a package function compiles to, "
+        + "or None if there's no such function."
+      fn =
+        (function
+        | exeState, _, _, [ hashDval ] ->
+          uply {
+            let (PT.Hash hashStr) = PT2DT.Hash.fromDT hashDval
+            match! exeState.fns.package (Hash hashStr) with
+            | None -> return Dval.optionNone (RT2DT.Instructions.knownType ())
+            | Some rtFn ->
+              return
+                RT2DT.Instructions.toDT rtFn.body
+                |> Dval.optionSome (RT2DT.Instructions.knownType ())
+          }
+        | _ -> incorrectArgs ())
+      sqlSpec = NotQueryable
+      previewable = Impure
+      capabilities = LibExecution.Capabilities.noCaps
+      deprecated = NotDeprecated }
+
+
     { name = fn "pmGetLocationsByType" 0
       typeParams = []
       parameters =

--- a/backend/src/Builtins/Builtins.Pure/Libs/List.fs
+++ b/backend/src/Builtins/Builtins.Pure/Libs/List.fs
@@ -375,6 +375,131 @@ let fns () : List<BuiltInFn> =
       deprecated = NotDeprecated }
 
 
+    { name = fn "listPush" 0
+      typeParams = []
+      parameters = [ Param.make "list" (TList varA) ""; Param.make "value" varA "" ]
+      returnType = TList varA
+      description = "Adds <param value> to the front of <param list>."
+      fn =
+        (function
+        | _, vm, _, [ DList(vt, l); value ] ->
+          // Native because every list built by a fold goes through here, once per element, and the
+          // Dark version had to build a one-element list to append.
+          match VT.merge vt (Dval.toValueType value) with
+          | Ok merged -> Ply(DList(merged, value :: l))
+          | Error() -> Ply(TypeChecker.DvalCreator.list vm.threadID vt (value :: l))
+        | _ -> incorrectArgs ())
+      sqlSpec = NotYetImplemented
+      previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
+      deprecated = NotDeprecated }
+
+
+    { name = fn "listPushBack" 0
+      typeParams = []
+      parameters = [ Param.make "list" (TList varA) ""; Param.make "value" varA "" ]
+      returnType = TList varA
+      description = "Adds <param value> to the back of <param list>."
+      fn =
+        (function
+        | _, vm, _, [ DList(vt, l); value ] ->
+          // Still O(n): a cons list has to be copied to append. Native for the same reason as `push`.
+          match VT.merge vt (Dval.toValueType value) with
+          | Ok merged -> Ply(DList(merged, l @ [ value ]))
+          | Error() ->
+            Ply(TypeChecker.DvalCreator.list vm.threadID vt (l @ [ value ]))
+        | _ -> incorrectArgs ())
+      sqlSpec = NotYetImplemented
+      previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
+      deprecated = NotDeprecated }
+
+
+    { name = fn "listFlatten" 0
+      typeParams = []
+      parameters = [ Param.make "list" (TList(TList varA)) "" ]
+      returnType = TList varA
+      description =
+        "Returns a single list containing the values of every list directly in <param list>
+         (does not recursively flatten nested lists)."
+      fn =
+        (function
+        | _, vm, _, [ DList(_, sublists) ] ->
+          // One concat, rather than an append per sublist, which re-copies the accumulator each step.
+          let inner =
+            sublists
+            |> List.fold
+              (fun acc sub ->
+                match acc, sub with
+                | Ok accVt, DList(vt, _) ->
+                  match VT.merge accVt vt with
+                  | Ok merged -> Ok merged
+                  | Error() -> Error()
+                | _ -> Error())
+              (Ok VT.unknown)
+          let items =
+            sublists
+            |> List.collect (fun sub ->
+              match sub with
+              | DList(_, items) -> items
+              | other -> [ other ])
+          match inner with
+          | Ok vt -> Ply(DList(vt, items))
+          | Error() -> Ply(TypeChecker.DvalCreator.list vm.threadID VT.unknown items)
+        | _ -> incorrectArgs ())
+      sqlSpec = NotYetImplemented
+      previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
+      deprecated = NotDeprecated }
+
+
+    { name = fn "listGetAt" 0
+      typeParams = []
+      parameters = [ Param.make "list" (TList varA) ""; Param.make "index" TInt "" ]
+      returnType = TypeReference.option varA
+      description =
+        "Returns {{Some value}} at <param index> in <param list>, or {{None}} if out of bounds."
+      fn =
+        (function
+        | _, vm, _, [ DList(vt, l); DInt index ] ->
+          // Still a walk, since that's what a cons list costs, but one walk rather than an interpreted
+          // call per position. Deliberately not `List.length` then `List.item`: that is O(n) even for
+          // index 0, and callers ask for low indices of long lists.
+          let rec walk (remaining : int64) (rest : List<Dval>) : Option<Dval> =
+            match rest with
+            | [] -> None
+            | head :: tail ->
+              if remaining = 0L then Some head else walk (remaining - 1L) tail
+          let item =
+            match DarkInt.toInt64 index with
+            | Some i when i >= 0L -> walk i l
+            | _ -> None
+          Ply(TypeChecker.DvalCreator.option vm.threadID vt item)
+        | _ -> incorrectArgs ())
+      sqlSpec = NotYetImplemented
+      previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
+      deprecated = NotDeprecated }
+
+
+    { name = fn "listReverse" 0
+      typeParams = []
+      parameters = [ Param.make "list" (TList varA) "" ]
+      returnType = TList varA
+      description = "Returns a reversed copy of <param list>."
+      fn =
+        (function
+        | _, _, _, [ DList(vt, l) ] ->
+          // Reordering can't change the element type and every element was checked on the way in, so no
+          // type check is needed. Native because `map` and `filter` both end in a reverse.
+          Ply(DList(vt, List.rev l))
+        | _ -> incorrectArgs ())
+      sqlSpec = NotYetImplemented
+      previewable = Pure
+      capabilities = LibExecution.Capabilities.noCaps
+      deprecated = NotDeprecated }
+
+
     ]
 
 

--- a/backend/src/Builtins/Builtins.Time/Libs/Time.fs
+++ b/backend/src/Builtins/Builtins.Time/Libs/Time.fs
@@ -42,7 +42,16 @@ let fns () : List<BuiltInFn> =
         (function
         | _, _, _, [ DUnit ] ->
           let ts = System.Diagnostics.Stopwatch.GetTimestamp()
-          let ms = ts * 1000L / System.Diagnostics.Stopwatch.Frequency
+          // Divide the ticks, don't scale them: `ts * 1000L` overflows int64 once the tick count passes
+          // ~9.2e15, which on a 1 GHz-tick clocksource is ~106 days of uptime, after which the wrap makes
+          // differences meaningless. Same bug class as the one that produced the negative durations in
+          // Prelude/Telemetry.fs. Differences stay accurate to 1 ms either way, which is all this promises.
+          let ticksPerMs = System.Diagnostics.Stopwatch.Frequency / 1000L
+          let ms =
+            if ticksPerMs > 0L then
+              ts / ticksPerMs
+            else
+              ts * 1000L / System.Diagnostics.Stopwatch.Frequency
           LibExecution.Dval.int (bigint ms) |> Ply
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
@@ -67,6 +76,29 @@ let fns () : List<BuiltInFn> =
       capabilities = LibExecution.Capabilities.noCaps
       deprecated = NotDeprecated }
 
+    { name = fn "interpreterStatsEnableDetailedTiming" 0
+      typeParams = []
+      parameters = [ Param.make "enabled" TBool "" ]
+      returnType = TUnit
+      description =
+        "Turns per-builtin and per-package-fn cumulative timing on or off for this VM. "
+        + "Off by default even when counting is on, because it costs a Stopwatch read per "
+        + "call: that is ~20ns on a TSC host but ~1.27us on an HPET one, where it would "
+        + "dominate the calls being measured. Turn it on for a deliberate profiling run, "
+        + "never for a run whose wall time you intend to quote."
+      fn =
+        (function
+        | _, vm, _, [ DBool enabled ] ->
+          // Counting has to be on for timing to record anything; asking for timing implies it.
+          if enabled then vm.stats.enabled <- true
+          vm.stats.detailedTiming <- enabled
+          DUnit |> Ply
+        | _ -> incorrectArgs ())
+      sqlSpec = NotYetImplemented
+      previewable = Impure
+      capabilities = LibExecution.Capabilities.noCaps
+      deprecated = NotDeprecated }
+
     { name = fn "interpreterStatsGet" 0
       typeParams = []
       parameters = [ Param.make "unit" TUnit "" ]
@@ -75,11 +107,20 @@ let fns () : List<BuiltInFn> =
         "Returns interpreter performance counters as a JSON string. "
         + "Includes instruction count, builtin/package call counts, frame pushes. "
         + "When detailed timing is enabled, also includes per-builtin and per-package-fn "
-        + "cumulative microseconds and call counts."
+        + "cumulative nanoseconds and call counts."
       fn =
         (function
         | _, vm, _, [ DUnit ] ->
           let s = vm.stats
+          // The accumulators hold raw Stopwatch ticks, so that the hot path has no division in it.
+          // Convert once, here. Reporting ticks as microseconds would be wrong by `Frequency / 1e6`,
+          // which varies by clocksource, so it's worse than being uniformly wrong.
+          //
+          // Nanoseconds rather than microseconds: individual calls cost tens of nanoseconds, so a
+          // microsecond report rounds nearly all of them to zero.
+          let nsPerTick =
+            1_000_000_000.0 / float System.Diagnostics.Stopwatch.Frequency
+          let toNs (ticks : int64) : int64 = int64 (float ticks * nsPerTick)
           let sb = System.Text.StringBuilder()
           sb.Append("{") |> ignore<System.Text.StringBuilder>
           sb.Append($"\"instructions\":{s.instructionCount}")
@@ -103,7 +144,7 @@ let fns () : List<BuiltInFn> =
                 match s.builtinCounts.TryGetValue(kv.Key) with
                 | true, c -> c
                 | _ -> 0L
-              sb.Append($"\"{kv.Key}\":{{\"us\":{kv.Value},\"n\":{count}}}")
+              sb.Append($"\"{kv.Key}\":{{\"ns\":{toNs kv.Value},\"n\":{count}}}")
               |> ignore<System.Text.StringBuilder>
               first <- false
             sb.Append("}") |> ignore<System.Text.StringBuilder>
@@ -117,7 +158,7 @@ let fns () : List<BuiltInFn> =
                 match s.packageFnCounts.TryGetValue(kv.Key) with
                 | true, c -> c
                 | _ -> 0L
-              sb.Append($"\"{kv.Key}\":{{\"us\":{kv.Value},\"n\":{count}}}")
+              sb.Append($"\"{kv.Key}\":{{\"ns\":{toNs kv.Value},\"n\":{count}}}")
               |> ignore<System.Text.StringBuilder>
               first <- false
             sb.Append("}") |> ignore<System.Text.StringBuilder>

--- a/backend/src/Cli/Cli.fs
+++ b/backend/src/Cli/Cli.fs
@@ -107,7 +107,10 @@ let execute
   (args : List<string>)
   : Task<RT.ExecutionResult> =
   task {
-    let state = state packageManager
+    // Split out because `cli.execute` turned out to be nearly identical for `status` and `help` despite help
+    // running 5x the instructions, which means most of it is a FIXED cost, not the Dark code running.
+    // `state` builds the builtins map and the execution state; this says how much of the fixed cost is that.
+    let state = Telemetry.time "cli.buildState" [] (fun () -> state packageManager)
     let fnName = RT.FQFnName.fqPackage (PackageRefs.Fn.Cli.executeCliCommand ())
     let args =
       args |> List.map RT.DString |> Dval.list RT.KTString |> NEList.singleton
@@ -120,23 +123,70 @@ let initSerializers () = ()
 [<EntryPoint>]
 let main (args : string[]) =
   try
+    // How long the process took to reach here. `cli.total` starts after resource extraction and can't
+    // see runtime init, assembly loading or JIT of the startup path, which is a large share of a short
+    // command. Wall clock rather than Stopwatch, because the only fixed point is when the OS started us.
+    // Read the switch before doing any measuring: `Process.GetCurrentProcess()` reads /proc and
+    // initialises the Process machinery, which is not free on a command this short, and the only thing
+    // it feeds is a telemetry event.
+    let telemetryEnabled =
+      match System.Environment.GetEnvironmentVariable "DARK_TELEMETRY" with
+      | "1" -> true
+      | _ -> false
+
+    let preMainMs =
+      if telemetryEnabled then
+        let processStart =
+          System.Diagnostics.Process.GetCurrentProcess().StartTime.ToUniversalTime()
+        int64 (System.DateTime.UtcNow - processStart).TotalMilliseconds
+      else
+        0L
+
     // Extract embedded resources FIRST — this sets DARK_CONFIG_RUNDIR
     // which LibConfig.Config needs to resolve paths correctly.
+    let extractStart = System.Diagnostics.Stopwatch.GetTimestamp()
     EmbeddedResources.extract ()
+    let extractTicks = System.Diagnostics.Stopwatch.GetTimestamp() - extractStart
     initSerializers ()
 
-    // Now safe to access LibConfig paths
-    let telemetryPath =
-      System.IO.Path.Combine(LibConfig.Config.logDir, "telemetry.jsonl")
-    Telemetry.init telemetryPath
+    // Now safe to access LibConfig paths.
+    //
+    // Gated on DARK_TELEMETRY (read above), the same switch the Dark side reads (see `initState` in
+    // cli/core.dark), so both halves of the instrument turn on together. Unconditional init would append
+    // to telemetry.jsonl on every invocation, and, since `InterpreterStats.create()` keys off this, would
+    // also leave per-instruction counting on in the hot loop for every run.
+    if telemetryEnabled then
+      Telemetry.init (
+        System.IO.Path.Combine(LibConfig.Config.logDir, "telemetry.jsonl")
+      )
+    // Emitted now rather than at the top, because telemetry has no output path until `init` above.
+    Telemetry.event "cli.preMain" [ "ms", string preMainMs ]
+    let ticksToMs (t : int64) = t * 1000L / System.Diagnostics.Stopwatch.Frequency
+    Telemetry.event "cli.extractResources" [ "ms", string (ticksToMs extractTicks) ]
+    // Drained here rather than logged in place: `extract` runs before telemetry has an output path.
+    for (label, ticks) in EmbeddedResources.timings do
+      Telemetry.event $"cli.{label}" [ "ms", string (ticksToMs ticks) ]
+
     use _totalSpan = Telemetry.span "cli.total" []
 
-    // If data.db is missing but seed.db exists, copy seed as data.db
-    let dbPath = LibConfig.Config.dbPath
-    let seedPath = System.IO.Path.Combine(LibConfig.Config.runDir, "seed.db")
-    if not (System.IO.File.Exists dbPath) && System.IO.File.Exists seedPath then
-      System.Console.Error.WriteLine "Copying seed.db as data.db"
-      System.IO.File.Copy(seedPath, dbPath)
+    // Named so the phases inside `cli.total` sum to it. Without this most of the total lands in "the
+    // rest", which is not a useful place for time to live.
+    Telemetry.time "cli.seedCheck" [] (fun () ->
+      // If data.db is missing but seed.db exists, copy seed as data.db
+      let dbPath = LibConfig.Config.dbPath
+      let seedPath = System.IO.Path.Combine(LibConfig.Config.runDir, "seed.db")
+      if not (System.IO.File.Exists dbPath) && System.IO.File.Exists seedPath then
+        System.Console.Error.WriteLine "Copying seed.db as data.db"
+        System.IO.File.Copy(seedPath, dbPath))
+
+    // Force the module-level `builtins` binding here, so its cost is attributed to a span of its own
+    // rather than to whichever phase happens to touch it first.
+    Telemetry.time "cli.builtinsInit" [] (fun () ->
+      builtins.fns |> Map.count |> ignore<int>)
+
+    // Separated from `growIfNeeded` so the first connection open and its PRAGMA round trip are attributable
+    // to themselves rather than to whichever query happened to run first.
+    Telemetry.time "cli.dbConnect" [] LibDB.Sqlite.Sql.warm
 
     // Grow the database: apply any unapplied ops and evaluate values.
     let cliPackageManager =
@@ -155,7 +205,95 @@ let main (args : string[]) =
         let result = execute cliPackageManager (Array.toList args)
         result.Result)
 
-    NonBlockingConsole.wait ()
+    Telemetry.time "cli.consoleWait" [] NonBlockingConsole.wait
+
+    // Startup instrumentation. All of it is inert when telemetry is off; read it with
+    // `scripts/testing/view-telemetry.py`.
+
+    // How many package items this run actually decoded. Emitted alongside the spans because per-item
+    // cost and item count are useless separately.
+    Telemetry.counterSnapshot ()
+    |> List.iter (fun (name, n) -> Telemetry.event name [ "count", string n ])
+
+    // Total the interpreter counters across every VM this run created. A VM is per-`executeFunction`
+    // and the stats hang off it, so without the sink the object is gone before anything could ask.
+    if Telemetry.isEnabled () then
+      let stats =
+        RT.InterpreterStatsSink.all
+        |> Seq.choose (fun o ->
+          match o with
+          | :? RT.InterpreterStats as s -> Some s
+          | _ -> None)
+        |> Seq.toList
+
+      // Per-opcode allocation, summed across every VM. Names come from reflection over the Instruction DU
+      // so tag order can't drift out of sync with a hand-written list.
+      let opcodeNames = RT.Opcode.names
+      let totalAlloc = Array.zeroCreate 32
+      let totalCount = Array.zeroCreate 32
+      for s in stats do
+        for i in 0..31 do
+          totalAlloc[i] <- totalAlloc[i] + s.allocByOpcode[i]
+          totalCount[i] <- totalCount[i] + s.countByOpcode[i]
+      for i in 0..31 do
+        if totalCount[i] > 0L then
+          let name = if i < opcodeNames.Length then opcodeNames[i] else string i
+          Telemetry.event
+            $"opcode.{name}"
+            [ "count", string totalCount[i]
+              "allocBytes", string totalAlloc[i]
+              "bytesPerOp", string (totalAlloc[i] / totalCount[i]) ]
+
+      // Per-builtin allocation, summed across VMs. This is what named the cost: ~99% of everything the
+      // process allocates happens inside builtin bodies, not the interpreter around them.
+      let byBuiltin = System.Collections.Generic.Dictionary<string, int64>()
+      for s in stats do
+        for kv in s.builtinAlloc do
+          match byBuiltin.TryGetValue kv.Key with
+          | true, v -> byBuiltin[kv.Key] <- v + kv.Value
+          | false, _ -> byBuiltin[kv.Key] <- kv.Value
+      byBuiltin
+      |> Seq.sortByDescending (fun kv -> kv.Value)
+      |> Seq.truncate 20
+      |> Seq.iter (fun kv ->
+        Telemetry.event $"builtinAlloc.{kv.Key}" [ "bytes", string kv.Value ])
+
+      for i in 0 .. min (RT.ApplyStage.names.Length - 1) 31 do
+        let total = stats |> List.sumBy (fun s -> s.allocByStage[i])
+        if total > 0L then
+          Telemetry.event
+            $"applyStage.{RT.ApplyStage.names[i]}"
+            [ "bytes", string total ]
+
+      Telemetry.event
+        "vm.stats"
+        [ "vms", string (List.length stats)
+          "instructions", string (stats |> List.sumBy (fun s -> s.instructionCount))
+          "builtinCalls", string (stats |> List.sumBy (fun s -> s.builtinCallCount))
+          "packageCalls", string (stats |> List.sumBy (fun s -> s.packageCallCount))
+          "framePushes", string (stats |> List.sumBy (fun s -> s.framePushCount))
+          "registersAllocated",
+          string (stats |> List.sumBy (fun s -> s.registersAllocated))
+          "builtinBodyAlloc",
+          string (stats |> List.sumBy (fun s -> s.builtinBodyAlloc))
+          "tstSizeSum", string (stats |> List.sumBy (fun s -> s.tstSizeSum))
+          "tstSizeMax",
+          string (stats |> List.map (fun s -> s.tstSizeMax) |> List.fold max 0L) ]
+
+    // Allocation per instruction, to separate "we allocate a Dval per operation" from "the async state
+    // machine costs per operation". Process-total, so it costs one call at exit rather than anything per
+    // instruction. GC counts come along because collection pauses would show up as neither.
+    if Telemetry.isEnabled () then
+      Telemetry.event
+        "gc.stats"
+        [ "totalAllocatedBytes", string (System.GC.GetTotalAllocatedBytes(false))
+          "gen0", string (System.GC.CollectionCount 0)
+          "gen1", string (System.GC.CollectionCount 1)
+          "gen2", string (System.GC.CollectionCount 2) ]
+
+    Telemetry.timerSnapshot ()
+    |> List.iter (fun (name, us) ->
+      Telemetry.event name [ "us", string us; "ms", string (us / 1000L) ])
 
     // Exit codes are bounded; narrow safely rather than letting an out-of-Int32
     // result throw an uncaught host OverflowException.

--- a/backend/src/Cli/Cli.fsproj
+++ b/backend/src/Cli/Cli.fsproj
@@ -3,6 +3,15 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <IsTrimmable>true</IsTrimmable>
+
+    <!-- Tiered PGO instruments tier-0 code to build a profile that tier-1 then optimizes against. A CLI
+         command lives a second or two and exits, so it pays the instrumentation and never collects on the
+         profile: measured ~20% of release throughput on a call-heavy script, and ~9% in Debug.
+
+         Scoped to this project rather than set globally because `darklang serve` is long-lived and is
+         exactly the shape PGO is designed for. If serve ever moves into its own entry point, it should
+         keep the default. -->
+    <TieredPGO>false</TieredPGO>
     <!-- Publishing configuration -->
     <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
     <!-- Assembly linking - trim framework assemblies too -->

--- a/backend/src/Cli/EmbeddedResources.fs
+++ b/backend/src/Cli/EmbeddedResources.fs
@@ -216,12 +216,27 @@ let private reconcileExistingStore (dbPath : string) : unit =
     // store.
     reseedAndReport dbPath current label
 
+/// Sub-timings for `extract`, in Stopwatch ticks. Collected rather than logged because `extract` runs
+/// before telemetry has an output path: it's what sets DARK_CONFIG_RUNDIR, which is where the log lives.
+/// `Cli.Main` drains this once telemetry is up.
+///
+/// Worth splitting out because on a shipped single-file binary this phase reads as "startup" when it's
+/// really a manifest-resource enumeration plus a throwaway SQLite connection, which are different
+/// things to fix.
+let timings : ResizeArray<string * int64> = ResizeArray()
+
+let inline private timed (label : string) (f : unit -> 'a) : 'a =
+  let t0 = System.Diagnostics.Stopwatch.GetTimestamp()
+  let r = f ()
+  timings.Add(label, System.Diagnostics.Stopwatch.GetTimestamp() - t0)
+  r
+
 let extract () : unit =
   // The embedded resource is `data.db.gz` (the seed db, gzip-compressed at
   // build time to save ~7 MB on binary size). On first run, decompress to
   // `~/.darklang/data.db`; on subsequent runs the file already exists and
   // grow/init proceeds against the local copy.
-  if hasEmbeddedResource "data.db.gz" then
+  if timed "extract.hasResource" (fun () -> hasEmbeddedResource "data.db.gz") then
     let darklangDir = getDarklangDirectory ()
 
     Environment.SetEnvironmentVariable("DARK_CONFIG_RUNDIR", darklangDir)
@@ -244,4 +259,4 @@ let extract () : unit =
 
       printfn "CLI data directory setup complete"
     else
-      reconcileExistingStore dbPath
+      timed "extract.reconcileStore" (fun () -> reconcileExistingStore dbPath)

--- a/backend/src/LibDB/Caching.fs
+++ b/backend/src/LibDB/Caching.fs
@@ -8,18 +8,21 @@ open Prelude
 
 
 let withCache (f : 'key -> Ply<Option<'value>>) =
-  let cache = ConcurrentDictionary<'key, 'value>()
+  // Holds the `Some` wrapper rather than the value, so a hit hands back the same option object instead
+  // of building a fresh one. `None` still isn't cached: a lookup that missed the store might succeed
+  // later, and this cache has no way to hear about it.
+  let cache = ConcurrentDictionary<'key, Option<'value>>()
   fun (key : 'key) ->
-    uply {
-      let mutable cached = Unchecked.defaultof<'value>
-      let inCache = cache.TryGetValue(key, &cached)
-      if inCache then
-        return Some cached
-      else
-        //debuG "missed" key
+    let mutable cached = Unchecked.defaultof<Option<'value>>
+    if cache.TryGetValue(key, &cached) then
+      // Deliberately outside the computation expression. Once a script is warm nearly every call lands
+      // here, and entering the builder to hand over a value already in hand costs more than the lookup.
+      Ply cached
+    else
+      uply {
         let! result = f key
         match result with
-        | Some v -> cache.TryAdd(key, v) |> ignore<bool>
+        | Some _ -> cache.TryAdd(key, result) |> ignore<bool>
         | None -> ()
         return result
-    }
+      }

--- a/backend/src/LibDB/NameLookup.fs
+++ b/backend/src/LibDB/NameLookup.fs
@@ -51,6 +51,7 @@ let findFirstPackageMatch
   (genericName : GenericName)
   (findInPM : PT.PackageLocation -> Ply<Option<Hash>>)
   : Ply<Option<Hash * PT.PackageLocation>> =
+  Telemetry.count "pkg.nameLookup"
   Ply.List.foldSequentially
     (fun acc (candidate : GenericName) ->
       match acc with

--- a/backend/src/LibDB/PackageManager.fs
+++ b/backend/src/LibDB/PackageManager.fs
@@ -48,7 +48,7 @@ let rt : RT.PackageManager =
     persistBlob = PMRT.Blob.insert
 
     isHarmful =
-      fun branchId (RT.Hash h) -> Ply(Set.contains h (loadHarmfulForBranch branchId))
+      fun branchId (RT.Hash h) -> Set.contains h (loadHarmfulForBranch branchId)
 
     init =
       uply {

--- a/backend/src/LibDB/PackageRefsGenerator.fs
+++ b/backend/src/LibDB/PackageRefsGenerator.fs
@@ -26,6 +26,26 @@ let private sourceTreePath =
   |> System.IO.Path.GetFullPath
 
 
+/// The `fqn -> hash` pairs already on disk, or empty if the file is missing or unreadable.
+let private readExistingFile () : Map<string, string> =
+  try
+    if System.IO.File.Exists(sourceTreePath) then
+      System.IO.File.ReadAllLines(sourceTreePath)
+      |> Array.choose (fun line ->
+        let line = line.Trim()
+        if line = "" then
+          None
+        else
+          match line.Split('|') with
+          | [| fqn; hash |] -> Some(fqn, hash)
+          | _ -> None)
+      |> Map.ofArray
+    else
+      Map.empty
+  with _ ->
+    Map.empty
+
+
 /// Query the DB for all current Darklang-owned locations and write
 /// `package-ref-hashes.txt` in the source tree.
 let generate () : Ply<unit> =
@@ -45,7 +65,21 @@ let generate () : Ply<unit> =
         buildKey "fn" (String.concat "." modules) name)
       |> Set.ofList
 
-    let allRefKeys = Set.union typeRefKeys fnRefKeys
+    // Union in whatever the existing file already knew about.
+    //
+    // `_lookup` is only populated as each `PackageRefs` nested module initializes, which happens when
+    // something touches it. A process that regenerates before touching them all -- or an older binary that
+    // predates a ref entirely -- would otherwise silently write a *shorter* file, dropping refs. That is
+    // not a theoretical concern: `growIfNeeded` regenerates on any startup that applies ops, so running a
+    // previous release inside the source tree was enough to truncate the file, after which the next build
+    // produced a binary that raised "PackageRefs: hash not found" on startup.
+    //
+    // Keys that no longer resolve are dropped below by the `List.choose` against the DB, so this
+    // accumulates known refs without letting deleted ones linger.
+    let existingKeys =
+      readExistingFile () |> Map.toList |> List.map fst |> Set.ofList
+
+    let allRefKeys = Set.unionMany [ typeRefKeys; fnRefKeys; existingKeys ]
 
     // Query all Darklang-owned locations from DB
     let! dbRows =
@@ -65,25 +99,9 @@ let generate () : Ply<unit> =
 
     let dbMap = dbRows |> Map.ofList
 
-    // Read the existing file to preserve entries not found in DB
-    // (e.g. RT types that share hashes with PT types and aren't in locations)
-    let existingMap =
-      try
-        if System.IO.File.Exists(sourceTreePath) then
-          System.IO.File.ReadAllLines(sourceTreePath)
-          |> Array.choose (fun line ->
-            let line = line.Trim()
-            if line = "" then
-              None
-            else
-              match line.Split('|') with
-              | [| fqn; hash |] -> Some(fqn, hash)
-              | _ -> None)
-          |> Map.ofArray
-        else
-          Map.empty
-      with _ ->
-        Map.empty
+    // Preserves entries not found in the DB (e.g. RT types that share hashes with PT types and aren't in
+    // locations), and, via `existingKeys` above, refs this process never registered.
+    let existingMap = readExistingFile ()
 
     // Merge: DB values win, existing file fills gaps for referenced items
     let merged =

--- a/backend/src/LibDB/ProgramTypes.fs
+++ b/backend/src/LibDB/ProgramTypes.fs
@@ -216,6 +216,7 @@ let search
       WHERE l.unlisted_at IS NULL
         AND {submoduleCondition}
         AND {branchFilter}
+      ORDER BY owner, modules
       """
       |> Sql.query
       |> Sql.parameters (sqlParams @ branchParams)
@@ -297,7 +298,11 @@ let search
       + $"  AND l.item_type = '{itemType}'\n"
       + $"  AND ({locationCondition})\n"
       + $"  AND {nameCondition}\n"
-      + $"  AND {branchFilter}"
+      + $"  AND {branchFilter}\n"
+      // Without this the order is whatever SQLite happens to produce, which is rowid order and therefore
+      // shifts whenever the package set changes. That made results reshuffle between runs for no reason
+      // the reader could see, and made any before/after diff of `search` output pure noise.
+      + "  ORDER BY l.owner, l.modules, l.name"
       |> Sql.query
       |> Sql.parameters (
         [ "modules", Sql.string currentModule

--- a/backend/src/LibDB/Queries.fs
+++ b/backend/src/LibDB/Queries.fs
@@ -242,7 +242,9 @@ let private getDependentsByLocationsChunk
             )
             AND l.unlisted_at IS NULL
             AND l.branch_id IN ({branchInClause})
-          ORDER BY l.item_hash
+          -- By name, not by hash. Hash order is stable but arbitrary to a reader, so a dependents list
+          -- looked shuffled; these columns are already selected, so ordering by them is free.
+          ORDER BY l.owner, l.modules, l.name
         """
 
       return!

--- a/backend/src/LibDB/RuntimeTypes.fs
+++ b/backend/src/LibDB/RuntimeTypes.fs
@@ -11,11 +11,33 @@ module RT = LibExecution.RuntimeTypes
 module BS = LibSerialization.Binary.Serialization
 
 
+/// Bracket a package-item load, splitting "the query" from "turning bytes into a runtime value": different
+/// problems with different fixes, and an aggregate can't tell them apart.
+///
+/// Gated: `Stopwatch.GetTimestamp()` costs ~1.27us on an HPET clocksource, so this is not something to
+/// pay when nobody is measuring.
+module private LoadTiming =
+  let inline enabled () = Telemetry.isEnabled ()
+
+  let inline now (on : bool) =
+    if on then System.Diagnostics.Stopwatch.GetTimestamp() else 0L
+
+  let record (on : bool) (kind : string) (t0 : int64) (t1 : int64) (t2 : int64) =
+    if on then
+      let toUs (a : int64) (b : int64) =
+        (b - a) * 1_000_000L / System.Diagnostics.Stopwatch.Frequency
+      Telemetry.addUs $"pkg.{kind}.sql" (toUs t0 t1)
+      Telemetry.addUs $"pkg.{kind}.deserialize" (toUs t1 t2)
+
+
 module Type =
   let get (hash : Hash) : Ply<Option<RT.PackageType.PackageType>> =
     uply {
+      Telemetry.count "pkg.type.get"
       let (Hash hashStr) = hash
-      return!
+      let on = LoadTiming.enabled ()
+      let t0 = LoadTiming.now on
+      let! bytes =
         Sql.query
           """
           SELECT rt_def
@@ -24,7 +46,11 @@ module Type =
           """
         |> Sql.parameters [ "hash", Sql.string hashStr ]
         |> Sql.executeRowOptionAsync (fun read -> read.bytes "rt_def")
-        |> Task.map (Option.map (BS.RT.PackageType.deserialize hash))
+      let t1 = LoadTiming.now on
+      let result = bytes |> Option.map (BS.RT.PackageType.deserialize hash)
+      let t2 = LoadTiming.now on
+      LoadTiming.record on "type" t0 t1 t2
+      return result
     }
 
 
@@ -37,8 +63,11 @@ module Value =
   /// not-yet-evaluated value the same as an absent one (grow populates it before it's needed in the happy path).
   let get (hash : Hash) : Ply<Option<RT.PackageValue.PackageValue>> =
     uply {
+      Telemetry.count "pkg.value.get"
       let (Hash hashStr) = hash
-      return!
+      let on = LoadTiming.enabled ()
+      let t0 = LoadTiming.now on
+      let! bytes =
         Sql.query
           """
           SELECT rt_dval
@@ -47,7 +76,11 @@ module Value =
           """
         |> Sql.parameters [ "hash", Sql.string hashStr ]
         |> Sql.executeRowOptionAsync (fun read -> read.bytes "rt_dval")
-        |> Task.map (Option.map (BS.RT.PackageValue.deserialize hash))
+      let t1 = LoadTiming.now on
+      let result = bytes |> Option.map (BS.RT.PackageValue.deserialize hash)
+      let t2 = LoadTiming.now on
+      LoadTiming.record on "value" t0 t1 t2
+      return result
     }
 
   /// Find all value hashes that have the given ValueType (exact match)
@@ -70,7 +103,14 @@ module Fn =
   let get (hash : Hash) : Ply<Option<RT.PackageFn.PackageFn>> =
     uply {
       let (Hash hashStr) = hash
-      return!
+      // One query and one deserialize PER FUNCTION, demand-driven. Counted because the per-item cost only
+      // matters once you know the item count -- see `Telemetry.count`.
+      Telemetry.count "pkg.fn.get"
+      // Gated: on an HPET clocksource a timestamp costs ~1.27us, so three per load is not something to
+      // pay when nobody is measuring.
+      let on = LoadTiming.enabled ()
+      let t0 = LoadTiming.now on
+      let! bytes =
         Sql.query
           """
           SELECT rt_instrs
@@ -79,7 +119,11 @@ module Fn =
           """
         |> Sql.parameters [ "hash", Sql.string hashStr ]
         |> Sql.executeRowOptionAsync (fun read -> read.bytes "rt_instrs")
-        |> Task.map (Option.map (BS.RT.PackageFn.deserialize hash))
+      let t1 = LoadTiming.now on
+      let result = bytes |> Option.map (BS.RT.PackageFn.deserialize hash)
+      let t2 = LoadTiming.now on
+      LoadTiming.record on "fn" t0 t1 t2
+      return result
     }
 
 
@@ -88,6 +132,7 @@ module Blob =
   /// Look up bytes by hash. Returns [None] when the row doesn't exist.
   let get (hash : string) : Ply<Option<byte[]>> =
     uply {
+      Telemetry.count "pkg.blob.get"
       return!
         Sql.query
           """

--- a/backend/src/LibDB/Sqlite.fs
+++ b/backend/src/LibDB/Sqlite.fs
@@ -38,6 +38,17 @@ module Sql =
   // never rebinds it — it stays the default `connString` store for the process's life.
   let mutable connect = Sql.connect connString |> initializeConnection
 
+  /// Force this module's initialization, and with it the first connection open and the PRAGMA round trip.
+  ///
+  /// Exists so the cost is attributable. It happens on whatever query runs first, which made it look like
+  /// part of `growIfNeeded`'s op check -- a check that is index-covered and takes 0.0 ms against this
+  /// store. Calling this first moves the cost into a span of its own rather than removing it.
+  let warm () : unit =
+    connect
+    |> Sql.query "SELECT 1"
+    |> Sql.executeNonQuery
+    |> ignore<Result<int, exn>>
+
   /// TEST-ONLY: repoint LibDB at the store file at `path` (created if missing), so a test can run true
   /// multi-instance scenarios — each "instance" is its own store, and you switch the active one by
   /// calling this. Every subsequent LibDB operation hits `path`. Call `resetStoreForTesting` to restore
@@ -53,14 +64,55 @@ module Sql =
     connString <- defaultConnString
     connect <- Sql.connect connString |> initializeConnection
 
+  /// Count and time every SQL statement this process runs.
+  ///
+  /// Instrumenting only package-item loads leaves everything Dark code issues through `Stdlib.Sqlite`,
+  /// `pmSearch` and the SCM builtins invisible, which is most of it, and makes SQL time easy to mistake
+  /// for interpreter cost.
+  ///
+  /// Gated, and per-statement rather than per-row: a timestamp costs ~1.27 us on an HPET clocksource.
+  let inline private timedTask (name : string) (f : unit -> Task<'a>) : Task<'a> =
+    if not (Telemetry.isEnabled ()) then
+      f ()
+    else
+      task {
+        Telemetry.count $"sql.{name}"
+        let t0 = System.Diagnostics.Stopwatch.GetTimestamp()
+        let! r = f ()
+        let t1 = System.Diagnostics.Stopwatch.GetTimestamp()
+        Telemetry.addUs
+          "sql.total"
+          ((t1 - t0) * 1_000_000L / System.Diagnostics.Stopwatch.Frequency)
+        return r
+      }
+
+  let inline private timedSync (name : string) (f : unit -> 'a) : 'a =
+    if not (Telemetry.isEnabled ()) then
+      f ()
+    else
+      Telemetry.count $"sql.{name}"
+      let t0 = System.Diagnostics.Stopwatch.GetTimestamp()
+      let r = f ()
+      let t1 = System.Diagnostics.Stopwatch.GetTimestamp()
+      Telemetry.addUs
+        "sql.total"
+        ((t1 - t0) * 1_000_000L / System.Diagnostics.Stopwatch.Frequency)
+      r
+
   let query (sql : string) : Sql.SqlProps = connect |> Sql.query sql
 
   let executeNonQueryAsync props =
-    Sql.executeNonQueryAsync props |> Async.StartAsTask |> Task.map Result.unwrap
+    timedTask "nonQuery" (fun () ->
+      Sql.executeNonQueryAsync props
+      |> Async.StartImmediateAsTask
+      |> Task.map Result.unwrap)
 
   let executeRowAsync (reader : RowReader -> 't) (props : Sql.SqlProps) : Task<'t> =
     task {
-      match! Sql.executeAsync reader props with
+      match!
+        timedTask "row" (fun () ->
+          Sql.executeAsync reader props |> Async.StartImmediateAsTask)
+      with
       | Ok [ a ] -> return a
       | Ok [] -> return Exception.raiseInternal $"No results; expected 1" []
       | Ok list ->
@@ -78,7 +130,10 @@ module Sql =
     (props : Sql.SqlProps)
     : Task<Option<'t>> =
     task {
-      match! Sql.executeAsync reader props with
+      match!
+        timedTask "rowOption" (fun () ->
+          Sql.executeAsync reader props |> Async.StartImmediateAsTask)
+      with
       | Ok [ a ] -> return Some a
       | Ok [] -> return None
       | Ok list ->
@@ -95,7 +150,7 @@ module Sql =
 
   let executeAsync rr props =
     Sql.executeAsync rr props
-    |> Async.StartAsTask
+    |> Async.StartImmediateAsTask
     |> Task.map (fun r ->
       match r with
       | Ok v -> v
@@ -103,7 +158,9 @@ module Sql =
         Exception.raiseInternal $"SQL query failed: {err}" [ "error", err ])
 
   let executeExistsSync (props : Sql.SqlProps) : bool =
-    match Sql.execute (fun read -> read.bool 0) props with
+    match
+      timedSync "existsSync" (fun () -> Sql.execute (fun read -> read.bool 0) props)
+    with
     | Ok [ true ] -> true
     | Ok [] -> false
     | Ok result ->
@@ -115,7 +172,10 @@ module Sql =
 
   let executeStatementAsync (props : Sql.SqlProps) : Task<unit> =
     task {
-      match! Sql.executeNonQueryAsync props with
+      match!
+        timedTask "statement" (fun () ->
+          Sql.executeNonQueryAsync props |> Async.StartImmediateAsTask)
+      with
       | Error err ->
         Exception.raiseInternal
           $"Database statement failed in executeStatementAsync: {err}"
@@ -124,7 +184,7 @@ module Sql =
     }
 
   let executeStatementSync (props : Sql.SqlProps) : unit =
-    match Sql.executeNonQuery props with
+    match timedSync "statementSync" (fun () -> Sql.executeNonQuery props) with
     | Ok _count -> ()
     | Error err ->
       Exception.raiseInternal

--- a/backend/src/LibDB/Tracing.fs
+++ b/backend/src/LibDB/Tracing.fs
@@ -164,18 +164,31 @@ module FnNameCache =
             $"{owner}.{modules}{name}")
           |> Async.AwaitTask
           |> Async.RunSynchronously
+          |> Ok
         with ex ->
           print $"[tracing] FnNameCache failed to resolve {hash}: {ex.Message}"
           Telemetry.event
             "trace.fnNameCacheResolveFailed"
             [ "hash", hash; "message", ex.Message ]
-          None
+          Error()
 
+      // Cache the miss too, as the raw hash. Caching only hits means a hash with no row in `locations`
+      // re-queries SQLite on every reference. A miss is as stable an answer as a hit, and the contract is
+      // already that a trace records the name as of execution time.
+      //
+      // A *failure* is not a miss, though, and must not be cached: the store being briefly unreadable
+      // (locked mid-reload, say) would otherwise degrade every later reference in the process to a raw
+      // hash, permanently, for a transient reason. Fall back to the hash for this one lookup and retry
+      // next time.
       match result with
-      | Some name ->
-        cache <- Map.add hash name cache
-        name
-      | None -> hash
+      | Error() -> hash
+      | Ok found ->
+        let resolved =
+          match found with
+          | Some name -> name
+          | None -> hash
+        cache <- Map.add hash resolved cache
+        resolved
 
 
 /// Display name written into the fn_hash column. Resolved at write time
@@ -217,16 +230,80 @@ type PartialEvent =
   }
 
 
+/// Cap on how many call events a single trace retains.
+///
+/// A trace is a debugging aid a human reads; past a few thousand calls it stops being one. Meanwhile every
+/// retained event pins its arguments and result alive, gets walked by `prepareTraceForStorage`, and gets
+/// binary-serialized twice (args and result) at store time. Uncapped, a list-heavy script spends most of
+/// its run and most of its allocation writing the trace rather than executing the program.
+///
+/// Override with `DARK_CONFIG_TRACE_MAX_EVENTS`; 0 means unlimited, for when you genuinely need the whole
+/// thing and are willing to pay for it.
+module TraceLimits =
+  let private fromEnv () : int =
+    match
+      System.Environment.GetEnvironmentVariable "DARK_CONFIG_TRACE_MAX_EVENTS"
+    with
+    | null
+    | "" -> 10_000
+    | s ->
+      match System.Int32.TryParse s with
+      | true, n when n >= 0 -> n
+      | _ -> 10_000
+
+  let mutable maxEvents : int = fromEnv ()
+
+  /// TEST-ONLY: run with a small cap, so a test can cross it without generating (and rendering) ten
+  /// thousand events. Call `resetMaxEventsForTesting` when done. NOT parallel-safe: it mutates
+  /// process-global state, so callers must be `testSequenced`.
+  let useMaxEventsForTesting (n : int) : unit = maxEvents <- n
+
+  /// TEST-ONLY: restore the configured cap after `useMaxEventsForTesting`.
+  let resetMaxEventsForTesting () : unit = maxEvents <- fromEnv ()
+
+
 /// Mutable per-trace tracer state. Captures every event in execution order
 /// and tracks the open call stack so children can find their parent.
 type TracerState =
-  { events : System.Collections.Generic.List<CompletedEvent>
-    stack : System.Collections.Generic.Stack<PartialEvent> }
+  {
+    events : System.Collections.Generic.List<CompletedEvent>
+    stack : System.Collections.Generic.Stack<PartialEvent>
+    /// Events past `TraceLimits.maxEvents`, counted so the trace can say it was truncated rather than
+    /// quietly looking complete.
+    mutable dropped : int
+  }
 
 
 let private newState () : TracerState =
   { events = System.Collections.Generic.List<CompletedEvent>()
-    stack = System.Collections.Generic.Stack<PartialEvent>() }
+    stack = System.Collections.Generic.Stack<PartialEvent>()
+    dropped = 0 }
+
+
+/// Retain an event unless we're at the cap, **reserving a slot for every frame still on the stack**.
+///
+/// That reservation is the whole trick, and without it the cap is worse than useless. Events are appended
+/// on *completion*, so they arrive in post-order: leaves first, the entry frame last. A naive "keep the
+/// first N" therefore keeps only the deepest calls and drops every one of their ancestors, including the
+/// single root. `formatFnCalls` renders by walking down from roots, so the result is a trace where every
+/// retained event is an orphan nothing walks to, and the viewer shows the truncation marker and nothing
+/// else.
+///
+/// Reserving `stack.Count` fixes it, because the frames on the stack are exactly the ancestors of whatever
+/// is completing now. Each pop both frees a reservation and consumes it, so `events.Count + stack.Count`
+/// never exceeds the cap and every ancestor of a retained event is itself retained. What gets dropped is
+/// deep siblings, which is what you want: the tree stays walkable and loses breadth, not its spine.
+///
+/// The *stack* is deliberately not capped: it's bounded by call depth rather than call count, and
+/// pushes/pops have to stay balanced or parent linkage breaks for the events we do keep.
+let private addEvent (state : TracerState) (ev : CompletedEvent) : unit =
+  if
+    TraceLimits.maxEvents = 0
+    || state.events.Count + state.stack.Count < TraceLimits.maxEvents
+  then
+    state.events.Add ev
+  else
+    state.dropped <- state.dropped + 1
 
 
 let private currentParentCallId (state : TracerState) : string option =
@@ -274,7 +351,8 @@ let private makeStoreFnResult (state : TracerState) : RT.Tracing.StoreFnResult =
   fun (_, name) args result ->
     match name with
     | RT.FQFnName.Builtin _ ->
-      state.events.Add(
+      addEvent
+        state
         { callId = newCallId ()
           parentCallId = currentParentCallId state
           kind = "builtin"
@@ -284,12 +362,12 @@ let private makeStoreFnResult (state : TracerState) : RT.Tracing.StoreFnResult =
           result = result
           // No frame-entry counterpart for builtins, so no real duration.
           durationMs = 0L }
-      )
     | RT.FQFnName.Package _ ->
       if state.stack.Count > 0 then
         let partial = state.stack.Pop()
         let endedAt = System.Diagnostics.Stopwatch.GetTimestamp()
-        state.events.Add(
+        addEvent
+          state
           { callId = partial.callId
             parentCallId = partial.parentCallId
             kind = "function"
@@ -298,7 +376,6 @@ let private makeStoreFnResult (state : TracerState) : RT.Tracing.StoreFnResult =
             args = partial.args
             result = result
             durationMs = ticksToMs (endedAt - partial.startedAtTicks) }
-        )
 
 
 /// Fired when a Lambda frame returns. Pop the matching entry and finalize.
@@ -309,7 +386,8 @@ let private makeStoreLambdaResult
     if state.stack.Count > 0 then
       let partial = state.stack.Pop()
       let endedAt = System.Diagnostics.Stopwatch.GetTimestamp()
-      state.events.Add(
+      addEvent
+        state
         { callId = partial.callId
           parentCallId = partial.parentCallId
           kind = "lambda"
@@ -318,7 +396,6 @@ let private makeStoreLambdaResult
           args = partial.args
           result = result
           durationMs = ticksToMs (endedAt - partial.startedAtTicks) }
-      )
 
 
 /// Store trace data to SQLite.
@@ -490,6 +567,10 @@ let private storeTrace
 
       let traceIdStr = string traceID
       use _span = Telemetry.span "trace.store" [ "traceId", traceIdStr ]
+      if state.dropped > 0 then
+        Telemetry.event
+          "trace.truncated"
+          [ "kept", string state.events.Count; "dropped", string state.dropped ]
       try
         let! preparedInput = prepareTraceForStorage exeState inputDval state
         TraceStorage.store
@@ -498,7 +579,23 @@ let private storeTrace
           handlerDesc
           inputVarName
           preparedInput
-          (Seq.toList state.events)
+          // A truncated trace carries a final marker row rather than just ending. Without it the trace
+          // reads as complete, and "the call I'm looking for isn't here" is indistinguishable from "it
+          // never happened" -- which is the one thing a debugging aid must never be ambiguous about.
+          (if state.dropped > 0 then
+             (Seq.toList state.events)
+             @ [ { callId = newCallId ()
+                   parentCallId = None
+                   kind = "truncated"
+                   fnHash =
+                     Some
+                       $"trace truncated: {state.dropped} further calls not recorded (cap {TraceLimits.maxEvents}, raise with DARK_CONFIG_TRACE_MAX_EVENTS)"
+                   lambdaExprId = None
+                   args = []
+                   result = RT.DUnit
+                   durationMs = 0L } ]
+           else
+             Seq.toList state.events)
           exeState.accountID
       with ex ->
         System.Console.Error.WriteLine
@@ -552,18 +649,32 @@ let createCliTracer
   : T =
   let results = TraceResults.empty ()
   let state = newState ()
-  { enabled = true
-    results = results
-    executionTracing =
-      { Exe.noTracing with
-          storeFrameEntry = makeStoreFrameEntry state
-          storeFnResult = makeStoreFnResult state
-          storeLambdaResult = makeStoreLambdaResult state
-          skipTracing = false }
-    storeTraceInput = fun _ _ _ -> ()
-    storeTraceResults =
-      fun exeState ->
-        storeTrace 0UL traceID description inputVarName inputDval state exeState }
+
+  // With detail off, collect nothing. `storeTrace` refuses to write in that case, so installing the
+  // hooks anyway means building an event per frame and holding every argument and result alive for the
+  // whole run, to discard all of it at the end.
+  //
+  // `Exe.noTracing` sets `skipTracing = true`, which also lets the interpreter skip its own per-frame
+  // bookkeeping (`pendingCallArgs`) rather than just calling no-op hooks.
+  if TraceDetail.current = TraceDetail.Off then
+    { enabled = false
+      results = results
+      executionTracing = Exe.noTracing
+      storeTraceInput = fun _ _ _ -> ()
+      storeTraceResults = fun _ -> uply { return () } }
+  else
+    { enabled = true
+      results = results
+      executionTracing =
+        { Exe.noTracing with
+            storeFrameEntry = makeStoreFrameEntry state
+            storeFnResult = makeStoreFnResult state
+            storeLambdaResult = makeStoreLambdaResult state
+            skipTracing = false }
+      storeTraceInput = fun _ _ _ -> ()
+      storeTraceResults =
+        fun exeState ->
+          storeTrace 0UL traceID description inputVarName inputDval state exeState }
 
 
 let createNonTracer (_traceID : AT.TraceID.T) : T =

--- a/backend/src/LibExecution/Execution.fs
+++ b/backend/src/LibExecution/Execution.fs
@@ -74,8 +74,8 @@ let rec callStackForFrame
       [ "frameID", string frameID ]
   | true, frame ->
     match frame.parent with
-    | None -> soFar
-    | Some(parentFrameID, _, _) ->
+    | ValueNone -> soFar
+    | ValueSome(parentFrameID, _, _) ->
       callStackForFrame vm parentFrameID (frame.executionPoint :: soFar)
 
 

--- a/backend/src/LibExecution/Interpreter.fs
+++ b/backend/src/LibExecution/Interpreter.fs
@@ -7,30 +7,100 @@ module RTE = RuntimeError
 module VT = ValueType
 
 
-/// Collect every TVariable name reachable inside [tr]. Used to find
-/// a fn's "implicit" type parameters — the free type-vars in its
-/// param/return types — so we can shadow inherited TST bindings
-/// of the same name when entering the fn's frame. Without shadowing,
-/// an outer fn's `'a := KTString` would leak into a nested fn's
-/// param of type `value: 'a` and force the nested arg to be a
-/// String even when the nested fn's own `'a` was meant to be
-/// something else.
-let rec private collectTVars (acc : Set<string>) (tr : TypeReference) : Set<string> =
-  match tr with
-  | TVariable name -> Set.add name acc
-  | TList inner
-  | TStream inner
-  | TDict inner
-  | TDB inner -> collectTVars acc inner
-  | TTuple(a, b, rest) ->
-    let acc = collectTVars acc a
-    let acc = collectTVars acc b
-    rest |> List.fold collectTVars acc
-  | TCustomType(_, args) -> args |> List.fold collectTVars acc
-  | TFn(args, ret) ->
-    let acc = NEList.toList args |> List.fold collectTVars acc
-    collectTVars acc ret
-  | _ -> acc
+/// The free type-vars of a function's signature -- its "implicit" type parameters -- computed once per
+/// function rather than per call.
+///
+/// Used to shadow inherited TST bindings of the same name when entering the fn's frame. Without
+/// shadowing, an outer fn's `'a := KTString` would leak into a nested fn's param of type `value: 'a` and
+/// force the nested arg to be a String even when the nested fn's own `'a` was meant to be something else.
+///
+/// Safe to memoise: it's a pure function of the signature, and a signature can't change under a running
+/// process, since package fns are content-addressed and builtins are compiled in. Most functions have no
+/// free type-vars at all, and `Set.empty` is a singleton, so the usual answer costs nothing.
+///
+/// Keyed by name/hash rather than held on the fn record because `BuiltInFn` and `PackageFn` are defined
+/// well below here and shared with code that has no interest in this.
+module private FreeTVars =
+  let private builtins =
+    System.Collections.Concurrent.ConcurrentDictionary<FQFnName.Builtin, Set<string>>()
+
+  let private packages =
+    System.Collections.Concurrent.ConcurrentDictionary<Hash, Set<string>>()
+
+  let rec private collect (acc : Set<string>) (tr : TypeReference) : Set<string> =
+    match tr with
+    | TVariable name -> Set.add name acc
+    | TList inner
+    | TStream inner
+    | TDict inner
+    | TDB inner -> collect acc inner
+    | TTuple(a, b, rest) ->
+      let acc = collect acc a
+      let acc = collect acc b
+      rest |> List.fold collect acc
+    | TCustomType(_, args) -> args |> List.fold collect acc
+    | TFn(args, ret) ->
+      let acc = NEList.toList args |> List.fold collect acc
+      collect acc ret
+    | _ -> acc
+
+  let ofBuiltin (fn : BuiltInFn) : Set<string> =
+    match builtins.TryGetValue fn.name with
+    | true, v -> v
+    | false, _ ->
+      let v =
+        fn.parameters
+        |> List.fold (fun acc (p : BuiltInParam) -> collect acc p.typ) Set.empty
+        |> fun acc -> collect acc fn.returnType
+      builtins[fn.name] <- v
+      v
+
+  /// Same idea for the frame's `ExecutionPoint`. It's two allocations -- the `FQFnName.Package` and the
+  /// `Function` around it -- built identically on every call to the same function.
+  let private packageEntryPoints =
+    System.Collections.Concurrent.ConcurrentDictionary<Hash, ExecutionPoint>()
+
+  let packageExecutionPoint (hash : Hash) : ExecutionPoint =
+    match packageEntryPoints.TryGetValue hash with
+    | true, v -> v
+    | false, _ ->
+      let v = Function(FQFnName.Package hash)
+      packageEntryPoints[hash] <- v
+      v
+
+  let ofPackage (fn : PackageFn.PackageFn) : Set<string> =
+    match packages.TryGetValue fn.hash with
+    | true, v -> v
+    | false, _ ->
+      let v =
+        fn.parameters
+        |> NEList.toList
+        |> List.fold
+          (fun acc (p : PackageFn.Parameter) -> collect acc p.typ)
+          Set.empty
+        |> fun acc -> collect acc fn.returnType
+      packages[fn.hash] <- v
+      v
+
+
+/// Read a list of registers into their Dvals in a single pass.
+///
+/// Don't simplify this back to `regs |> NEList.toList |> List.map (fun r -> registers[r])`: that runs on
+/// every Apply and allocates the intermediate list, the mapped result and a closure over `registers`.
+/// Top-level rather than local so `registers` is a parameter and nothing is captured.
+let rec private readRegs
+  (registers : Registers)
+  (regs : List<Register>)
+  : List<Dval> =
+  match regs with
+  | [] -> []
+  | r :: rest -> registers[r] :: readRegs registers rest
+
+let private readRegsNE
+  (registers : Registers)
+  (regs : NEList<Register>)
+  : List<Dval> =
+  registers[regs.head] :: readRegs registers regs.tail
 
 
 /// True iff the ValueType has no Unknown anywhere in its tree.
@@ -98,38 +168,69 @@ let rec private isFullyKnown (vt : ValueType) : bool =
 ///   - On any shape mismatch (different head, mismatched arity), we
 ///     return `acc` unchanged and let typeCheckParams report the
 ///     real error.
+/// Matches on `tr` and then on `vt`, rather than on the pair, and walks argument lists in lockstep
+/// rather than zipping them. `Tuple<TypeReference, ValueType>` was the most-allocated type in the
+/// interpreter's allocation-tick profile, and this function is where they came from: it runs per argument
+/// per call and recurses through the type structure.
 let rec private inferTVarsFromArg
   (acc : Map<string, ValueType>)
   (tr : TypeReference)
   (vt : ValueType)
   : Map<string, ValueType> =
-  match tr, vt with
-  | TVariable name, vt when isFullyKnown vt && not (Map.containsKey name acc) ->
-    Map.add name vt acc
-  | TVariable _, _ -> acc
-
-  | TList tr', ValueType.Known(KTList vt') -> inferTVarsFromArg acc tr' vt'
-  | TStream tr', ValueType.Known(KTStream vt') -> inferTVarsFromArg acc tr' vt'
-  | TDict tr', ValueType.Known(KTDict vt') -> inferTVarsFromArg acc tr' vt'
-
-  | TTuple(a, b, rest), ValueType.Known(KTTuple(a', b', rest')) ->
-    let acc = inferTVarsFromArg acc a a'
-    let acc = inferTVarsFromArg acc b b'
-    if List.length rest = List.length rest' then
-      List.zip rest rest'
-      |> List.fold (fun acc (tr, vt) -> inferTVarsFromArg acc tr vt) acc
+  match tr with
+  | TVariable name ->
+    if isFullyKnown vt && not (Map.containsKey name acc) then
+      Map.add name vt acc
     else
       acc
 
-  | TCustomType({ resolved = Ok _ }, typeArgs),
-    ValueType.Known(KTCustomType(_, vtArgs)) ->
-    if List.length typeArgs = List.length vtArgs then
-      List.zip typeArgs vtArgs
-      |> List.fold (fun acc (tr, vt) -> inferTVarsFromArg acc tr vt) acc
-    else
-      acc
+  | TList tr' ->
+    match vt with
+    | ValueType.Known(KTList vt') -> inferTVarsFromArg acc tr' vt'
+    | _ -> acc
+  | TStream tr' ->
+    match vt with
+    | ValueType.Known(KTStream vt') -> inferTVarsFromArg acc tr' vt'
+    | _ -> acc
+  | TDict tr' ->
+    match vt with
+    | ValueType.Known(KTDict vt') -> inferTVarsFromArg acc tr' vt'
+    | _ -> acc
 
-  | _, _ -> acc
+  | TTuple(a, b, rest) ->
+    match vt with
+    | ValueType.Known(KTTuple(a', b', rest')) ->
+      let acc = inferTVarsFromArg acc a a'
+      let acc = inferTVarsFromArg acc b b'
+      inferTVarsFromArgs acc rest rest'
+    | _ -> acc
+
+  | TCustomType({ resolved = Ok _ }, typeArgs) ->
+    match vt with
+    | ValueType.Known(KTCustomType(_, vtArgs)) ->
+      inferTVarsFromArgs acc typeArgs vtArgs
+    | _ -> acc
+
+  | _ -> acc
+
+/// Lockstep over matched-arity type argument lists. Arity mismatch returns `acc` untouched, as the
+/// zip-based version did -- `typeCheckParams` reports the real error.
+and private inferTVarsFromArgs
+  (acc : Map<string, ValueType>)
+  (trs : List<TypeReference>)
+  (vts : List<ValueType>)
+  : Map<string, ValueType> =
+  if List.length trs <> List.length vts then
+    acc
+  else
+    let rec go acc (trs : List<TypeReference>) (vts : List<ValueType>) =
+      match trs with
+      | [] -> acc
+      | tr :: trRest ->
+        match vts with
+        | [] -> acc
+        | vt :: vtRest -> go (inferTVarsFromArg acc tr vt) trRest vtRest
+    go acc trs vts
 
 
 let rec checkAndExtractLetPattern
@@ -262,6 +363,1015 @@ let rec checkAndExtractMatchPattern
 
 
 
+/// Record bytes allocated in a synchronous region of the Apply path. `before` must come from a
+/// `GC.GetAllocatedBytesForCurrentThread()` taken in the same synchronous stretch -- see the note on
+/// `InterpreterStats.allocByStage` for why spanning an await would measure the wrong thing.
+let inline private recordStage (vm : VMState) (stage : int) (before : int64) : unit =
+  if vm.stats.enabled then
+    let d = System.GC.GetAllocatedBytesForCurrentThread() - before
+    if d > 0L then vm.stats.allocByStage[stage] <- vm.stats.allocByStage[stage] + d
+
+/// Frame identity is internal to a VM: `callFrames`, `pendingCallArgs` and `framePushTimestamps` key on it,
+/// and the tracer's `storeFrameEntry` ignores the argument entirely. It never reaches storage or the wire.
+///
+/// So it doesn't need to be random. `Guid.NewGuid()` draws from the cryptographic RNG, and a frame push
+/// happens tens of thousands of times in a single command.
+///
+/// The counter lives on the VM, not in this module. A VM's interpreter loop is single-threaded so a
+/// per-VM counter needs no synchronization, whereas a process-global `let mutable` does: tests run VMs in
+/// parallel, and a non-atomic shared increment handed two frames the same id, dropping one from
+/// `callFrames` and failing the parent lookup on return. Caught by
+/// `Interpreter.Fns.Package.Recursion.addUpTo 30000`.
+let inline private nextFrameId (vm : VMState) : uuid =
+  vm.frameIdCounter <- vm.frameIdCounter + 1L
+  let n = vm.frameIdCounter
+  System.Guid(
+    int (n &&& 0xFFFFFFFFL),
+    int16 ((n >>> 32) &&& 0xFFFFL),
+    0s,
+    0uy,
+    0uy,
+    0uy,
+    0uy,
+    0uy,
+    0uy,
+    0uy,
+    0uy
+  )
+
+/// `Map.remove` rebuilds nodes along the search path even when the key isn't there.
+///
+/// The type symbol table averages 1.23 entries (measured), and the names stripped from it are a function's
+/// own type variables, which are usually *not* bound by the caller -- so most of these removes were
+/// allocating a new tree to produce the same contents. `Map.containsKey` is a lookup and allocates nothing.
+let inline private removeIfPresent
+  (name : string)
+  (m : TypeSymbolTable)
+  : TypeSymbolTable =
+  if Map.containsKey name m then Map.remove name m else m
+
+
+/// Check as many arguments as can be answered without awaiting, returning where it stopped.
+///
+/// `TypeChecker.tryUnifySync` answers the ordinary cases outright, so this walks the parameter and
+/// argument lists together for as long as that keeps working, and hands the remainder to the
+/// computation-expression version. Getting all the way through, which is the usual case, allocates
+/// nothing: top-level so nothing is captured, and a struct tuple so the return isn't an allocation.
+let rec private checkBiParamsSync
+  (i : int)
+  (ps : List<BuiltInParam>)
+  (args : List<Dval>)
+  (tst : TypeSymbolTable)
+  : struct (int * List<BuiltInParam> * List<Dval> * TypeSymbolTable) =
+  match ps with
+  | [] -> struct (i, ps, args, tst)
+  | p :: pRest ->
+    match args with
+    | [] -> struct (i, ps, args, tst)
+    | a :: aRest ->
+      match TypeChecker.tryUnifySync tst p.typ a with
+      | ValueSome updatedTst -> checkBiParamsSync (i + 1) pRest aRest updatedTst
+      | ValueNone -> struct (i, ps, args, tst)
+
+/// As [checkBiParamsSync], for package fns.
+let rec private checkPkgParamsSync
+  (i : int)
+  (ps : List<PackageFn.Parameter>)
+  (args : List<Dval>)
+  (tst : TypeSymbolTable)
+  : struct (int * List<PackageFn.Parameter> * List<Dval> * TypeSymbolTable) =
+  match ps with
+  | [] -> struct (i, ps, args, tst)
+  | p :: pRest ->
+    match args with
+    | [] -> struct (i, ps, args, tst)
+    | a :: aRest ->
+      match TypeChecker.tryUnifySync tst p.typ a with
+      | ValueSome updatedTst -> checkPkgParamsSync (i + 1) pRest aRest updatedTst
+      | ValueNone -> struct (i, ps, args, tst)
+
+
+let inline private allocNow (vm : VMState) : int64 =
+  if vm.stats.enabled then System.GC.GetAllocatedBytesForCurrentThread() else 0L
+
+
+/// Run consecutive instructions that need no `await`, without entering the interpreter's computation
+/// expression at all. Returns the counter where it stopped: past the end of the block, or at one of the
+/// five opcodes that must be handled on the async path.
+///
+/// Those five -- CreateRecord, CloneRecordWithUpdates, CreateEnum, LoadValue, Apply -- are the only ones
+/// that await. The other eighteen are register moves, jumps, comparisons, match tests and container
+/// construction, and they are the overwhelming majority of instructions executed.
+let private runSyncInstructions
+  (exeState : ExecutionState)
+  (vm : VMState)
+  (currentFrame : CallFrame)
+  (registers : Dval array)
+  (instrData : InstrData)
+  (startCounter : int)
+  : int =
+  let raiseRTE rte = raiseRTE vm.threadID rte
+  let mutable counter = startCounter
+  let mutable running = true
+
+  while running && counter < instrData.instructions.Length do
+    let inst = instrData.instructions[counter]
+
+    match inst with
+    | CreateRecord _
+    | CloneRecordWithUpdates _
+    | CreateEnum _
+    | LoadValue _
+    | Apply _ -> running <- false
+    | _ ->
+      if vm.stats.enabled then
+        vm.stats.instructionCount <- vm.stats.instructionCount + 1L
+
+      let allocBefore =
+        if vm.stats.enabled then
+          System.GC.GetAllocatedBytesForCurrentThread()
+        else
+          0L
+
+      match inst with
+      | LoadVal(reg, value) -> registers[reg] <- value
+      | CopyVal(copyTo, copyFrom) -> registers[copyTo] <- registers[copyFrom]
+      | Or(createTo, left, right) ->
+        match registers[left] with
+        | DBool true -> registers[createTo] <- DBool true
+        | DBool false ->
+          match registers[right] with
+          | DBool true -> registers[createTo] <- DBool true
+          | DBool false -> registers[createTo] <- DBool false
+          | r ->
+            RTE.Bools.OrOnlySupportsBooleans(VT.bool, Dval.toValueType r)
+            |> RTE.Bool
+            |> raiseRTE
+        | l ->
+          let r = registers[right]
+          RTE.Bools.OrOnlySupportsBooleans(Dval.toValueType l, Dval.toValueType r)
+          |> RTE.Bool
+          |> raiseRTE
+      | And(createTo, left, right) ->
+        match registers[left] with
+        | DBool false -> registers[createTo] <- DBool false
+        | DBool true ->
+          match registers[right] with
+          | DBool true -> registers[createTo] <- DBool true
+          | DBool false -> registers[createTo] <- DBool false
+          | r ->
+            RTE.Bools.AndOnlySupportsBooleans(VT.bool, Dval.toValueType r)
+            |> RTE.Bool
+            |> raiseRTE
+        | l ->
+          let r = registers[right]
+          RTE.Bools.AndOnlySupportsBooleans(Dval.toValueType l, Dval.toValueType r)
+          |> RTE.Bool
+          |> raiseRTE
+
+
+      // == Working with Variables ==
+      | CheckLetPatternAndExtractVars(valueReg, pat) ->
+        let dv = registers[valueReg]
+        // Fast path for the common single-variable let binding
+        match pat with
+        | LPVariable extractTo -> registers[extractTo] <- dv
+        | LPUnit ->
+          match dv with
+          | DUnit -> ()
+          | _ -> raiseRTE (RTE.Let(RTE.Lets.PatternDoesNotMatch(dv, pat)))
+        | _ ->
+          let doesMatch, registersToAssign = checkAndExtractLetPattern pat dv
+          if doesMatch then
+            registersToAssign
+            |> List.iter (fun (reg, value) -> registers[reg] <- value)
+          else
+            raiseRTE (RTE.Let(RTE.Lets.PatternDoesNotMatch(dv, pat)))
+
+
+      // TODO References to DBs should be resolved at parse-time, not
+      // runtime. For consistency, safety, etc. We should have a specific
+      // EReferenceDB construct that we respect throughout WT, NR, PT, RT,
+      // PT2RT, etc. I don't think this would be that hard.
+      | VarNotFound(targetRegIfDB, varName) ->
+        match exeState.program.dbs |> Map.get varName with
+        | Some _foundDB -> registers[targetRegIfDB] <- DDB varName
+        | None -> raiseRTE (RTE.VariableNotFound varName)
+
+
+
+      // == Working with Basic Types ==
+      | CreateString(targetReg, segments) ->
+        let sb = new System.Text.StringBuilder()
+
+        segments
+        |> List.iter (fun seg ->
+          match seg with
+          | Text s -> sb.Append s |> ignore<System.Text.StringBuilder>
+          | Interpolated reg ->
+            match registers[reg] with
+            | DString s -> sb.Append s |> ignore<System.Text.StringBuilder>
+            | dv ->
+              let vt = Dval.toValueType dv
+              raiseRTE (
+                RTE.String(RTE.Strings.Error.NonStringInInterpolation(vt, dv))
+              ))
+
+        registers[targetReg] <- DString(sb.ToString())
+
+
+      // == Flow Control ==
+      // -- Jumps --
+      | JumpBy jumpBy -> counter <- counter + jumpBy
+      | JumpByIfFalse(jumpBy, condReg) ->
+        match registers[condReg] with
+        | DBool false -> counter <- counter + jumpBy
+        | DBool true -> ()
+        | dv ->
+          raiseRTE (
+            RTE.Bool(RTE.Bools.ConditionRequiresBool(Dval.toValueType dv, dv))
+          )
+
+      // -- Match --
+      | CheckMatchPatternAndExtractVars(valueReg, pat, failJump) ->
+        // Fast path for common single-variable match
+        match pat with
+        | MPVariable reg -> registers[reg] <- registers[valueReg]
+        | _ ->
+          let doesMatch, registersToAssign =
+            checkAndExtractMatchPattern pat registers[valueReg]
+          if doesMatch then
+            registersToAssign
+            |> List.iter (fun (reg, value) -> registers[reg] <- value)
+          else
+            counter <- counter + failJump
+      | MatchUnmatched(valueReg) ->
+        let unmatchedValue = registers[valueReg]
+        raiseRTE (RTE.Match(RTE.Matches.MatchUnmatched unmatchedValue))
+
+
+      // == Working with Collections ==
+      | CreateList(listReg, itemsToAddRegs) ->
+        let itemsToAdd = readRegs registers itemsToAddRegs
+        registers[listReg] <-
+          TypeChecker.DvalCreator.list vm.threadID VT.unknown itemsToAdd
+      | CreateDict(dictReg, entries) ->
+        let entries =
+          entries |> List.map (fun (key, valueReg) -> (key, registers[valueReg]))
+        registers[dictReg] <-
+          TypeChecker.DvalCreator.dict vm.threadID VT.unknown entries
+      | CreateTuple(tupleReg, firstReg, secondReg, theRestRegs) ->
+        let first = registers[firstReg]
+        let second = registers[secondReg]
+        let theRest = readRegs registers theRestRegs
+        registers[tupleReg] <- DTuple(first, second, theRest)
+
+
+      // == Working with Custom Data ==
+      // -- Records --
+      | GetRecordField(targetReg, recordReg, fieldName) ->
+        match registers[recordReg] with
+        | DRecord(_, _, _, fields) ->
+          if fieldName = "" then
+            RTE.Records.FieldAccessEmptyFieldName |> RTE.Record |> raiseRTE
+          else
+            match Map.find fieldName fields with
+            | Some value -> registers[targetReg] <- value
+            | None ->
+              RTE.Records.FieldAccessFieldNotFound fieldName
+              |> RTE.Record
+              |> raiseRTE
+        | dv ->
+          RTE.Records.FieldAccessNotRecord(Dval.toValueType dv)
+          |> RTE.Record
+          |> raiseRTE
+
+
+      // -- Enums --
+      | CreateLambda(lambdaReg, impl) ->
+        exeState.lambdaInstrCache[impl.exprId] <- impl
+
+        registers[lambdaReg] <-
+          { exprId = impl.exprId
+            closedRegisters =
+              impl.registersToCloseOver
+              |> List.map (fun (parentReg, childReg) ->
+                childReg, registers[parentReg])
+            typeSymbolTable = currentFrame.typeSymbolTable
+            argsSoFar = [] }
+          |> AppLambda
+          |> DApplicable
+
+
+
+      // == Working with things that Apply (fns, lambdas) ==
+      // `add (increment 1L) (3L)` and store results in `putResultIn`
+      | RaiseNRE(names, nre) -> raiseRTE (RTE.ParseTimeNameResolution(names, nre))
+
+      // CLEANUP: consider renaming this to something like "RequireExprToReturnUnit"
+      | CheckIfFirstExprIsUnit reg ->
+        match registers[reg] with
+        | DUnit -> ()
+        | dval ->
+          RTE.Statements.FirstExpressionMustBeUnit(
+            ValueType.Known KTUnit,
+            Dval.toValueType dval,
+            dval
+          )
+          |> RuntimeError.Statement
+          |> raiseRTE
+      // Unreachable: these five were filtered out above, but the match must be exhaustive.
+      | CreateRecord _
+      | CloneRecordWithUpdates _
+      | CreateEnum _
+      | LoadValue _
+      | Apply _ -> ()
+
+      if vm.stats.enabled then
+        let tag = Opcode.index inst
+        if tag >= 0 && tag < vm.stats.allocByOpcode.Length then
+          let delta = System.GC.GetAllocatedBytesForCurrentThread() - allocBefore
+          if delta > 0L then
+            vm.stats.allocByOpcode[tag] <- vm.stats.allocByOpcode[tag] + delta
+          vm.stats.countByOpcode[tag] <- vm.stats.countByOpcode[tag] + 1L
+
+      counter <- counter + 1
+
+  counter
+
+
+
+/// Write a pattern-match's register assignments into a frame's registers.
+///
+/// Top-level and fully parameterised so nothing is captured: the `List.iter` this replaces allocated a
+/// closure over the register array, on a path that runs once per lambda parameter per lambda call.
+let rec private assignRegisters
+  (r : Dval array)
+  (assignments : List<Register * Dval>)
+  : unit =
+  match assignments with
+  | [] -> ()
+  | (reg, value) :: rest ->
+    r[reg] <- value
+    assignRegisters r rest
+
+/// Bind a lambda's parameters to its arguments, in lockstep.
+///
+/// The `List.zip |> List.iter` this replaces built a pair per parameter and two closures per call.
+let rec private bindLambdaParams
+  (vm : VMState)
+  (r : Dval array)
+  (pats : List<LetPattern>)
+  (args : List<Dval>)
+  : unit =
+  match pats with
+  | [] -> ()
+  | pat :: patRest ->
+    match args with
+    | [] -> ()
+    | arg :: argRest ->
+      let doesMatch, registersToAssign = checkAndExtractLetPattern pat arg
+      if doesMatch then
+        assignRegisters r registersToAssign
+      else
+        RTE.Let(RTE.Lets.PatternDoesNotMatch(arg, pat)) |> raiseRTE vm.threadID
+      bindLambdaParams vm r patRest argRest
+
+
+/// The parts of an `Apply` that the call paths below all need.
+///
+/// Bundled so their call sites aren't a column of eight positional arguments, twice. A struct record, so
+/// passing it around costs nothing; each function unpacks what it uses at the top rather than reading
+/// through `ctx.` everywhere.
+[<Struct>]
+type private ApplyContext =
+  {
+    applicable : ApplicableNamedFn
+    typeArgs : List<TypeReference>
+    args : List<Dval>
+    tst : TypeSymbolTable
+    /// Register in the calling frame that the result goes in.
+    putResultIn : Register
+    /// Where to resume the calling frame once this call returns.
+    returnPc : int
+  }
+
+
+/// Explicit type args, resolved against the OUTER symbol table so the wrapper-pass-through pattern works:
+/// a wrapper body calling `Builtin.x<'a>` needs `'a` resolved against the wrapper's table, not the
+/// post-shadow one.
+///
+/// `ValueNone` means it needs the package store. That is the one step that can block before any of the
+/// call has happened, and it is rare -- most calls pass no type args at all -- so the callers keep it out
+/// of line rather than awaiting on every call.
+let private resolveTypeArgsSync
+  (exeState : ExecutionState)
+  (vm : VMState)
+  (name : FQFnName.FQFnName)
+  (typeParamCount : int)
+  (ctx : ApplyContext)
+  : List<ValueType> voption =
+  match ctx.typeArgs with
+  | [] -> ValueSome []
+  | typeArgs ->
+    // Separate lets, not `let a, b = (x, y)`: the tuple form allocates.
+    let typeArgCount = List.length typeArgs
+    if typeArgCount <> typeParamCount then
+      RTE.Applications.WrongNumberOfTypeArgsForFn(name, typeParamCount, typeArgCount)
+      |> RTE.Apply
+      |> raiseRTE vm.threadID
+    typeArgs
+    |> Ply.List.mapSequentially (TypeReference.toVT exeState.types ctx.tst)
+    |> Ply.trySync
+
+/// As `resolveTypeArgsSync`, for when it does need the store. Cold path; the arity check already ran.
+let private resolveTypeArgsAsync
+  (exeState : ExecutionState)
+  (ctx : ApplyContext)
+  : Ply<List<ValueType>> =
+  ctx.typeArgs
+  |> Ply.List.mapSequentially (TypeReference.toVT exeState.types ctx.tst)
+
+
+
+/// Everything from "we have the arguments and a checked symbol table" to "we have a checked result".
+///
+/// Shared by the synchronous path and the fallback below it, so there is one copy of the capability gate,
+/// the stats bracket, the result check and the trace.
+let private invokeBuiltin
+  (exeState : ExecutionState)
+  (vm : VMState)
+  (currentFrame : CallFrame)
+  (fn : BuiltInFn)
+  (tst : TypeSymbolTable)
+  (typeArgs : List<TypeReference>)
+  (allArgs : List<Dval>)
+  : Ply<Dval> =
+  let raiseRTE rte = raiseRTE vm.threadID rte
+  // Resolve type variables in typeArgs before passing to builtin.
+  // When a package function like Stdlib.Json.parse<Int64> calls
+  // Builtin.jsonParse<'a>, the 'a needs to resolve to Int64.
+  let resolvedTypeArgs =
+    match typeArgs with
+    | [] -> []
+    | _ -> typeArgs |> List.map (TypeReference.resolveTypeVariables tst)
+  let sw =
+    if vm.stats.enabled then
+      vm.stats.builtinCallCount <- vm.stats.builtinCallCount + 1L
+      if vm.stats.detailedTiming then
+        System.Diagnostics.Stopwatch.GetTimestamp()
+      else
+        0L
+    else
+      0L
+  // capabilities gate: a builtin runs only if the instance's grant covers the DOMAIN
+  // it declares it needs (`fn.capabilities`): a structural PRESENCE check, no name
+  // matching. Nuanced builtins (http/file/exec/…) additionally enforce the SPECIFIC
+  // target (URL/path/args) in their own body via `CapabilityCheck`. Default grant is
+  // allCaps (no behavior change); a real instance narrows it (default NONE for `dark run`).
+  // fast-path: pure builtins (the vast majority) all share the one `noCaps` instance,
+  // so a reference check skips the structural scan entirely in the hot path. A false
+  // negative (an all-empty need built fresh) just runs the full check, still correct.
+  if not (System.Object.ReferenceEquals(fn.capabilities, Capabilities.noCaps)) then
+    match Capabilities.coversStructurally exeState.grantedCaps fn.capabilities with
+    | Capabilities.Denied what ->
+      raiseRTE (
+        RTE.UncaughtException(
+          $"capability denied: `{fn.name.name}` needs {what}, which this instance doesn't grant. Grant it with `dark caps`.",
+          []
+        )
+      )
+    | Capabilities.Allowed -> ()
+
+  let bodyAllocBefore =
+    if vm.stats.enabled then System.GC.GetAllocatedBytesForCurrentThread() else 0L
+
+  // Every builtin's signature is async because some of them have to be -- HTTP, the package store,
+  // anything touching disk. Most aren't: `Int64.add` computes and returns.
+  let body = fn.fn (exeState, vm, resolvedTypeArgs, allArgs)
+
+  /// Stats, the result type-check and the trace. Runs whether or not the body had to wait.
+  let finish (result : Dval) : Ply<Dval> =
+    if vm.stats.enabled then
+      let d = System.GC.GetAllocatedBytesForCurrentThread() - bodyAllocBefore
+      if d > 0L then
+        vm.stats.builtinBodyAlloc <- vm.stats.builtinBodyAlloc + d
+        let n = fn.name.name
+        match vm.stats.builtinAlloc.TryGetValue n with
+        | true, v -> vm.stats.builtinAlloc[n] <- v + d
+        | false, _ -> vm.stats.builtinAlloc[n] <- d
+    // `sw = 0L` means the bracket never opened: timing was off when this call started and the call
+    // itself turned it on (`interpreterStatsEnableDetailedTiming` is the case). Subtracting from zero
+    // would record the raw tick count as a duration.
+    if vm.stats.enabled && vm.stats.detailedTiming && sw <> 0L then
+      let elapsed = System.Diagnostics.Stopwatch.GetTimestamp() - sw
+      vm.stats.recordBuiltin (fn.name.name, elapsed)
+
+    let trace (result : Dval) =
+      if not exeState.tracing.skipTracing then
+        let source : Tracing.Source = (currentFrame.executionPoint, None)
+        let fnRecord : Tracing.FunctionRecord = (source, FQFnName.Builtin fn.name)
+        exeState.tracing.storeFnResult
+          fnRecord
+          (NEList.ofListUnsafe "" [] allArgs)
+          result
+      result
+
+    let biResAlloc = allocNow vm
+    match TypeChecker.tryUnifySync tst fn.returnType result with
+    | ValueSome _ ->
+      recordStage vm ApplyStage.BiCheckResult biResAlloc
+      Ply(trace result)
+    | ValueNone ->
+      uply {
+        match!
+          TypeChecker.checkFnResult
+            exeState.types
+            (FQFnName.Builtin fn.name)
+            tst
+            fn.returnType
+            result
+        with
+        | Ok _ -> ()
+        | Error rte -> raiseRTE rte
+        recordStage vm ApplyStage.BiCheckResult biResAlloc
+        return trace result
+      }
+
+  match Ply.trySync body with
+  | ValueSome result -> finish result
+  | ValueNone ->
+    uply {
+      let! result = body
+      return! finish result
+    }
+
+
+/// Run a builtin call without entering the interpreter's computation expression.
+///
+/// Synchronous because almost nothing here ever waits: resolving a type arg is a cache hit, checking an
+/// argument needs no lookup in the ordinary case, and a pure builtin hands back a `Ply` that is already
+/// finished. Entering the builder for those costs a continuation closure each time, and this runs once
+/// per call.
+///
+/// Two things can still need the package store, and each has an escape hatch that keeps a single
+/// implementation rather than a fast copy and a slow copy that drift:
+///
+/// The three ways a builtin call ends, once the symbol table is settled: too many arguments, not enough
+/// (so it stays a partial application), or exactly right.
+///
+/// Top-level rather than a local function, so it captures nothing. As a closure over the nine values it
+/// needs, it was an allocation on every builtin call.
+let private completeBuiltin
+  (exeState : ExecutionState)
+  (vm : VMState)
+  (currentFrame : CallFrame)
+  (ctx : ApplyContext)
+  (fn : BuiltInFn)
+  (allArgs : List<Dval>)
+  (argCount : int)
+  (paramCount : int)
+  (tst : TypeSymbolTable)
+  : Ply<Dval> =
+  if argCount > paramCount then
+    RTE.Applications.TooManyArgsForFn(ctx.applicable.name, paramCount, argCount)
+    |> RTE.Apply
+    |> raiseRTE vm.threadID
+  elif argCount < paramCount then
+    // CLEANUP should the typeArgs here be of VTs, not TRs? check out usages, I suppose.
+    { ctx.applicable with
+        typeSymbolTable = tst
+        typeArgs = ctx.typeArgs
+        argsSoFar = allArgs }
+    |> AppNamedFn
+    |> DApplicable
+    |> Ply
+  else
+    invokeBuiltin exeState vm currentFrame fn tst ctx.typeArgs allArgs
+
+
+/// - Resolving explicit type args, which happens before anything else, is done by `callBuiltin` and
+///   handed in here already resolved.
+/// - Argument checking can need `Types.find` partway through, so it hands the *remainder* to a `uply`
+///   and returns a `Called` that isn't finished yet.
+let private callBuiltinResolved
+  (exeState : ExecutionState)
+  (vm : VMState)
+  (currentFrame : CallFrame)
+  (ctx : ApplyContext)
+  (fn : BuiltInFn)
+  (resolvedTypeArgsVT : List<ValueType>)
+  : Ply<Dval> =
+  let raiseRTE rte = raiseRTE vm.threadID rte
+  let applicable = ctx.applicable
+  let newArgDvals = ctx.args
+
+  let mutable tst = ctx.tst
+
+  // Step 2: shadow this fn's free type-vars from the inherited TST. Mirrors the package-fn path;
+  // without shadowing, an outer fn's `'a := X` would silently constrain a builtin's unrelated `'a`
+  // (e.g. `==` with `'a` polluted to a tuple type from a parent List<(...)> context).
+  let biShadowAlloc = allocNow vm
+  let fnFreeTVars = FreeTVars.ofBuiltin fn
+  // Only used to strip names from `tst`, so with nothing in `tst` there's nothing to strip and not even
+  // the memo lookup is worth doing.
+  let implicitTypeParams : Set<string> =
+    if Map.isEmpty tst then Set.empty else fnFreeTVars
+  tst <- implicitTypeParams |> Set.fold (fun m name -> removeIfPresent name m) tst
+
+  // Step 3: bind the (already-resolved) explicit type args. If the caller omitted type args, leave the
+  // typeParams unbound for inference to fill in.
+  let explicitlyBound =
+    if List.isEmpty resolvedTypeArgsVT then
+      Map.empty
+    else
+      List.zip fn.typeParams resolvedTypeArgsVT |> Map
+  tst <- Map.mergeFavoringRight tst explicitlyBound
+  recordStage vm ApplyStage.BiTstShadow biShadowAlloc
+
+  let biArgsAlloc = allocNow vm
+  let allArgs =
+    match applicable.argsSoFar with
+    | [] -> newArgDvals
+    | prev -> prev @ newArgDvals
+  recordStage vm ApplyStage.BiArgs biArgsAlloc
+
+  let paramCount = List.length fn.parameters
+  let argCount = List.length allArgs
+
+  // Step 4: infer type-variable bindings from arg ValueTypes for any TVariables in the param types not
+  // bound by explicit type args. Same rule as the package-fn path. Nothing to infer for a fn with no
+  // free type-vars, which most builtins are, and skipping saves a `Dval.toValueType` per argument.
+  if argCount > 0 && not (Set.isEmpty fnFreeTVars) then
+    // Lockstep: projecting the param types into their own list and zipping it against the args
+    // allocates two lists and a pair per argument.
+    let rec inferBi acc (ps : List<BuiltInParam>) (args : List<Dval>) =
+      match ps with
+      | [] -> acc
+      | p :: pRest ->
+        match args with
+        | [] -> acc
+        | a :: aRest ->
+          inferBi (inferTVarsFromArg acc p.typ (Dval.toValueType a)) pRest aRest
+    let inferredBound = inferBi explicitlyBound fn.parameters allArgs
+    if not (Map.isEmpty inferredBound) then
+      tst <- Map.mergeFavoringRight tst inferredBound
+
+  // Step 5: type-check the new arguments against the corresponding parameters. Walk them in lockstep
+  // rather than building an indexed triple list and zipping it against the args. `already` is the count
+  // already applied, so the first parameter checked keeps its original index.
+  let biTcRunAlloc = allocNow vm
+  let already = List.length applicable.argsSoFar
+  let struct (biNextI, biRestPs, biRestArgs, biTst) =
+    checkBiParamsSync already (List.skip already fn.parameters) newArgDvals tst
+  tst <- biTst
+  recordStage vm ApplyStage.BiTypeCheckRun biTcRunAlloc
+
+  match biRestPs, biRestArgs with
+  | [], _
+  | _, [] ->
+    completeBuiltin exeState vm currentFrame ctx fn allArgs argCount paramCount tst
+  | _ ->
+    // Something in the remaining parameters needs the type store. Finish the check in a computation
+    // expression and carry on from there -- still the one implementation, just resumed asynchronously.
+    let typeCheckParam = TypeChecker.checkFnParam exeState.types applicable.name
+    uply {
+      let mutable tstRest = tst
+      let rec checkRest i (ps : List<BuiltInParam>) (args : List<Dval>) =
+        uply {
+          match ps with
+          | [] -> return ()
+          | p :: pRest ->
+            match args with
+            | [] -> return ()
+            | a :: aRest ->
+              match! typeCheckParam tstRest i p.name p.typ a with
+              | Ok updatedTst ->
+                tstRest <- updatedTst
+                return! checkRest (i + 1) pRest aRest
+              | Error rte -> return raiseRTE rte
+        }
+      do! checkRest biNextI biRestPs biRestArgs
+      return!
+        completeBuiltin
+          exeState
+          vm
+          currentFrame
+          ctx
+          fn
+          allArgs
+          argCount
+          paramCount
+          tstRest
+    }
+
+
+
+/// Run a builtin call, resolving its explicit type args first.
+let private callBuiltin
+  (exeState : ExecutionState)
+  (vm : VMState)
+  (currentFrame : CallFrame)
+  (ctx : ApplyContext)
+  (fn : BuiltInFn)
+  : Ply<Dval> =
+  let run resolved = callBuiltinResolved exeState vm currentFrame ctx fn resolved
+  match
+    resolveTypeArgsSync
+      exeState
+      vm
+      ctx.applicable.name
+      (List.length fn.typeParams)
+      ctx
+  with
+  | ValueSome resolved -> run resolved
+  | ValueNone ->
+    uply {
+      let! resolved = resolveTypeArgsAsync exeState ctx
+      return! run resolved
+    }
+
+
+
+/// What a package-fn call produces: either it wasn't fully applied, or there's a frame to run.
+[<Struct>]
+type private PackageOutcome =
+  | PartiallyApplied of dval : Dval
+  | PushFrame of frame : CallFrame
+
+
+/// Too many arguments for a package fn, not enough (so it stays a partial application), or exactly right
+/// -- in which case build the frame to run it in.
+///
+/// Top-level rather than a local function, for the same reason as `completeBuiltin`: as a closure over
+/// the values it needs, it was an allocation on every package call.
+let private completePackage
+  (exeState : ExecutionState)
+  (vm : VMState)
+  (currentFrame : CallFrame)
+  (pendingCallArgs : System.Collections.Generic.Dictionary<uuid, Dval list>)
+  (ctx : ApplyContext)
+  (fn : PackageFn.PackageFn)
+  (implicitTypeParams : Set<string>)
+  (newlyBound : TypeSymbolTable)
+  (allArgs : List<Dval>)
+  (argCount : int)
+  (paramCount : int)
+  (tst : TypeSymbolTable)
+  : PackageOutcome =
+  let raiseRTE rte = raiseRTE vm.threadID rte
+  let applicable = ctx.applicable
+  let typeArgs = ctx.typeArgs
+  if argCount > paramCount then
+    RTE.Applications.TooManyArgsForFn(applicable.name, paramCount, argCount)
+    |> RTE.Apply
+    |> raiseRTE
+  elif argCount < paramCount then
+    { applicable with
+        typeArgs = typeArgs
+        argsSoFar = allArgs
+        typeSymbolTable = tst }
+    |> AppNamedFn
+    |> DApplicable
+    |> PartiallyApplied
+  else
+    // Inherit the outer frame's TST but shadow this fn's own free type-vars first, so the inner fn's
+    // `'a` is local to this call and not the outer's.
+    let frameTst =
+      let stripped =
+        implicitTypeParams
+        |> Set.fold
+          (fun m name -> removeIfPresent name m)
+          currentFrame.typeSymbolTable
+      Map.mergeFavoringRight stripped newlyBound
+    let pkgFrameAlloc = allocNow vm
+    if vm.stats.enabled then
+      let n = int64 (Map.count frameTst)
+      vm.stats.tstSizeSum <- vm.stats.tstSizeSum + n
+      if n > vm.stats.tstSizeMax then vm.stats.tstSizeMax <- n
+    let newFrameId = nextFrameId vm
+    if not exeState.tracing.skipTracing then pendingCallArgs[newFrameId] <- allArgs
+    if vm.stats.enabled then
+      vm.stats.packageCallCount <- vm.stats.packageCallCount + 1L
+      vm.stats.framePushCount <- vm.stats.framePushCount + 1L
+      if vm.stats.detailedTiming then
+        vm.stats.framePushTimestamps[newFrameId] <-
+          System.Diagnostics.Stopwatch.GetTimestamp()
+    let pkgEp = FreeTVars.packageExecutionPoint fn.hash
+    if not exeState.tracing.skipTracing then
+      exeState.tracing.storeFrameEntry newFrameId pkgEp allArgs
+    let frame =
+      { id = newFrameId
+        parent = ValueSome(struct (vm.currentFrameID, ctx.putResultIn, ctx.returnPc))
+        programCounter = 0
+        registers =
+          if vm.stats.enabled then
+            vm.stats.registersAllocated <-
+              vm.stats.registersAllocated + int64 fn.body.registerCount
+          let r = Array.zeroCreate fn.body.registerCount
+          // A manual walk rather than `List.iteri`, whose closure over `r` is an allocation on a path
+          // that runs once per call.
+          let rec fill i (args : List<Dval>) =
+            match args with
+            | [] -> ()
+            | a :: rest ->
+              r[i] <- a
+              fill (i + 1) rest
+          fill 0 allArgs
+          r
+        typeSymbolTable = frameTst
+        executionPoint = pkgEp
+        expectedReturnType = ValueSome fn.returnType
+        // We already hold the fn here, so the loop needn't fetch it.
+        instrData =
+          match exeState.packageFnInstrCache.TryGetValue fn.hash with
+          | true, cached -> cached
+          | false, _ ->
+            let d : InstrData =
+              { instructions = List.toArray fn.body.instructions
+                resultReg = fn.body.resultIn }
+            exeState.packageFnInstrCache[fn.hash] <- d
+            d }
+    recordStage vm ApplyStage.PkgFrame pkgFrameAlloc
+    PushFrame frame
+
+
+/// Everything after the explicit type args are resolved. See `callPackage`.
+let private callPackageResolved
+  (exeState : ExecutionState)
+  (vm : VMState)
+  (currentFrame : CallFrame)
+  (pendingCallArgs : System.Collections.Generic.Dictionary<uuid, Dval list>)
+  (ctx : ApplyContext)
+  (fn : PackageFn.PackageFn)
+  (resolvedExplicitTypeArgsVT : List<ValueType>)
+  : Ply<PackageOutcome> =
+  let raiseRTE rte = raiseRTE vm.threadID rte
+  let applicable = ctx.applicable
+  let newArgDvals = ctx.args
+  let mutable tst = ctx.tst
+
+  // Step 2: shadow this fn's free type-vars in the inherited TST. Each fn's TVariables are scoped to
+  // that fn; without shadowing, an outer fn's `'a := X` would silently constrain a nested fn's
+  // unrelated `'a`.
+  let pkgShadowAlloc = allocNow vm
+  // Used to strip names from `tst` here and from the parent's table when building `frameTst` below.
+  // Both empty means both strips are no-ops, so don't compute it.
+  let fnFreeTVars = FreeTVars.ofPackage fn
+  let implicitTypeParams : Set<string> =
+    if Map.isEmpty tst && Map.isEmpty currentFrame.typeSymbolTable then
+      Set.empty
+    else
+      fnFreeTVars
+  tst <- implicitTypeParams |> Set.fold (fun m name -> removeIfPresent name m) tst
+
+  // Step 3: bind the (already-resolved) explicit type args into the freshly-shadowed tst. Explicit args
+  // win over inferred bindings filled in below. If the caller omitted type args, leave the typeParams
+  // unbound for inference.
+  let explicitlyBound =
+    if List.isEmpty resolvedExplicitTypeArgsVT then
+      Map.empty
+    else
+      List.zip fn.typeParams resolvedExplicitTypeArgsVT |> Map
+  if not (Map.isEmpty explicitlyBound) then
+    tst <- Map.mergeFavoringRight tst explicitlyBound
+  recordStage vm ApplyStage.PkgTstShadow pkgShadowAlloc
+
+  // Pre-compute allArgs so inference runs BEFORE typeCheckParams. Otherwise the type check runs against
+  // a TST that doesn't yet know `'a := whatever`.
+  let allArgs =
+    match applicable.argsSoFar with
+    | [] -> newArgDvals
+    | prev -> prev @ newArgDvals
+
+  let paramCount = NEList.length fn.parameters
+  let argCount = List.length allArgs
+
+  // Step 4: infer type-variable bindings from arg ValueTypes for any TVariables in the param types not
+  // bound by explicit type args. Lets wrappers of the shape
+  //   let f (x: List<'a>) : Stream<'a> = Builtin.fromList<'a> x
+  // work without callers passing explicit type args. See [inferTVarsFromArg] for the unification rules.
+  let pkgInferAlloc = allocNow vm
+  let newlyBound =
+    // A fn with no free type-vars has nothing to infer, and this is the majority of them. Skipping the
+    // walk skips a `Dval.toValueType` per argument, which builds a ValueType tree only to throw away.
+    if argCount = 0 || Set.isEmpty fnFreeTVars then
+      explicitlyBound
+    else
+      // Lockstep walk, no projected list and no zip pairs.
+      let rec inferPkg acc (ps : List<PackageFn.Parameter>) (args : List<Dval>) =
+        match ps with
+        | [] -> acc
+        | p :: pRest ->
+          match args with
+          | [] -> acc
+          | a :: aRest ->
+            inferPkg (inferTVarsFromArg acc p.typ (Dval.toValueType a)) pRest aRest
+      inferPkg explicitlyBound (NEList.toList fn.parameters) allArgs
+  if not (Map.isEmpty newlyBound) then
+    tst <- Map.mergeFavoringRight tst newlyBound
+  recordStage vm ApplyStage.PkgInfer pkgInferAlloc
+
+
+  // Step 5: type-check params against the fully-resolved tst. Lockstep walk, no indexed-triple list and
+  // no zip.
+  let pkgTcAlloc = allocNow vm
+  let alreadyApplied = List.length applicable.argsSoFar
+  let pkgParams = fn.parameters |> NEList.toList |> List.skip alreadyApplied
+  recordStage vm ApplyStage.PkgTypeCheckArgs pkgTcAlloc
+
+  let pkgTcRunAlloc = allocNow vm
+  let struct (pkgNextI, pkgRestPs, pkgRestArgs, pkgTst) =
+    checkPkgParamsSync alreadyApplied pkgParams newArgDvals tst
+  tst <- pkgTst
+  recordStage vm ApplyStage.PkgTypeCheckRun pkgTcRunAlloc
+
+  match pkgRestPs, pkgRestArgs with
+  | [], _
+  | _, [] ->
+    Ply(
+      completePackage
+        exeState
+        vm
+        currentFrame
+        pendingCallArgs
+        ctx
+        fn
+        implicitTypeParams
+        newlyBound
+        allArgs
+        argCount
+        paramCount
+        tst
+    )
+  | _ ->
+    // Something in the remaining parameters needs the type store. Finish the check in a computation
+    // expression and carry on from there -- still one implementation, just resumed asynchronously.
+    let typeCheckParam = TypeChecker.checkFnParam exeState.types applicable.name
+    uply {
+      let mutable tstRest = tst
+      let rec checkRest i (ps : List<PackageFn.Parameter>) (args : List<Dval>) =
+        uply {
+          match ps with
+          | [] -> return ()
+          | p :: pRest ->
+            match args with
+            | [] -> return ()
+            | a :: aRest ->
+              match! typeCheckParam tstRest i p.name p.typ a with
+              | Ok updatedTst ->
+                tstRest <- updatedTst
+                return! checkRest (i + 1) pRest aRest
+              | Error rte -> return raiseRTE rte
+        }
+      do! checkRest pkgNextI pkgRestPs pkgRestArgs
+      return
+        completePackage
+          exeState
+          vm
+          currentFrame
+          pendingCallArgs
+          ctx
+          fn
+          implicitTypeParams
+          newlyBound
+          allArgs
+          argCount
+          paramCount
+          tstRest
+    }
+
+
+/// Run a package-fn call, resolving its explicit type args first. Outside the computation expression for
+/// the same reason as `callBuiltin`.
+let private callPackage
+  (exeState : ExecutionState)
+  (vm : VMState)
+  (currentFrame : CallFrame)
+  (pendingCallArgs : System.Collections.Generic.Dictionary<uuid, Dval list>)
+  (ctx : ApplyContext)
+  (fn : PackageFn.PackageFn)
+  : Ply<PackageOutcome> =
+  let run resolved =
+    callPackageResolved exeState vm currentFrame pendingCallArgs ctx fn resolved
+  match
+    resolveTypeArgsSync
+      exeState
+      vm
+      ctx.applicable.name
+      (List.length fn.typeParams)
+      ctx
+  with
+  | ValueSome resolved -> run resolved
+  | ValueNone ->
+    uply {
+      let! resolved = resolveTypeArgsAsync exeState ctx
+      return! run resolved
+    }
+
+
+
+
 let rec private executeInner (exeState : ExecutionState) (vm : VMState) : Ply<Dval> =
   uply {
     let raiseRTE rte = raiseRTE vm.threadID rte
@@ -276,811 +1386,328 @@ let rec private executeInner (exeState : ExecutionState) (vm : VMState) : Ply<Dv
       let registers = currentFrame.registers
 
 
-      let! instrData =
-        match currentFrame.executionPoint with
-        | Source -> Ply(snd vm.rootInstrData)
-
-        | Lambda(parentContext, lambdaID) ->
-          match Map.tryFind lambdaID vm.lambdaInstrDataCache with
-          | Some cached -> Ply cached
-          | None ->
-            let lambda =
-              match exeState.lambdaInstrCache.TryGetValue lambdaID with
-              | true, l -> l.instructions
-              | false, _ ->
-                Exception.raiseInternal
-                  "lambda not found"
-                  [ "lambdaID", lambdaID; "parentContext", parentContext ]
-
-            let instrData =
-              { instructions = List.toArray lambda.instructions
-                resultReg = lambda.resultIn }
-            vm.lambdaInstrDataCache <-
-              Map.add lambdaID instrData vm.lambdaInstrDataCache
-            Ply instrData
-
-        | Function(FQFnName.Builtin _) ->
-          // we should error in some better way (CLEANUP)
-          // , but the point is that callstacks shouldn't be created for builtin fn calls
-          raiseRTE (RTE.FnNotFound(FQFnName.fqBuiltin "builtin" 0))
-
-        | Function(FQFnName.Package fn) ->
-          uply {
-            match exeState.packageFnInstrCache.TryGetValue fn with
-            | true, cached -> return cached
-            | false, _ ->
-              match! exeState.fns.package fn with
-              | Some fn ->
-                let instrData =
-                  { instructions = List.toArray fn.body.instructions
-                    resultReg = fn.body.resultIn }
-                exeState.packageFnInstrCache[fn.hash] <- instrData
-                return instrData
-
-              | None -> return raiseRTE (RTE.FnNotFound(FQFnName.Package fn))
-          }
-
+      // Resolved when the frame was pushed. This used to be a cache lookup bound with `let!` on every
+      // iteration of this loop, which in the Ply builder's dynamic path allocates a continuation closure
+      // each time -- once per awaiting instruction executed, so tens of thousands per script.
+      let instrData = currentFrame.instrData
 
       let mutable frameToPush = None
 
       while counter < instrData.instructions.Length && frameToPush = None do
-        if vm.stats.enabled then
-          vm.stats.instructionCount <- vm.stats.instructionCount + 1L
+        // Drain every instruction that doesn't need to await, outside the computation expression.
+        counter <-
+          runSyncInstructions exeState vm currentFrame registers instrData counter
 
-        let inst = instrData.instructions[counter]
-        match inst with
+        if counter < instrData.instructions.Length && frameToPush = None then
+          if vm.stats.enabled then
+            vm.stats.instructionCount <- vm.stats.instructionCount + 1L
 
-        // == Simple register operations ==
-        | LoadVal(reg, value) -> registers[reg] <- value
-
-        | CopyVal(copyTo, copyFrom) -> registers[copyTo] <- registers[copyFrom]
-
-        | Or(createTo, left, right) ->
-          match registers[left] with
-          | DBool true -> registers[createTo] <- DBool true
-          | DBool false ->
-            match registers[right] with
-            | DBool true -> registers[createTo] <- DBool true
-            | DBool false -> registers[createTo] <- DBool false
-            | r ->
-              RTE.Bools.OrOnlySupportsBooleans(VT.bool, Dval.toValueType r)
-              |> RTE.Bool
-              |> raiseRTE
-          | l ->
-            let r = registers[right]
-            RTE.Bools.OrOnlySupportsBooleans(Dval.toValueType l, Dval.toValueType r)
-            |> RTE.Bool
-            |> raiseRTE
-
-        | And(createTo, left, right) ->
-          match registers[left] with
-          | DBool false -> registers[createTo] <- DBool false
-          | DBool true ->
-            match registers[right] with
-            | DBool true -> registers[createTo] <- DBool true
-            | DBool false -> registers[createTo] <- DBool false
-            | r ->
-              RTE.Bools.AndOnlySupportsBooleans(VT.bool, Dval.toValueType r)
-              |> RTE.Bool
-              |> raiseRTE
-          | l ->
-            let r = registers[right]
-            RTE.Bools.AndOnlySupportsBooleans(Dval.toValueType l, Dval.toValueType r)
-            |> RTE.Bool
-            |> raiseRTE
-
-
-        // == Working with Variables ==
-        | CheckLetPatternAndExtractVars(valueReg, pat) ->
-          let dv = registers[valueReg]
-          // Fast path for the common single-variable let binding
-          match pat with
-          | LPVariable extractTo -> registers[extractTo] <- dv
-          | LPUnit ->
-            match dv with
-            | DUnit -> ()
-            | _ -> raiseRTE (RTE.Let(RTE.Lets.PatternDoesNotMatch(dv, pat)))
-          | _ ->
-            let doesMatch, registersToAssign = checkAndExtractLetPattern pat dv
-            if doesMatch then
-              registersToAssign
-              |> List.iter (fun (reg, value) -> registers[reg] <- value)
+          let inst = instrData.instructions[counter]
+          let allocBefore =
+            if vm.stats.enabled then
+              System.GC.GetAllocatedBytesForCurrentThread()
             else
-              raiseRTE (RTE.Let(RTE.Lets.PatternDoesNotMatch(dv, pat)))
+              0L
 
-
-        // TODO References to DBs should be resolved at parse-time, not
-        // runtime. For consistency, safety, etc. We should have a specific
-        // EReferenceDB construct that we respect throughout WT, NR, PT, RT,
-        // PT2RT, etc. I don't think this would be that hard.
-        | VarNotFound(targetRegIfDB, varName) ->
-          match exeState.program.dbs |> Map.get varName with
-          | Some _foundDB -> registers[targetRegIfDB] <- DDB varName
-          | None -> raiseRTE (RTE.VariableNotFound varName)
-
-
-
-        // == Working with Basic Types ==
-        | CreateString(targetReg, segments) ->
-          let sb = new System.Text.StringBuilder()
-
-          segments
-          |> List.iter (fun seg ->
-            match seg with
-            | Text s -> sb.Append s |> ignore<System.Text.StringBuilder>
-            | Interpolated reg ->
-              match registers[reg] with
-              | DString s -> sb.Append s |> ignore<System.Text.StringBuilder>
-              | dv ->
-                let vt = Dval.toValueType dv
-                raiseRTE (
-                  RTE.String(RTE.Strings.Error.NonStringInInterpolation(vt, dv))
-                ))
-
-          registers[targetReg] <- DString(sb.ToString())
-
-
-        // == Flow Control ==
-        // -- Jumps --
-        | JumpBy jumpBy -> counter <- counter + jumpBy
-
-        | JumpByIfFalse(jumpBy, condReg) ->
-          match registers[condReg] with
-          | DBool false -> counter <- counter + jumpBy
-          | DBool true -> ()
-          | dv ->
-            raiseRTE (
-              RTE.Bool(RTE.Bools.ConditionRequiresBool(Dval.toValueType dv, dv))
-            )
-
-        // -- Match --
-        | CheckMatchPatternAndExtractVars(valueReg, pat, failJump) ->
-          // Fast path for common single-variable match
-          match pat with
-          | MPVariable reg -> registers[reg] <- registers[valueReg]
-          | _ ->
-            let doesMatch, registersToAssign =
-              checkAndExtractMatchPattern pat registers[valueReg]
-            if doesMatch then
-              registersToAssign
-              |> List.iter (fun (reg, value) -> registers[reg] <- value)
-            else
-              counter <- counter + failJump
-
-        | MatchUnmatched(valueReg) ->
-          let unmatchedValue = registers[valueReg]
-          raiseRTE (RTE.Match(RTE.Matches.MatchUnmatched unmatchedValue))
-
-
-        // == Working with Collections ==
-        | CreateList(listReg, itemsToAddRegs) ->
-          let itemsToAdd = itemsToAddRegs |> List.map (fun r -> registers[r])
-          registers[listReg] <-
-            TypeChecker.DvalCreator.list vm.threadID VT.unknown itemsToAdd
-
-        | CreateDict(dictReg, entries) ->
-          let entries =
-            entries |> List.map (fun (key, valueReg) -> (key, registers[valueReg]))
-          registers[dictReg] <-
-            TypeChecker.DvalCreator.dict vm.threadID VT.unknown entries
-
-        | CreateTuple(tupleReg, firstReg, secondReg, theRestRegs) ->
-          let first = registers[firstReg]
-          let second = registers[secondReg]
-          let theRest = theRestRegs |> List.map (fun r -> registers[r])
-          registers[tupleReg] <- DTuple(first, second, theRest)
-
-
-        // == Working with Custom Data ==
-        // -- Records --
-        | CreateRecord(recordReg, sourceTypeName, typeArgs, fields) ->
-          let fields =
-            fields |> List.map (fun (name, valueReg) -> (name, registers[valueReg]))
-
-          let! typeArgs =
-            typeArgs
-            |> Ply.List.mapSequentially (
-              TypeReference.toVT exeState.types currentFrame.typeSymbolTable
-            )
-
-          let! record =
-            TypeChecker.DvalCreator.record
-              exeState.types
-              vm.threadID
-              currentFrame.typeSymbolTable
-              sourceTypeName
-              typeArgs
+          match inst with
+          | CreateRecord(recordReg, sourceTypeName, typeArgs, fields) ->
+            let fields =
               fields
-
-          registers[recordReg] <- record
-
-
-        | CloneRecordWithUpdates(targetReg, originalRecordReg, fieldUpdates) ->
-          let originalRecord = registers[originalRecordReg]
-
-          match originalRecord with
-          | DRecord(sourceTypeName, resolvedTypeName, typeArgs, originalFields) ->
-            let fieldUpdates =
-              fieldUpdates
               |> List.map (fun (name, valueReg) -> (name, registers[valueReg]))
 
-            let! updatedRecord =
-              TypeChecker.DvalCreator.recordUpdate
+            let! typeArgs =
+              typeArgs
+              |> Ply.List.mapSequentially (
+                TypeReference.toVT exeState.types currentFrame.typeSymbolTable
+              )
+
+            let! record =
+              TypeChecker.DvalCreator.record
                 exeState.types
                 vm.threadID
                 currentFrame.typeSymbolTable
                 sourceTypeName
-                resolvedTypeName
                 typeArgs
-                originalFields
+                fields
+
+            registers[recordReg] <- record
+          | CloneRecordWithUpdates(targetReg, originalRecordReg, fieldUpdates) ->
+            let originalRecord = registers[originalRecordReg]
+
+            match originalRecord with
+            | DRecord(sourceTypeName, resolvedTypeName, typeArgs, originalFields) ->
+              let fieldUpdates =
                 fieldUpdates
+                |> List.map (fun (name, valueReg) -> (name, registers[valueReg]))
 
-            registers[targetReg] <- updatedRecord
-
-          | dv ->
-            Dval.toValueType dv
-            |> RTE.Records.UpdateNotRecord
-            |> RTE.Record
-            |> raiseRTE
-
-
-        | GetRecordField(targetReg, recordReg, fieldName) ->
-          match registers[recordReg] with
-          | DRecord(_, _, _, fields) ->
-            if fieldName = "" then
-              RTE.Records.FieldAccessEmptyFieldName |> RTE.Record |> raiseRTE
-            else
-              match Map.find fieldName fields with
-              | Some value -> registers[targetReg] <- value
-              | None ->
-                RTE.Records.FieldAccessFieldNotFound fieldName
-                |> RTE.Record
-                |> raiseRTE
-          | dv ->
-            RTE.Records.FieldAccessNotRecord(Dval.toValueType dv)
-            |> RTE.Record
-            |> raiseRTE
-
-
-        // -- Enums --
-        | CreateEnum(enumReg, typeName, typeArgs, caseName, fields) ->
-          let fields = fields |> List.map (fun valueReg -> registers[valueReg])
-
-          let tst = currentFrame.typeSymbolTable
-
-          let! typeArgs =
-            typeArgs
-            |> Ply.List.mapSequentially (TypeReference.toVT exeState.types tst)
-
-          let! newEnum =
-            TypeChecker.DvalCreator.enum
-              exeState.types
-              vm.threadID
-              tst
-              typeName
-              typeArgs
-              caseName
-              fields
-
-          registers[enumReg] <- newEnum
-
-
-        | LoadValue(createTo, name) ->
-          match name with
-          | FQValueName.Builtin builtin ->
-            match Map.find builtin exeState.values.builtIn with
-            | Some v -> registers[createTo] <- v.body
-            | None -> raiseRTE (RTE.ValueNotFound name)
-
-          | FQValueName.Package pkg ->
-            match! exeState.values.package pkg with
-            | Some v ->
-              // The Dval is already stored in the package value
-              registers[createTo] <- v.body
-            | None -> raiseRTE (RTE.ValueNotFound name)
-
-
-        | CreateLambda(lambdaReg, impl) ->
-          exeState.lambdaInstrCache[impl.exprId] <- impl
-
-          registers[lambdaReg] <-
-            { exprId = impl.exprId
-              closedRegisters =
-                impl.registersToCloseOver
-                |> List.map (fun (parentReg, childReg) ->
-                  childReg, registers[parentReg])
-              typeSymbolTable = currentFrame.typeSymbolTable
-              argsSoFar = [] }
-            |> AppLambda
-            |> DApplicable
-
-
-
-        // == Working with things that Apply (fns, lambdas) ==
-        // `add (increment 1L) (3L)` and store results in `putResultIn`
-        | Apply(putResultIn, thingToCallReg, typeArgs, newArgRegs) ->
-          // CLEANUP
-          // only the first apply of an applicable should be allowed to provide type args
-
-          let applicable =
-            let thingToCall = registers[thingToCallReg]
-            match thingToCall with
-            | DApplicable applicable -> applicable
-            | _ ->
-              RTE.Applications.ExpectedApplicableButNot(
-                Dval.toValueType thingToCall,
-                thingToCall
-              )
-              |> RTE.Apply
-              |> raiseRTE
-
-          let newArgDvals =
-            newArgRegs |> NEList.toList |> List.map (fun r -> registers[r])
-
-          match applicable with
-          | AppLambda appLambda ->
-            let exprId = appLambda.exprId
-            let foundLambda =
-              match exeState.lambdaInstrCache.TryGetValue exprId with
-              | true, lambda -> lambda
-              | false, _ ->
-                Exception.raiseInternal "lambda not found" [ "exprId", exprId ]
-
-            let allArgs =
-              match appLambda.argsSoFar with
-              | [] -> newArgDvals
-              | prev -> prev @ newArgDvals
-
-            let argCount = List.length allArgs
-            let paramCount = NEList.length foundLambda.patterns
-
-            if typeArgs <> [] then
-              RTE.Applications.CannotApplyTypeArgsToLambda |> RTE.Apply |> raiseRTE
-
-            if argCount = paramCount then
-              let newFrame =
-                { id = guuid ()
-                  parent = Some(vm.currentFrameID, putResultIn, counter + 1)
-                  programCounter = 0
-                  registers =
-                    let r = Array.zeroCreate foundLambda.instructions.registerCount
-
-                    // extract and copy over the args
-                    List.zip (NEList.toList foundLambda.patterns) allArgs
-                    |> List.iter (fun (pat, arg) ->
-                      let doesMatch, registersToAssign =
-                        checkAndExtractLetPattern pat arg
-
-                      if doesMatch then
-                        registersToAssign
-                        |> List.iter (fun (reg, value) -> r[reg] <- value)
-                      else
-                        raiseRTE (RTE.Let(RTE.Lets.PatternDoesNotMatch(arg, pat))))
-
-                    // copy over closed registers
-                    appLambda.closedRegisters
-                    |> List.iter (fun (reg, value) -> r[reg] <- value)
-
-                    // Put the lambda itself in the self register so the body can
-                    // call itself. If it already has no applied args, reuse it
-                    // as-is.
-                    match foundLambda.selfRegister with
-                    | Some selfReg ->
-                      r[selfReg] <-
-                        if List.isEmpty appLambda.argsSoFar then
-                          DApplicable(AppLambda appLambda)
-                        else
-                          DApplicable(AppLambda { appLambda with argsSoFar = [] })
-                    | None -> ()
-
-                    r
-                  typeSymbolTable =
-                    if Map.isEmpty appLambda.typeSymbolTable then
-                      currentFrame.typeSymbolTable
-                    else if Map.isEmpty currentFrame.typeSymbolTable then
-                      appLambda.typeSymbolTable
-                    else
-                      Map.mergeFavoringRight
-                        appLambda.typeSymbolTable
-                        currentFrame.typeSymbolTable
-                  executionPoint = Lambda(currentFrame.executionPoint, exprId) }
-
-              if vm.stats.enabled then
-                vm.stats.framePushCount <- vm.stats.framePushCount + 1L
-              if not exeState.tracing.skipTracing then
-                exeState.tracing.storeFrameEntry
-                  newFrame.id
-                  newFrame.executionPoint
-                  allArgs
-              frameToPush <- Some newFrame
-
-            else if argCount > paramCount then
-              RTE.Applications.TooManyArgsForLambda(exprId, paramCount, argCount)
-              |> RTE.Apply
-              |> raiseRTE
-            else
-              registers[putResultIn] <-
-                { appLambda with argsSoFar = allArgs } |> AppLambda |> DApplicable
-
-          | AppNamedFn applicable ->
-            // some helpers
-            let name = applicable.name
-
-            let handleTooManyArgs expected actual =
-              RTE.Applications.TooManyArgsForFn(name, expected, actual)
-              |> RTE.Apply
-              |> raiseRTE
-
-            let handleWrongTypeArgCount expected actual =
-              RTE.Applications.WrongNumberOfTypeArgsForFn(name, expected, actual)
-              |> RTE.Apply
-              |> raiseRTE
-
-            let typeCheckParam =
-              TypeChecker.checkFnParam exeState.types applicable.name
-
-            let mutable tst =
-              if Map.isEmpty applicable.typeSymbolTable then
-                currentFrame.typeSymbolTable
-              else if Map.isEmpty currentFrame.typeSymbolTable then
-                applicable.typeSymbolTable
-              else
-                Map.mergeFavoringRight
+              let! updatedRecord =
+                TypeChecker.DvalCreator.recordUpdate
+                  exeState.types
+                  vm.threadID
                   currentFrame.typeSymbolTable
-                  applicable.typeSymbolTable
+                  sourceTypeName
+                  resolvedTypeName
+                  typeArgs
+                  originalFields
+                  fieldUpdates
 
-            let typeCheckParams pairs =
-              pairs
-              |> Ply.List.iterSequentially (fun ((pIndex, pName, pType), arg) ->
-                uply {
-                  match! typeCheckParam tst pIndex pName pType arg with
-                  | Ok updatedTst ->
-                    tst <- updatedTst
-                    return ()
-                  | Error rte -> return raiseRTE rte
-                })
+              registers[targetReg] <- updatedRecord
 
-            let typeArgs =
-              match applicable.typeArgs, typeArgs with
-              | [], newTypeArgs -> newTypeArgs
-              | oldTypeArgs, [] -> oldTypeArgs
-              | _, _ ->
-                RTE.Applications.CannotApplyTypeArgsMoreThanOnce
+            | dv ->
+              Dval.toValueType dv
+              |> RTE.Records.UpdateNotRecord
+              |> RTE.Record
+              |> raiseRTE
+          | CreateEnum(enumReg, typeName, typeArgs, caseName, fields) ->
+            let fields = fields |> List.map (fun valueReg -> registers[valueReg])
+
+            let tst = currentFrame.typeSymbolTable
+
+            let! typeArgs =
+              typeArgs
+              |> Ply.List.mapSequentially (TypeReference.toVT exeState.types tst)
+
+            let! newEnum =
+              TypeChecker.DvalCreator.enum
+                exeState.types
+                vm.threadID
+                tst
+                typeName
+                typeArgs
+                caseName
+                fields
+
+            registers[enumReg] <- newEnum
+          | LoadValue(createTo, name) ->
+            match name with
+            | FQValueName.Builtin builtin ->
+              match Map.find builtin exeState.values.builtIn with
+              | Some v -> registers[createTo] <- v.body
+              | None -> raiseRTE (RTE.ValueNotFound name)
+
+            | FQValueName.Package pkg ->
+              match! exeState.values.package pkg with
+              | Some v ->
+                // The Dval is already stored in the package value
+                registers[createTo] <- v.body
+              | None -> raiseRTE (RTE.ValueNotFound name)
+          | Apply(putResultIn, thingToCallReg, typeArgs, newArgRegs) ->
+            // CLEANUP
+            // only the first apply of an applicable should be allowed to provide type args
+
+            let applicable =
+              let thingToCall = registers[thingToCallReg]
+              match thingToCall with
+              | DApplicable applicable -> applicable
+              | _ ->
+                RTE.Applications.ExpectedApplicableButNot(
+                  Dval.toValueType thingToCall,
+                  thingToCall
+                )
                 |> RTE.Apply
                 |> raiseRTE
 
-            // TODO: reduce duplication between branches
-            match applicable.name with
-            | FQFnName.Builtin builtin ->
-              match Map.find builtin exeState.fns.builtIn with
-              | None -> return RTE.FnNotFound(FQFnName.Builtin builtin) |> raiseRTE
-              | Some fn ->
-                // Step 1: resolve typeArgs against the OUTER tst so the
-                // wrapper-pass-through pattern works (a wrapper body
-                // calling Builtin.x<'a> needs `'a` resolved against the
-                // wrapper's tst, not the post-shadow one).
-                let typeParamCount, typeArgCount =
-                  (List.length fn.typeParams, List.length typeArgs)
-                if typeArgCount <> typeParamCount then
-                  return handleWrongTypeArgCount typeParamCount typeArgCount
-                let! resolvedTypeArgsVT =
-                  typeArgs
-                  |> Ply.List.mapSequentially (TypeReference.toVT exeState.types tst)
+            let applyArgsAlloc = allocNow vm
+            let newArgDvals = readRegsNE registers newArgRegs
+            recordStage vm ApplyStage.ApplyArgs applyArgsAlloc
 
-                // Step 2: shadow this fn's free type-vars from the
-                // inherited TST. Mirrors the package-fn path; without
-                // shadowing, an outer fn's `'a := X` would silently
-                // constrain a builtin's unrelated `'a` (e.g. `==` with
-                // `'a` polluted to a tuple type from a parent
-                // List<(...)> context).
-                let implicitTypeParams =
-                  let withParams =
-                    fn.parameters
-                    |> List.fold (fun acc p -> collectTVars acc p.typ) Set.empty
-                  collectTVars withParams fn.returnType
-                tst <-
-                  implicitTypeParams
-                  |> Set.fold (fun m name -> Map.remove name m) tst
+            match applicable with
+            | AppLambda appLambda ->
+              let exprId = appLambda.exprId
+              let foundLambda =
+                match exeState.lambdaInstrCache.TryGetValue exprId with
+                | true, lambda -> lambda
+                | false, _ ->
+                  Exception.raiseInternal "lambda not found" [ "exprId", exprId ]
 
-                // Step 3: bind the (already-resolved) explicit type args.
-                // If the caller omitted type args, leave the typeParams
-                // unbound for inference to fill in.
-                let explicitlyBound =
-                  if List.isEmpty resolvedTypeArgsVT then
-                    Map.empty
-                  else
-                    List.zip fn.typeParams resolvedTypeArgsVT |> Map
-                tst <- Map.mergeFavoringRight tst explicitlyBound
+              let allArgs =
+                match appLambda.argsSoFar with
+                | [] -> newArgDvals
+                | prev -> prev @ newArgDvals
 
-                let allArgs =
-                  match applicable.argsSoFar with
-                  | [] -> newArgDvals
-                  | prev -> prev @ newArgDvals
+              let argCount = List.length allArgs
+              let paramCount = NEList.length foundLambda.patterns
 
-                let paramCount, argCount =
-                  (List.length fn.parameters, List.length allArgs)
+              if typeArgs <> [] then
+                RTE.Applications.CannotApplyTypeArgsToLambda |> RTE.Apply |> raiseRTE
 
-                // Infer type-variable bindings from arg ValueTypes for any
-                // TVariables in the param types not bound by explicit type
-                // args. Same rule as the package-fn path.
-                if argCount > 0 then
-                  let paramTypes = fn.parameters |> List.map (fun p -> p.typ)
-                  let pairs =
-                    List.zipUntilEitherEnds paramTypes allArgs
-                    |> List.map (fun (tr, dv) -> tr, Dval.toValueType dv)
-                  let inferredBound =
-                    pairs
-                    |> List.fold
-                      (fun acc (tr, vt) -> inferTVarsFromArg acc tr vt)
-                      explicitlyBound
-                  if not (Map.isEmpty inferredBound) then
-                    tst <- Map.mergeFavoringRight tst inferredBound
+              if argCount = paramCount then
+                let lambdaFrameAlloc = allocNow vm
+                let newFrame =
+                  { id = nextFrameId vm
+                    parent =
+                      ValueSome(struct (vm.currentFrameID, putResultIn, counter + 1))
+                    programCounter = 0
+                    registers =
+                      if vm.stats.enabled then
+                        vm.stats.registersAllocated <-
+                          vm.stats.registersAllocated
+                          + int64 foundLambda.instructions.registerCount
+                      let r = Array.zeroCreate foundLambda.instructions.registerCount
 
-                // type-check new arguments against the corresponding parameters
-                do!
-                  List.zipUntilEitherEnds
-                    (fn.parameters
-                     |> List.mapi (fun i p -> i, p.name, p.typ)
-                     |> List.skip (List.length applicable.argsSoFar))
-                    newArgDvals
-                  |> typeCheckParams
-
-                let! result =
-                  uply {
-                    if argCount > paramCount then
-                      return handleTooManyArgs paramCount argCount
-                    else if argCount < paramCount then
-                      return
-                        // CLEANUP should the typeArgs here be of VTs, not TRs? check out usages, I suppose.
-                        { applicable with
-                            typeSymbolTable = tst
-                            typeArgs = typeArgs
-                            argsSoFar = allArgs }
-                        |> AppNamedFn
-                        |> DApplicable
-                    else
-                      // Resolve type variables in typeArgs before passing to builtin.
-                      // When a package function like Stdlib.Json.parse<Int64> calls
-                      // Builtin.jsonParse<'a>, the 'a needs to resolve to Int64.
-                      let resolvedTypeArgs =
-                        typeArgs |> List.map (TypeReference.resolveTypeVariables tst)
-                      let sw =
-                        if vm.stats.enabled then
-                          vm.stats.builtinCallCount <- vm.stats.builtinCallCount + 1L
-                          if vm.stats.detailedTiming then
-                            System.Diagnostics.Stopwatch.GetTimestamp()
-                          else
-                            0L
-                        else
-                          0L
-                      // capabilities gate: a builtin runs only if the instance's grant covers the DOMAIN
-                      // it declares it needs (`fn.capabilities`) — a structural PRESENCE check, no name
-                      // matching. Nuanced builtins (http/file/exec/…) additionally enforce the SPECIFIC
-                      // target (URL/path/args) in their own body via `CapabilityCheck`. Default grant is
-                      // allCaps (no behavior change); a real instance narrows it (default NONE for `dark run`).
-                      // fast-path: pure builtins (the vast majority) all share the one `noCaps` instance,
-                      // so a reference check skips the structural scan entirely in the hot path. A false
-                      // negative (an all-empty need built fresh) just runs the full check — still correct.
-                      if
-                        not (
-                          System.Object.ReferenceEquals(
-                            fn.capabilities,
-                            Capabilities.noCaps
-                          )
-                        )
-                      then
-                        match
-                          Capabilities.coversStructurally
-                            exeState.grantedCaps
-                            fn.capabilities
-                        with
-                        | Capabilities.Denied what ->
-                          raiseRTE (
-                            RTE.UncaughtException(
-                              $"capability denied: `{fn.name.name}` needs {what}, which this instance doesn't grant. Grant it with `dark caps`.",
-                              []
-                            )
-                          )
-                        | Capabilities.Allowed -> ()
-                      let! result = fn.fn (exeState, vm, resolvedTypeArgs, allArgs)
-                      if vm.stats.enabled && vm.stats.detailedTiming then
-                        let elapsed =
-                          System.Diagnostics.Stopwatch.GetTimestamp() - sw
-                        vm.stats.recordBuiltin (fn.name.name, elapsed)
-
-                      let expectedReturnType = fn.returnType
-                      match!
-                        TypeChecker.checkFnResult
-                          exeState.types
-                          (FQFnName.Builtin fn.name)
-                          tst
-                          expectedReturnType
-                          result
-                      with
-                      | Ok _ -> ()
-                      | Error rte -> raiseRTE rte
-
-                      // Trace builtin function call.
-                      if not exeState.tracing.skipTracing then
-                        let source : Tracing.Source =
-                          (currentFrame.executionPoint, None)
-                        let fnRecord : Tracing.FunctionRecord =
-                          (source, FQFnName.Builtin fn.name)
-                        exeState.tracing.storeFnResult
-                          fnRecord
-                          (NEList.ofListUnsafe "" [] allArgs)
-                          result
-
-                      return result
-                  }
-
-                registers[putResultIn] <- result
-
-            | FQFnName.Package pkg ->
-              // Harmful-deprecation runtime halt.
-              // Checked before even fetching the fn so the error is surfaced
-              // whether or not the fn definition is still available.
-              let! isHarmful = exeState.fns.isHarmful pkg
-              if isHarmful && not exeState.allowHarmful then
-                return RTE.DeprecatedItemHalted pkg |> raiseRTE
-              match! exeState.fns.package pkg with
-              | None -> return RTE.FnNotFound(FQFnName.Package pkg) |> raiseRTE
-              | Some fn ->
-                // Step 1: resolve any explicit typeArgs against the
-                // OUTER tst — they may reference outer-scope TVariables
-                // (e.g. a wrapper's body calling Builtin.x<'a> uses the
-                // wrapper's `'a`). Type-arg count is required to either
-                // match exactly OR be zero (inference fills the rest in
-                // step 4 below).
-                let! resolvedExplicitTypeArgsVT =
-                  match typeArgs, fn.typeParams with
-                  | [], _ -> Ply [] // OK to omit type args entirely
-                  | _ ->
-                    uply {
-                      let typeParamCount, typeArgCount =
-                        (List.length fn.typeParams, List.length typeArgs)
-                      if typeArgCount <> typeParamCount then
-                        return handleWrongTypeArgCount typeParamCount typeArgCount
-                      return!
-                        typeArgs
-                        |> Ply.List.mapSequentially (
-                          TypeReference.toVT exeState.types tst
-                        )
-                    }
-
-                // Step 2: shadow this fn's free type-vars in the inherited
-                // TST. Each fn's TVariables are scoped to that fn; without
-                // shadowing, an outer fn's `'a := X` would silently
-                // constrain a nested fn's unrelated `'a`.
-                let implicitTypeParams =
-                  let withParams =
-                    fn.parameters
-                    |> NEList.toList
-                    |> List.fold (fun acc p -> collectTVars acc p.typ) Set.empty
-                  collectTVars withParams fn.returnType
-                tst <-
-                  implicitTypeParams
-                  |> Set.fold (fun m name -> Map.remove name m) tst
-
-                // Step 3: bind the (already-resolved) explicit type args
-                // into the freshly-shadowed tst. Explicit args win over
-                // inferred bindings filled in below. If the caller
-                // omitted type args, leave the typeParams unbound for
-                // inference.
-                let explicitlyBound =
-                  if List.isEmpty resolvedExplicitTypeArgsVT then
-                    Map.empty
-                  else
-                    List.zip fn.typeParams resolvedExplicitTypeArgsVT |> Map
-                if not (Map.isEmpty explicitlyBound) then
-                  tst <- Map.mergeFavoringRight tst explicitlyBound
-
-                // Step 3: pre-compute allArgs so we can run inference
-                // BEFORE typeCheckParams. Otherwise the type check runs
-                // against a TST that doesn't yet know `'a := whatever`.
-                let allArgs =
-                  match applicable.argsSoFar with
-                  | [] -> newArgDvals
-                  | prev -> prev @ newArgDvals
-
-                let paramCount, argCount =
-                  (NEList.length fn.parameters, List.length allArgs)
-
-                // Step 4: infer type-variable bindings from arg ValueTypes
-                // for any TVariables in the param types not bound by
-                // explicit type args. Lets wrappers of the shape
-                //   let f (x: List<'a>) : Stream<'a> = Builtin.fromList<'a> x
-                // work without callers passing explicit type args. See
-                // [inferTVarsFromArg] for the unification rules.
-                let inferredBound =
-                  if argCount = 0 then
-                    explicitlyBound
-                  else
-                    let paramTypes =
-                      fn.parameters |> NEList.toList |> List.map (fun p -> p.typ)
-                    let pairs =
-                      List.zipUntilEitherEnds paramTypes allArgs
-                      |> List.map (fun (tr, dv) -> tr, Dval.toValueType dv)
-                    pairs
-                    |> List.fold
-                      (fun acc (tr, vt) -> inferTVarsFromArg acc tr vt)
-                      explicitlyBound
-                let newlyBound = inferredBound
-                if not (Map.isEmpty newlyBound) then
-                  tst <- Map.mergeFavoringRight tst newlyBound
-
-                // Step 5: now type-check params against the fully-resolved tst.
-                do!
-                  List.zipUntilEitherEnds
-                    (fn.parameters
-                     |> NEList.toList
-                     |> List.mapi (fun i p -> i, p.name, p.typ)
-                     |> List.skip (List.length applicable.argsSoFar))
-                    newArgDvals
-                  |> typeCheckParams
-
-                if argCount > paramCount then
-                  return handleTooManyArgs paramCount argCount
-                else if argCount < paramCount then
-                  registers[putResultIn] <-
-                    { applicable with
-                        typeArgs = typeArgs
-                        argsSoFar = allArgs
-                        typeSymbolTable = tst }
-                    |> AppNamedFn
-                    |> DApplicable
-                else
-                  // push a new frame to execute the function. Inherit the
-                  // outer frame's TST but shadow this fn's own free
-                  // type-vars first, so the inner fn's `'a` is local to
-                  // this call and not the outer's.
-                  let frameTst =
-                    let stripped =
-                      implicitTypeParams
-                      |> Set.fold
-                        (fun m name -> Map.remove name m)
-                        currentFrame.typeSymbolTable
-                    Map.mergeFavoringRight stripped newlyBound
-                  let newFrameId = guuid ()
-                  if not exeState.tracing.skipTracing then
-                    pendingCallArgs[newFrameId] <- allArgs
-                  if vm.stats.enabled then
-                    vm.stats.packageCallCount <- vm.stats.packageCallCount + 1L
-                    vm.stats.framePushCount <- vm.stats.framePushCount + 1L
-                    if vm.stats.detailedTiming then
-                      vm.stats.framePushTimestamps[newFrameId] <-
-                        System.Diagnostics.Stopwatch.GetTimestamp()
-                  let pkgEp = Function(FQFnName.Package fn.hash)
-                  if not exeState.tracing.skipTracing then
-                    exeState.tracing.storeFrameEntry newFrameId pkgEp allArgs
-                  frameToPush <-
-                    { id = newFrameId
-                      parent = Some(vm.currentFrameID, putResultIn, counter + 1)
-                      programCounter = 0
-                      registers =
-                        let r = Array.zeroCreate fn.body.registerCount
-                        allArgs |> List.iteri (fun i arg -> r[i] <- arg)
+                      // extract and copy over the args
+                      bindLambdaParams
+                        vm
                         r
-                      typeSymbolTable = frameTst
-                      executionPoint = pkgEp }
-                    |> Some
+                        (foundLambda.patterns.head :: foundLambda.patterns.tail)
+                        allArgs
 
-        | RaiseNRE(names, nre) -> raiseRTE (RTE.ParseTimeNameResolution(names, nre))
+                      // copy over closed registers
+                      assignRegisters r appLambda.closedRegisters
 
-        // CLEANUP: consider renaming this to something like "RequireExprToReturnUnit"
-        | CheckIfFirstExprIsUnit reg ->
-          match registers[reg] with
-          | DUnit -> ()
-          | dval ->
-            RTE.Statements.FirstExpressionMustBeUnit(
-              ValueType.Known KTUnit,
-              Dval.toValueType dval,
-              dval
-            )
-            |> RuntimeError.Statement
-            |> raiseRTE
+                      // Put the lambda itself in the self register so the body can
+                      // call itself. If it already has no applied args, reuse it
+                      // as-is.
+                      match foundLambda.selfRegister with
+                      | Some selfReg ->
+                        r[selfReg] <-
+                          if List.isEmpty appLambda.argsSoFar then
+                            DApplicable(AppLambda appLambda)
+                          else
+                            DApplicable(AppLambda { appLambda with argsSoFar = [] })
+                      | None -> ()
 
-        counter <- counter + 1
+                      r
+                    typeSymbolTable =
+                      if Map.isEmpty appLambda.typeSymbolTable then
+                        currentFrame.typeSymbolTable
+                      else if Map.isEmpty currentFrame.typeSymbolTable then
+                        appLambda.typeSymbolTable
+                      else
+                        Map.mergeFavoringRight
+                          appLambda.typeSymbolTable
+                          currentFrame.typeSymbolTable
+                    executionPoint = Lambda(currentFrame.executionPoint, exprId)
+                    expectedReturnType = ValueNone
+                    // Resolved here so the loop never has to look it up. Same shared InstrData the
+                    // per-VM cache holds; this is a reference to it, not a copy.
+                    instrData =
+                      match Map.tryFind exprId vm.lambdaInstrDataCache with
+                      | Some cached -> cached
+                      | None ->
+                        let d : InstrData =
+                          { instructions =
+                              List.toArray foundLambda.instructions.instructions
+                            resultReg = foundLambda.instructions.resultIn }
+                        vm.lambdaInstrDataCache <-
+                          Map.add exprId d vm.lambdaInstrDataCache
+                        d }
+
+                recordStage vm ApplyStage.LambdaFrame lambdaFrameAlloc
+                if vm.stats.enabled then
+                  vm.stats.framePushCount <- vm.stats.framePushCount + 1L
+                if not exeState.tracing.skipTracing then
+                  exeState.tracing.storeFrameEntry
+                    newFrame.id
+                    newFrame.executionPoint
+                    allArgs
+                frameToPush <- Some newFrame
+
+              else if argCount > paramCount then
+                RTE.Applications.TooManyArgsForLambda(exprId, paramCount, argCount)
+                |> RTE.Apply
+                |> raiseRTE
+              else
+                registers[putResultIn] <-
+                  { appLambda with argsSoFar = allArgs } |> AppLambda |> DApplicable
+
+            | AppNamedFn applicable ->
+              // The symbol table the call starts from. `callBuiltin` and `callPackage` take it from
+              // here and do the rest -- shadowing, inference, checking, invocation -- outside this
+              // computation expression, which is where all of it used to live.
+              let tst =
+                if Map.isEmpty applicable.typeSymbolTable then
+                  currentFrame.typeSymbolTable
+                else if Map.isEmpty currentFrame.typeSymbolTable then
+                  applicable.typeSymbolTable
+                else
+                  Map.mergeFavoringRight
+                    currentFrame.typeSymbolTable
+                    applicable.typeSymbolTable
+
+              let typeArgs =
+                match applicable.typeArgs, typeArgs with
+                | [], newTypeArgs -> newTypeArgs
+                | oldTypeArgs, [] -> oldTypeArgs
+                | _, _ ->
+                  RTE.Applications.CannotApplyTypeArgsMoreThanOnce
+                  |> RTE.Apply
+                  |> raiseRTE
+
+              let ctx : ApplyContext =
+                { applicable = applicable
+                  typeArgs = typeArgs
+                  args = newArgDvals
+                  tst = tst
+                  putResultIn = putResultIn
+                  returnPc = counter + 1 }
+
+              // CLEANUP the two branches below are near-identical in shape, and so are `callBuiltin`
+              // and `callPackage` behind them: same five steps, different parameter and outcome types.
+              // Unifying them needs `BuiltInParam` and `PackageFn.Parameter` to share an interface.
+              match applicable.name with
+              | FQFnName.Builtin builtin ->
+                let biLookupAlloc = allocNow vm
+                match Map.find builtin exeState.fns.builtIn with
+                | None -> return RTE.FnNotFound(FQFnName.Builtin builtin) |> raiseRTE
+                | Some fn ->
+                  recordStage vm ApplyStage.BiFnLookup biLookupAlloc
+                  let call = callBuiltin exeState vm currentFrame ctx fn
+                  // Usually already finished, in which case there's no bind to pay for.
+                  match Ply.trySync call with
+                  | ValueSome dv -> registers[putResultIn] <- dv
+                  | ValueNone ->
+                    let! dv = call
+                    registers[putResultIn] <- dv
+
+              | FQFnName.Package pkg ->
+                // Harmful-deprecation runtime halt.
+                // Checked before even fetching the fn so the error is surfaced
+                // whether or not the fn definition is still available.
+                let isHarmful = exeState.fns.isHarmful pkg
+                if isHarmful && not exeState.allowHarmful then
+                  return RTE.DeprecatedItemHalted pkg |> raiseRTE
+                let pkgFetchAlloc = allocNow vm
+                // Warm cache after the first call, which for a script means all but a handful of these.
+                let fetch = exeState.fns.package pkg
+                let mutable fetched = None
+                match Ply.trySync fetch with
+                | ValueSome f -> fetched <- f
+                | ValueNone ->
+                  let! f = fetch
+                  fetched <- f
+                match fetched with
+                | None -> return RTE.FnNotFound(FQFnName.Package pkg) |> raiseRTE
+                | Some fn ->
+                  recordStage vm ApplyStage.PkgFetch pkgFetchAlloc
+                  let call =
+                    callPackage exeState vm currentFrame pendingCallArgs ctx fn
+                  // Overwritten on the next line either way; F# needs something to start from.
+                  let mutable outcome = PartiallyApplied DUnit
+                  match Ply.trySync call with
+                  | ValueSome o -> outcome <- o
+                  | ValueNone ->
+                    let! o = call
+                    outcome <- o
+                  match outcome with
+                  | PartiallyApplied dv -> registers[putResultIn] <- dv
+                  | PushFrame frame -> frameToPush <- Some frame
+
+          // Handled by `runSyncInstructions`; the match must still be exhaustive.
+          | _ -> ()
+
+          if vm.stats.enabled then
+            let tag = Opcode.index inst
+            if tag >= 0 && tag < vm.stats.allocByOpcode.Length then
+              // Clamped at zero: these arms await, and this counter is per-thread, so a resume on another
+              // thread makes the odd delta meaningless rather than merely noisy.
+              let delta = System.GC.GetAllocatedBytesForCurrentThread() - allocBefore
+              if delta > 0L then
+                vm.stats.allocByOpcode[tag] <- vm.stats.allocByOpcode[tag] + delta
+              vm.stats.countByOpcode[tag] <- vm.stats.countByOpcode[tag] + 1L
+
+          counter <- counter + 1
+
 
 
       // exited loop -- either pushed a frame or finished the current frame
@@ -1097,51 +1724,56 @@ let rec private executeInner (exeState : ExecutionState) (vm : VMState) : Ply<Dv
         let resultOfFrame = registers[instrData.resultReg]
 
         match currentFrame.parent with
-        | Some(parentID, regOfParentToPutResultInto, pcOfParent) ->
+        | ValueSome(parentID, regOfParentToPutResultInto, pcOfParent) ->
           // We just finished processing a frame, and we need to return a value to the parent frame
 
           // TODO this might be where the type-checking of a fn result needs to happen.
           // But when here, it's not always a fn call - could also be for a lambda.
 
           // Type-check results of fns
+          let retTcAlloc = allocNow vm
           match currentFrame.executionPoint with
           | Source -> ()
           | Lambda _ -> ()
           | Function fnName ->
-            let! expectedReturnType =
-              match fnName with
-              | FQFnName.Package id ->
-                uply {
-                  let! fn = exeState.fns.package id
-                  match fn with
-                  | None -> return RTE.FnNotFound fnName |> raiseRTE
-                  | Some fn -> return fn.returnType
-                }
-
-              | FQFnName.Builtin builtin ->
-                let fn = Map.findUnsafe builtin exeState.fns.builtIn
-                Ply fn.returnType
+            // Recorded when the frame was pushed. Builtins never get a frame, so a Function frame always
+            // carries one; the fallback keeps the match total rather than asserting.
+            let expectedReturnType =
+              match currentFrame.expectedReturnType with
+              | ValueSome t -> t
+              | ValueNone ->
+                match fnName with
+                | FQFnName.Builtin builtin ->
+                  (Map.findUnsafe builtin exeState.fns.builtIn).returnType
+                | FQFnName.Package _ -> RTE.FnNotFound fnName |> raiseRTE
 
             let tst = currentFrame.typeSymbolTable
-            match!
-              TypeChecker.unify exeState.types tst expectedReturnType resultOfFrame
-            with
-            | Ok _updatedTst ->
-              //currentFrame.typeSymbolTable <- updatedTst
-              // CLEANUP is this^ or something like it worthwhile?
-              ()
-            | Error _path ->
-              let! expectedVT =
-                TypeReference.toVT exeState.types tst expectedReturnType
-              return
-                RuntimeError.Applications.FnResultNotExpectedType(
-                  fnName,
-                  expectedVT,
-                  Dval.toValueType resultOfFrame,
-                  resultOfFrame
-                )
-                |> RuntimeError.Apply
-                |> raiseRTE
+            // Every frame return checks its result, so the same sync-first treatment as the argument
+            // checks applies: skip the bind when the answer needs no type lookup.
+            match TypeChecker.tryUnifySync tst expectedReturnType resultOfFrame with
+            | ValueSome _ -> ()
+            | ValueNone ->
+              match!
+                TypeChecker.unify exeState.types tst expectedReturnType resultOfFrame
+              with
+              | Ok _updatedTst ->
+                //currentFrame.typeSymbolTable <- updatedTst
+                // CLEANUP is this^ or something like it worthwhile?
+                ()
+              | Error _path ->
+                let! expectedVT =
+                  TypeReference.toVT exeState.types tst expectedReturnType
+                return
+                  RuntimeError.Applications.FnResultNotExpectedType(
+                    fnName,
+                    expectedVT,
+                    Dval.toValueType resultOfFrame,
+                    resultOfFrame
+                  )
+                  |> RuntimeError.Apply
+                  |> raiseRTE
+
+          recordStage vm ApplyStage.FrameReturnTypeCheck retTcAlloc
 
           // Record per-package-fn timing on frame return
           if vm.stats.enabled && vm.stats.detailedTiming then
@@ -1155,6 +1787,7 @@ let rec private executeInner (exeState : ExecutionState) (vm : VMState) : Ply<Dv
               vm.stats.framePushTimestamps.Remove(vm.currentFrameID) |> ignore<bool>
             | false, _ -> ()
 
+          let framePopAlloc = allocNow vm
           vm.callFrames.Remove(vm.currentFrameID) |> ignore<bool>
 
           vm.currentFrameID <- parentID
@@ -1182,8 +1815,9 @@ let rec private executeInner (exeState : ExecutionState) (vm : VMState) : Ply<Dv
             | Source -> pendingCallArgs.Remove(currentFrame.id) |> ignore<bool>
           parentFrame.registers[regOfParentToPutResultInto] <- resultOfFrame
           parentFrame.programCounter <- pcOfParent
+          recordStage vm ApplyStage.FramePop framePopAlloc
 
-        | None ->
+        | ValueNone ->
           vm.callFrames.Remove(vm.currentFrameID) |> ignore<bool>
           finalResult <- Some resultOfFrame
 

--- a/backend/src/LibExecution/PackageRefs.fs
+++ b/backend/src/LibExecution/PackageRefs.fs
@@ -93,7 +93,13 @@ module Type =
         if Map.isEmpty h then
           "" // Hash file not yet populated (CI before reload-packages)
         else
-          Exception.raiseInternal "PackageRefs: type hash not found" [ "fqn", fqn ]
+          // Non-empty hash file that doesn't know this ref means the file is stale, which happens
+          // whenever a ref is added (or an older binary regenerates the file in-place -- `growIfNeeded`
+          // rewrites it, so running a previous release inside the source tree is enough). The fix is
+          // always the same, so say it rather than making the next person find it in AGENTS.md.
+          Exception.raiseInternal
+            "PackageRefs: type hash not found. The hash file is stale; regenerate it with `> backend/src/LibExecution/package-ref-hashes.txt && ./scripts/build/reload-packages`"
+            [ "fqn", fqn ]
 
   // Darklang.Sync.* — internal sync machinery (op-log wire types)
   module Sync =
@@ -277,6 +283,10 @@ module Type =
       let dval = p [] "Dval"
       let knownType = p [] "KnownType"
       let valueType = p [] "ValueType"
+      let stringSegment = p [] "StringSegment"
+      let instruction = p [] "Instruction"
+      let instructions = p [] "Instructions"
+      let lambdaImpl = p [] "LambdaImpl"
       let applicableNamedFn = p [] "ApplicableNamedFn"
       let applicableLambda = p [] "ApplicableLambda"
       let applicable = p [] "Applicable"
@@ -445,7 +455,9 @@ module Fn =
         if Map.isEmpty h then
           "" // Hash file not yet populated (CI before reload-packages)
         else
-          Exception.raiseInternal "PackageRefs: fn hash not found" [ "fqn", fqn ]
+          Exception.raiseInternal
+            "PackageRefs: fn hash not found. The hash file is stale; regenerate it with `> backend/src/LibExecution/package-ref-hashes.txt && ./scripts/build/reload-packages`"
+            [ "fqn", fqn ]
 
   module Stdlib =
     let private p addl = p ("Stdlib" :: addl)

--- a/backend/src/LibExecution/ProgramTypesToRuntimeTypes.fs
+++ b/backend/src/LibExecution/ProgramTypesToRuntimeTypes.fs
@@ -1396,7 +1396,7 @@ module PackageManager =
 
       // PT PackageManager doesn't surface deprecation state; transient
       // wrappers (tests, in-memory flows) have no branch chain anyway.
-      isHarmful = fun _ _ -> Ply false
+      isHarmful = fun _ _ -> false
 
       init = pm.init }
 

--- a/backend/src/LibExecution/RuntimeTypes.fs
+++ b/backend/src/LibExecution/RuntimeTypes.fs
@@ -1331,28 +1331,53 @@ module Dval =
     | DInt i -> DarkInt.toBigInt i
     | _ -> Exception.raiseInternal "asBigInt called on a non-Int Dval" []
 
+
+  // `ValueType.Known KTBool` and friends are constants, but the `Known` wrapper was
+  // allocated fresh on every call. `toValueType` runs at least twice per argument per
+  // function call -- once for inference, once for the parameter type check -- so these were
+  // among the most frequently allocated objects in the interpreter. Nullary DU cases like
+  // `KTBool` are already singletons; only the wrapper was being rebuilt.
+  let private vtUnit : ValueType = ValueType.Known KTUnit
+  let private vtBool : ValueType = ValueType.Known KTBool
+  let private vtInt8 : ValueType = ValueType.Known KTInt8
+  let private vtUInt8 : ValueType = ValueType.Known KTUInt8
+  let private vtInt16 : ValueType = ValueType.Known KTInt16
+  let private vtUInt16 : ValueType = ValueType.Known KTUInt16
+  let private vtInt32 : ValueType = ValueType.Known KTInt32
+  let private vtUInt32 : ValueType = ValueType.Known KTUInt32
+  let private vtInt64 : ValueType = ValueType.Known KTInt64
+  let private vtUInt64 : ValueType = ValueType.Known KTUInt64
+  let private vtInt128 : ValueType = ValueType.Known KTInt128
+  let private vtUInt128 : ValueType = ValueType.Known KTUInt128
+  let private vtInt : ValueType = ValueType.Known KTInt
+  let private vtFloat : ValueType = ValueType.Known KTFloat
+  let private vtChar : ValueType = ValueType.Known KTChar
+  let private vtString : ValueType = ValueType.Known KTString
+  let private vtDateTime : ValueType = ValueType.Known KTDateTime
+  let private vtUuid : ValueType = ValueType.Known KTUuid
+
   let rec toValueType (dv : Dval) : ValueType =
     match dv with
-    | DUnit -> ValueType.Known KTUnit
+    | DUnit -> vtUnit
 
-    | DBool _ -> ValueType.Known KTBool
+    | DBool _ -> vtBool
 
-    | DInt8 _ -> ValueType.Known KTInt8
-    | DUInt8 _ -> ValueType.Known KTUInt8
-    | DInt16 _ -> ValueType.Known KTInt16
-    | DUInt16 _ -> ValueType.Known KTUInt16
-    | DInt32 _ -> ValueType.Known KTInt32
-    | DUInt32 _ -> ValueType.Known KTUInt32
-    | DInt64 _ -> ValueType.Known KTInt64
-    | DUInt64 _ -> ValueType.Known KTUInt64
-    | DInt128 _ -> ValueType.Known KTInt128
-    | DUInt128 _ -> ValueType.Known KTUInt128
-    | DInt _ -> ValueType.Known KTInt
-    | DFloat _ -> ValueType.Known KTFloat
-    | DChar _ -> ValueType.Known KTChar
-    | DString _ -> ValueType.Known KTString
-    | DDateTime _ -> ValueType.Known KTDateTime
-    | DUuid _ -> ValueType.Known KTUuid
+    | DInt8 _ -> vtInt8
+    | DUInt8 _ -> vtUInt8
+    | DInt16 _ -> vtInt16
+    | DUInt16 _ -> vtUInt16
+    | DInt32 _ -> vtInt32
+    | DUInt32 _ -> vtUInt32
+    | DInt64 _ -> vtInt64
+    | DUInt64 _ -> vtUInt64
+    | DInt128 _ -> vtInt128
+    | DUInt128 _ -> vtUInt128
+    | DInt _ -> vtInt
+    | DFloat _ -> vtFloat
+    | DChar _ -> vtChar
+    | DString _ -> vtString
+    | DDateTime _ -> vtDateTime
+    | DUuid _ -> vtUuid
 
     | DList(t, _) -> ValueType.Known(KTList t)
     | DDict(t, _) -> ValueType.Known(KTDict t)
@@ -1594,7 +1619,9 @@ type PackageManager =
     /// Branch-scoped because deprecation state flows through branches; the
     /// other PM lookups are content-addressed and need no branch.
     /// Only fns participate — see DeprecationKind.Harmful for why.
-    isHarmful : BranchId -> FQFnName.Package -> Ply<bool>
+    /// Synchronous: every implementation computes this without I/O (the DB-backed one reads a per-branch
+    /// cache), so returning `Ply<bool>` would cost a computation-expression bind on every package call.
+    isHarmful : BranchId -> FQFnName.Package -> bool
 
     init : Ply<unit>
   }
@@ -1605,7 +1632,7 @@ type PackageManager =
       getValue = (fun _ -> Ply None)
       getBlob = (fun _ -> Ply None)
       persistBlob = (fun _ _ -> uply { return () })
-      isHarmful = (fun _ _ -> Ply false)
+      isHarmful = (fun _ _ -> false)
 
       init = uply { return () } }
 
@@ -1766,17 +1793,40 @@ module Tracing =
 // -- The VM --
 type Registers = Dval array
 
+type InstrData =
+  {
+    instructions : Instruction array
+
+    /// The register that the result of the block will be in
+    resultReg : Register
+  }
+
 type CallFrame =
   {
     id : uuid
 
     /// (Id * where to put result in parent * pc of parent to return to)
-    parent : Option<uuid * Register * int>
+    ///
+    /// A struct option of a struct tuple: the root frame aside, one of these is built for every function
+    /// call in the program, and the reference-typed form was two allocations each time.
+    parent : voption<struct (uuid * Register * int)>
 
-    // The instructions and resultReg are not in the CallFrame itself.
-    // Multiple CFs may be operating on the same fn/lambda/etc.,
-    // so we keep only one copy of such, in the root of the VMState
     executionPoint : ExecutionPoint
+
+    /// The instructions this frame runs, resolved once when the frame is pushed.
+    ///
+    /// A reference to the single shared `InstrData` for the fn or lambda, not a copy: the caches in
+    /// `ExecutionState` and `VMState` still hold one each, and every frame running the same function
+    /// points at it. Holding it here keeps the interpreter loop from binding a cache lookup with `let!`
+    /// on every iteration.
+    instrData : InstrData
+
+    /// The declared return type, for the check that runs when this frame returns.
+    ///
+    /// Resolved at push time for the same reason as `instrData`: otherwise every frame return re-fetches
+    /// the function purely to read one field, and binds it, which costs a continuation closure per return.
+    /// `ValueNone` for the root frame and for lambdas, neither of which declares one.
+    expectedReturnType : TypeReference voption
 
     /// What instruction index we are currently 'at'
     mutable programCounter : int
@@ -1786,13 +1836,135 @@ type CallFrame =
     registers : Registers
   }
 
-type InstrData =
-  {
-    instructions : Instruction array
+/// Synchronous regions of the Apply path that the allocation counters attribute to.
+module ApplyStage =
+  let names : string[] =
+    [| "pkg.tstShadow"
+       "pkg.infer"
+       "pkg.typeCheckArgs"
+       "pkg.frame"
+       "bi.tstShadow"
+       "bi.args"
+       "lambda.frame"
+       "applyArgs"
+       "pkg.typeCheckRun"
+       "bi.typeCheckRun"
+       "bi.checkResult"
+       "frame.returnTypeCheck"
+       "frame.pop"
+       "pkg.fetch"
+       "bi.fnLookup" |]
 
-    /// The register that the result of the block will be in
-    resultReg : Register
-  }
+  [<Literal>]
+  let PkgTstShadow = 0
+  [<Literal>]
+  let PkgInfer = 1
+  [<Literal>]
+  let PkgTypeCheckArgs = 2
+  [<Literal>]
+  let PkgFrame = 3
+  [<Literal>]
+  let BiTstShadow = 4
+  [<Literal>]
+  let BiArgs = 5
+  [<Literal>]
+  let LambdaFrame = 6
+  [<Literal>]
+  let ApplyArgs = 7
+  [<Literal>]
+  let PkgTypeCheckRun = 8
+  [<Literal>]
+  let BiTypeCheckRun = 9
+  [<Literal>]
+  let BiCheckResult = 10
+  [<Literal>]
+  let FrameReturnTypeCheck = 11
+  [<Literal>]
+  let FramePop = 12
+  [<Literal>]
+  let PkgFetch = 13
+  [<Literal>]
+  let BiFnLookup = 14
+
+
+/// Stable index and display name per `Instruction` case, used by the per-opcode allocation counters on
+/// `InterpreterStats`. The DU's compiler-generated `Tag` isn't accessible from here, so the mapping is
+/// written out; `names` and `index` must stay in the same order.
+module Opcode =
+  let names : string[] =
+    [| "LoadVal"
+       "CopyVal"
+       "Or"
+       "And"
+       "CreateString"
+       "CheckLetPatternAndExtractVars"
+       "JumpByIfFalse"
+       "JumpBy"
+       "CheckMatchPatternAndExtractVars"
+       "MatchUnmatched"
+       "CreateTuple"
+       "CreateList"
+       "CreateDict"
+       "CreateRecord"
+       "CloneRecordWithUpdates"
+       "GetRecordField"
+       "CreateEnum"
+       "LoadValue"
+       "CreateLambda"
+       "Apply"
+       "RaiseNRE"
+       "VarNotFound"
+       "CheckIfFirstExprIsUnit" |]
+
+  let index (i : Instruction) : int =
+    match i with
+    | LoadVal _ -> 0
+    | CopyVal _ -> 1
+    | Or _ -> 2
+    | And _ -> 3
+    | CreateString _ -> 4
+    | CheckLetPatternAndExtractVars _ -> 5
+    | JumpByIfFalse _ -> 6
+    | JumpBy _ -> 7
+    | CheckMatchPatternAndExtractVars _ -> 8
+    | MatchUnmatched _ -> 9
+    | CreateTuple _ -> 10
+    | CreateList _ -> 11
+    | CreateDict _ -> 12
+    | CreateRecord _ -> 13
+    | CloneRecordWithUpdates _ -> 14
+    | GetRecordField _ -> 15
+    | CreateEnum _ -> 16
+    | LoadValue _ -> 17
+    | CreateLambda _ -> 18
+    | Apply _ -> 19
+    | RaiseNRE _ -> 20
+    | VarNotFound _ -> 21
+    | CheckIfFirstExprIsUnit _ -> 22
+
+
+/// Every `InterpreterStats` created while telemetry is on, so the process can total them at exit. A VM is
+/// created per `executeFunction` and the stats hang off the VM, so there is otherwise no way to ask "how
+/// many instructions did that command run?": the object is gone by the time anyone could look.
+///
+/// Instrumentation only: the bag stays empty and nothing is enabled when telemetry is off.
+module InterpreterStatsSink =
+  let all = System.Collections.Concurrent.ConcurrentBag<obj>()
+
+  /// Nothing ever removes from the bag, and a VM is created per `executeFunction`, so a long-lived
+  /// process with telemetry on (`serve`, or a long interactive session) would accumulate one entry per
+  /// call forever. A one-shot CLI command creates a handful, so a cap costs nothing there and bounds the
+  /// leak everywhere else. Past the cap we stop recording rather than evicting: the exit dump wants the
+  /// run's first VMs, not its last.
+  let maxRetained = 10_000
+
+  let mutable private retained = 0
+
+  let add (s : obj) : unit =
+    if retained < maxRetained then
+      retained <- retained + 1
+      all.Add s
+
 
 /// Lightweight interpreter performance counters.
 /// Incremented during execution, read/reset via builtins.
@@ -1820,21 +1992,73 @@ type InterpreterStats =
     packageFnCounts : Dictionary<string, int64>
     /// Timestamp when each frame was pushed (for measuring total fn time)
     framePushTimestamps : Dictionary<uuid, int64>
+
+    /// Bytes allocated while executing each opcode, indexed by the `Instruction` DU tag, plus how many of
+    /// each ran. Neither instruction count nor call count predicts wall time well, because the interpreter
+    /// is allocation-bound; this says *which* opcodes produce the garbage.
+    ///
+    /// A `GC.GetAllocatedBytesForCurrentThread()` is ~4 ns against a ~6.7 us instruction, so unlike a
+    /// Stopwatch read (~1.27 us on an HPET host) this is affordable per instruction.
+    allocByOpcode : int64[]
+    countByOpcode : int64[]
+
+    /// Total register slots allocated across every frame pushed. Each frame gets its own
+    /// `Array.zeroCreate registerCount`, so this times 8 bytes is the register-file share of Apply's
+    /// allocation -- the leading suspect for its ~5.6 KB per call.
+    mutable registersAllocated : int64
+
+    /// Bytes allocated inside builtin bodies (`fn.fn`), separated from the interpreter machinery around
+    /// them. The per-opcode counter can't answer this: Apply's arm awaits, so its delta spans nested
+    /// execution and over-counts (it reports more than the process allocates in total).
+    mutable builtinBodyAlloc : int64
+
+    /// Bytes allocated per builtin name. Unlike `builtinTiming` this doesn't need `detailedTiming`: an
+    /// allocation read is ~4 ns where a Stopwatch read is ~1.27 us on an HPET host, so it's affordable
+    /// on every call.
+    builtinAlloc : Dictionary<string, int64>
+
+    /// Bytes allocated in named *synchronous* regions of the Apply path, indexed by `ApplyStage`.
+    ///
+    /// Only synchronous regions: a bracket spanning an `await` measures the nested execution that resumes
+    /// inside it, not the region. That artifact made both the per-opcode Apply counter and the
+    /// builtin-body counter over-report (the former claimed more bytes than the process allocated in
+    /// total; the latter attributed 97% to the root script-runner builtin, which encloses everything).
+    allocByStage : int64[]
+
+    /// Type-symbol-table size at each frame push, summed and maxed. The TST is an immutable F# Map that a
+    /// frame inherits from its parent, so if bindings accumulate down the call stack every merge on it is
+    /// O(k) in a growing k -- which would make Apply's cost superlinear in depth rather than constant.
+    mutable tstSizeSum : int64
+    mutable tstSizeMax : int64
   }
 
   static member create() =
-    { enabled = false
-      instructionCount = 0L
-      builtinCallCount = 0L
-      packageCallCount = 0L
-      framePushCount = 0L
-      packageFnLoadCount = 0L
-      detailedTiming = false
-      builtinTiming = Dictionary()
-      builtinCounts = Dictionary()
-      packageFnTiming = Dictionary()
-      packageFnCounts = Dictionary()
-      framePushTimestamps = Dictionary() }
+    let s =
+      { enabled = Telemetry.isEnabled ()
+        instructionCount = 0L
+        builtinCallCount = 0L
+        packageCallCount = 0L
+        framePushCount = 0L
+        packageFnLoadCount = 0L
+        // Off even when counting is on: per-call timing costs a `Stopwatch.GetTimestamp()`, which is ~1.27us
+        // on an HPET host. Turn it on deliberately, per run, via `Builtin.interpreterStatsEnableDetailedTiming`.
+        detailedTiming = false
+        builtinTiming = Dictionary()
+        builtinCounts = Dictionary()
+        packageFnTiming = Dictionary()
+        packageFnCounts = Dictionary()
+        framePushTimestamps = Dictionary()
+        allocByOpcode = Array.zeroCreate 32
+        countByOpcode = Array.zeroCreate 32
+        registersAllocated = 0L
+        builtinBodyAlloc = 0L
+        builtinAlloc = Dictionary()
+        allocByStage = Array.zeroCreate 32
+        tstSizeSum = 0L
+        tstSizeMax = 0L }
+
+    if s.enabled then InterpreterStatsSink.add (box s)
+    s
 
   member this.reset() =
     this.instructionCount <- 0L
@@ -1847,6 +2071,14 @@ type InterpreterStats =
     this.packageFnTiming.Clear()
     this.packageFnCounts.Clear()
     this.framePushTimestamps.Clear()
+    this.registersAllocated <- 0L
+    this.builtinBodyAlloc <- 0L
+    this.builtinAlloc.Clear()
+    this.tstSizeSum <- 0L
+    this.tstSizeMax <- 0L
+    System.Array.Clear(this.allocByStage, 0, this.allocByStage.Length)
+    System.Array.Clear(this.allocByOpcode, 0, this.allocByOpcode.Length)
+    System.Array.Clear(this.countByOpcode, 0, this.countByOpcode.Length)
 
   member private this.addTiming
     (timingDict : Dictionary<string, int64>)
@@ -1854,10 +2086,13 @@ type InterpreterStats =
     (name : string)
     (elapsedTicks : int64)
     =
-    let usec = elapsedTicks * 1000000L / System.Diagnostics.Stopwatch.Frequency
+    // Raw ticks, not microseconds. The reporting boundary (`interpreterStatsGet`) documents that these
+    // accumulators hold ticks and converts once there; dividing here both contradicted that -- so the
+    // report multiplied ticks-per-ns by a value already in microseconds and under-reported by 1000x on a
+    // 1 GHz clocksource -- and put a division in the hot path that the comment there says it avoids.
     match timingDict.TryGetValue(name) with
-    | true, v -> timingDict[name] <- v + usec
-    | false, _ -> timingDict[name] <- usec
+    | true, v -> timingDict[name] <- v + elapsedTicks
+    | false, _ -> timingDict[name] <- elapsedTicks
     match countDict.TryGetValue(name) with
     | true, v -> countDict[name] <- v + 1L
     | false, _ -> countDict[name] <- 1L
@@ -1883,6 +2118,12 @@ type VMState =
 
     /// Performance counters — incremented during execution
     stats : InterpreterStats
+
+    /// Source of frame ids. Per-VM rather than global because a VM's interpreter loop is single-threaded,
+    /// so this needs no synchronization -- and a process-global counter would need it: tests run VMs in
+    /// parallel, and a non-atomic shared increment hands two frames the same id, which silently drops one
+    /// from `callFrames` and fails the parent lookup on return.
+    mutable frameIdCounter : int64
   }
 
   static member create(instrs : Option<tlid> * Instructions) : VMState =
@@ -1890,13 +2131,19 @@ type VMState =
 
     let rootCallFrameID = System.Guid.NewGuid()
 
+    let rootInstrData : InstrData =
+      { instructions = List.toArray instrs.instructions
+        resultReg = instrs.resultIn }
+
     let rootCallFrame : CallFrame =
       { id = rootCallFrameID
         executionPoint = Source
+        instrData = rootInstrData
+        expectedReturnType = ValueNone
         programCounter = 0
         registers = Array.zeroCreate instrs.registerCount
         typeSymbolTable = Map.empty
-        parent = None }
+        parent = ValueNone }
 
     { threadID = System.Guid.NewGuid()
       currentFrameID = rootCallFrameID
@@ -1904,13 +2151,10 @@ type VMState =
         let d = Dictionary()
         d[rootCallFrameID] <- rootCallFrame
         d
-      rootInstrData =
-        let instrs =
-          { instructions = List.toArray instrs.instructions
-            resultReg = instrs.resultIn }
-        (tlid, instrs)
+      rootInstrData = (tlid, rootInstrData)
       lambdaInstrDataCache = Map.empty
-      stats = InterpreterStats.create () }
+      stats = InterpreterStats.create ()
+      frameIdCounter = 0L }
 
   static member createWithoutTLID(instrs : Instructions) : VMState =
     VMState.create (None, instrs)
@@ -2077,7 +2321,7 @@ and Functions =
     builtIn : Map<FQFnName.Builtin, BuiltInFn>
     package : FQFnName.Package -> Ply<Option<PackageFn.PackageFn>>
     /// `PackageManager.isHarmful` with the state's branchId pre-applied.
-    isHarmful : FQFnName.Package -> Ply<bool>
+    isHarmful : FQFnName.Package -> bool
   }
 
 

--- a/backend/src/LibExecution/RuntimeTypesToDarkTypes.fs
+++ b/backend/src/LibExecution/RuntimeTypesToDarkTypes.fs
@@ -834,6 +834,139 @@ module Dval =
 
 
 // TODO: make sure we've tested all of these RTEs
+// One-way: nothing constructs instructions Dark-side yet.
+module StringSegment =
+  let typeName () =
+    FQTypeName.fqPackage (
+      PackageRefs.Type.LanguageTools.RuntimeTypes.stringSegment ()
+    )
+  let knownType () = KTCustomType(typeName (), [])
+
+  let toDT (s : StringSegment) : Dval =
+    let (caseName, fields) =
+      match s with
+      | Text t -> "Text", [ DString t ]
+      | Interpolated r -> "Interpolated", [ DInt32 r ]
+    DEnum(typeName (), typeName (), [], caseName, fields)
+
+
+module Instruction =
+  let typeName () =
+    FQTypeName.fqPackage (PackageRefs.Type.LanguageTools.RuntimeTypes.instruction ())
+  let knownType () = KTCustomType(typeName (), [])
+
+  let private reg (r : Register) : Dval = DInt32 r
+  let private regs (rs : List<Register>) : Dval = Dval.list KTInt32 (List.map reg rs)
+
+  let private namedRegs (prs : List<string * Register>) : Dval =
+    prs
+    |> List.map (fun (n, r) -> DTuple(DString n, reg r, []))
+    |> Dval.list (KTTuple(VT.string, VT.int32, []))
+
+  let private typeArgs (ts : List<TypeReference>) : Dval =
+    ts |> List.map TypeReference.toDT |> Dval.list (TypeReference.knownType ())
+
+  let instructionsTypeName () =
+    FQTypeName.fqPackage (
+      PackageRefs.Type.LanguageTools.RuntimeTypes.instructions ()
+    )
+
+  let lambdaImplTypeName () =
+    FQTypeName.fqPackage (PackageRefs.Type.LanguageTools.RuntimeTypes.lambdaImpl ())
+
+  // Mutually recursive: an instruction can create a lambda, whose body is more instructions.
+  let rec toDT (i : Instruction) : Dval =
+    let (caseName, fields) =
+      match i with
+      | LoadVal(r, v) -> "LoadVal", [ reg r; Dval.toDT v ]
+      | CopyVal(t, s) -> "CopyVal", [ reg t; reg s ]
+      | Or(t, l, r) -> "Or", [ reg t; reg l; reg r ]
+      | And(t, l, r) -> "And", [ reg t; reg l; reg r ]
+      | CreateString(t, segs) ->
+        "CreateString",
+        [ reg t
+          segs
+          |> List.map StringSegment.toDT
+          |> Dval.list (StringSegment.knownType ()) ]
+      | CheckLetPatternAndExtractVars(v, p) ->
+        "CheckLetPatternAndExtractVars", [ reg v; LetPattern.toDT p ]
+      | JumpByIfFalse(n, c) -> "JumpByIfFalse", [ DInt32 n; reg c ]
+      | JumpBy n -> "JumpBy", [ DInt32 n ]
+      | CheckMatchPatternAndExtractVars(v, p, fail) ->
+        "CheckMatchPatternAndExtractVars",
+        [ reg v; MatchPattern.toDT p; DInt32 fail ]
+      | MatchUnmatched v -> "MatchUnmatched", [ reg v ]
+      | CreateTuple(t, a, b, rest) ->
+        "CreateTuple", [ reg t; reg a; reg b; regs rest ]
+      | CreateList(t, items) -> "CreateList", [ reg t; regs items ]
+      | CreateDict(t, entries) -> "CreateDict", [ reg t; namedRegs entries ]
+      | CreateRecord(t, name, targs, fields) ->
+        "CreateRecord",
+        [ reg t; FQTypeName.toDT name; typeArgs targs; namedRegs fields ]
+      | CloneRecordWithUpdates(t, orig, updates) ->
+        "CloneRecordWithUpdates", [ reg t; reg orig; namedRegs updates ]
+      | GetRecordField(t, r, name) ->
+        "GetRecordField", [ reg t; reg r; DString name ]
+      | CreateEnum(t, name, targs, case, fields) ->
+        "CreateEnum",
+        [ reg t; FQTypeName.toDT name; typeArgs targs; DString case; regs fields ]
+      | LoadValue(t, name) -> "LoadValue", [ reg t; FQValueName.toDT name ]
+      | CreateLambda(t, l) -> "CreateLambda", [ reg t; lambdaImplToDT l ]
+      | Apply(t, fnReg, targs, args) ->
+        "Apply", [ reg t; reg fnReg; typeArgs targs; regs (NEList.toList args) ]
+      | RaiseNRE(names, err) ->
+        "RaiseNRE",
+        [ names |> List.map DString |> Dval.list KTString
+          NameResolutionError.toDT err ]
+      | VarNotFound(t, name) -> "VarNotFound", [ reg t; DString name ]
+      | CheckIfFirstExprIsUnit r -> "CheckIfFirstExprIsUnit", [ reg r ]
+    DEnum(typeName (), typeName (), [], caseName, fields)
+
+  and instructionsToDT (i : Instructions) : Dval =
+    DRecord(
+      instructionsTypeName (),
+      instructionsTypeName (),
+      [],
+      Map
+        [ "registerCount", DInt32 i.registerCount
+          "instructions", i.instructions |> List.map toDT |> Dval.list (knownType ())
+          "resultIn", DInt32 i.resultIn ]
+    )
+
+  and lambdaImplToDT (l : LambdaImpl) : Dval =
+    DRecord(
+      lambdaImplTypeName (),
+      lambdaImplTypeName (),
+      [],
+      Map
+        [ "exprId", DUInt64 l.exprId
+          "patterns",
+          l.patterns
+          |> NEList.toList
+          |> List.map LetPattern.toDT
+          |> Dval.list (LetPattern.knownType ())
+          "registersToCloseOver",
+          l.registersToCloseOver
+          |> List.map (fun (a, b) -> DTuple(DInt32 a, DInt32 b, []))
+          |> Dval.list (KTTuple(VT.int32, VT.int32, []))
+          "selfRegister", l.selfRegister |> Option.map DInt32 |> Dval.option KTInt32
+          "instructions", instructionsToDT l.instructions ]
+    )
+
+
+/// Thin aliases so callers say `Instructions.toDT`. The functions live on `Instruction` because the
+/// three types are mutually recursive and F# modules can't be.
+module Instructions =
+  let typeName () = Instruction.instructionsTypeName ()
+  let knownType () = KTCustomType(typeName (), [])
+  let toDT (i : Instructions) : Dval = Instruction.instructionsToDT i
+
+module LambdaImpl =
+  let typeName () = Instruction.lambdaImplTypeName ()
+  let knownType () = KTCustomType(typeName (), [])
+  let toDT (l : LambdaImpl) : Dval = Instruction.lambdaImplToDT l
+
+
 module RuntimeError =
   module Bools =
     let toDT (e : RuntimeError.Bools.Error) : Dval =

--- a/backend/src/LibExecution/TypeChecker.fs
+++ b/backend/src/LibExecution/TypeChecker.fs
@@ -16,6 +16,223 @@ type OverwriteBehaviour =
   | ReplaceValue
   | ThrowIfDuplicate
 
+/// Synchronous answer for the unifications that need no recursion, no type lookup and no await: a
+/// concrete scalar against its own ValueType, or anything against `Unknown`. That is the overwhelming
+/// majority of calls, and type-checking arguments and results is a large share of what the interpreter
+/// allocates, so answering them without entering a computation expression is worth the separate path.
+///
+/// `TVariable` is deliberately excluded rather than folded into the `Unknown` case. The full matcher tries
+/// `TVariable name, _` FIRST, so a type variable meeting `Unknown` binds the variable to `Unknown`; short
+/// -circuiting that here would skip the binding and silently change inference.
+let private unifiesTrivially (expected : TypeReference) (actual : ValueType) : bool =
+  // Matches on `expected` and then on `actual` rather than on the pair. F# allocates the tuple for a
+  // two-value match here rather than eliding it -- the same change to `inferTVarsFromArg` moved total
+  // allocation 3.3% -- and this runs on every unification.
+  //
+  // `TVariable` is deliberately excluded rather than folded into the `Unknown` case: the full matcher
+  // tries `TVariable name, _` FIRST, so a type variable meeting `Unknown` binds the variable to
+  // `Unknown`, and short-circuiting that here would skip the binding and change inference.
+  match expected with
+  | TVariable _ -> false
+  | _ ->
+    match actual with
+    | ValueType.Unknown -> true
+    | ValueType.Known kt ->
+      match expected with
+      | TUnit ->
+        (match kt with
+         | KTUnit -> true
+         | _ -> false)
+      | TBool ->
+        (match kt with
+         | KTBool -> true
+         | _ -> false)
+      | TInt8 ->
+        (match kt with
+         | KTInt8 -> true
+         | _ -> false)
+      | TUInt8 ->
+        (match kt with
+         | KTUInt8 -> true
+         | _ -> false)
+      | TInt16 ->
+        (match kt with
+         | KTInt16 -> true
+         | _ -> false)
+      | TUInt16 ->
+        (match kt with
+         | KTUInt16 -> true
+         | _ -> false)
+      | TInt32 ->
+        (match kt with
+         | KTInt32 -> true
+         | _ -> false)
+      | TUInt32 ->
+        (match kt with
+         | KTUInt32 -> true
+         | _ -> false)
+      | TInt64 ->
+        (match kt with
+         | KTInt64 -> true
+         | _ -> false)
+      | TUInt64 ->
+        (match kt with
+         | KTUInt64 -> true
+         | _ -> false)
+      | TInt128 ->
+        (match kt with
+         | KTInt128 -> true
+         | _ -> false)
+      | TUInt128 ->
+        (match kt with
+         | KTUInt128 -> true
+         | _ -> false)
+      | TInt ->
+        (match kt with
+         | KTInt -> true
+         | _ -> false)
+      | TFloat ->
+        (match kt with
+         | KTFloat -> true
+         | _ -> false)
+      | TChar ->
+        (match kt with
+         | KTChar -> true
+         | _ -> false)
+      | TString ->
+        (match kt with
+         | KTString -> true
+         | _ -> false)
+      | TUuid ->
+        (match kt with
+         | KTUuid -> true
+         | _ -> false)
+      | TDateTime ->
+        (match kt with
+         | KTDateTime -> true
+         | _ -> false)
+      | TBlob ->
+        (match kt with
+         | KTBlob -> true
+         | _ -> false)
+      | _ -> false
+
+
+/// Answer a unification without entering a computation expression, for the cases that need no type lookup
+/// and no recursion into a compound type.
+///
+/// `unifyValueType` already answers these two cases without awaiting, but it returns a `Ply`, so every
+/// caller still binds it and the Ply builder allocates a continuation closure for the bind. Returning the
+/// answer directly is what lets the whole argument-check loop stay out of the CE.
+///
+/// `Undecided` means "this one has to go the async route"; it is never a type error, so callers must
+/// fall back rather than treat it as a failure.
+///
+/// A struct DU rather than `Result<_, _> voption`: this runs per argument per call, and the `Ok` wrapper
+/// alone was one of the more frequently allocated objects in the interpreter.
+[<Struct>]
+type SyncUnification =
+  /// Unified, with the symbol table it produced.
+  | Unified of tst : TypeSymbolTable
+  /// Genuinely doesn't unify, with the path to where it went wrong.
+  | Mismatched of path : ReverseTypeCheckPath
+  /// Needs the async path -- a type lookup, or an error message worth building properly.
+  | Undecided
+
+let rec unifyValueTypeSync
+  (tst : TypeSymbolTable)
+  (pathSoFar : ReverseTypeCheckPath)
+  (expected : TypeReference)
+  (actual : ValueType)
+  : SyncUnification =
+  if unifiesTrivially expected actual then
+    Unified tst
+  else
+    match expected with
+    // Same reasoning as the hoisted case in `unifyValueType`, and deliberately the same logic: most
+    // arguments bind a type variable, and most rebind it to what it already held.
+    | TVariable name ->
+      // `TryGetValue` rather than `Map.get`, which allocates a `Some` for every bound type variable it
+      // finds -- and finding one is the common case here, not the exception.
+      let mutable bound = Unchecked.defaultof<ValueType>
+      if not (tst.TryGetValue(name, &bound)) then
+        Unified(Map.add name actual tst)
+      elif bound = actual then
+        Unified tst
+      else
+        match ValueType.merge bound actual with
+        | Ok merged ->
+          if merged = bound then Unified tst else Unified(Map.add name merged tst)
+        | Error() -> Mismatched pathSoFar
+
+    // Containers recurse but never need a type lookup, so they stay on this path. Without these a
+    // `List<Int>` argument -- which is most of what the standard library passes around -- would fall to
+    // the async route purely for being a container, which is the common case rather than a rare one.
+    | TList innerT ->
+      match actual with
+      | ValueType.Known(KTList innerV) ->
+        unifyValueTypeSync
+          tst
+          (TypeCheckPathPart.ListType :: pathSoFar)
+          innerT
+          innerV
+      | _ -> Undecided
+    | TStream innerT ->
+      match actual with
+      | ValueType.Known(KTStream innerV) ->
+        unifyValueTypeSync
+          tst
+          (TypeCheckPathPart.ListType :: pathSoFar)
+          innerT
+          innerV
+      | _ -> Undecided
+    | TDict innerT ->
+      match actual with
+      | ValueType.Known(KTDict innerV) ->
+        unifyValueTypeSync
+          tst
+          (TypeCheckPathPart.DictValueType :: pathSoFar)
+          innerT
+          innerV
+      | _ -> Undecided
+
+    | TTuple(tFirst, tSecond, tRest) ->
+      match actual with
+      | ValueType.Known(KTTuple(vFirst, vSecond, vRest)) ->
+        if List.length tRest <> List.length vRest then
+          Undecided // length mismatch: let the async path build the error
+        else
+          let rec go i tst (es : List<TypeReference>) (vs : List<ValueType>) =
+            match es with
+            | [] -> Unified tst
+            | e :: eRest ->
+              match vs with
+              | [] -> Unified tst
+              | v :: vRest ->
+                match
+                  unifyValueTypeSync
+                    tst
+                    (TypeCheckPathPart.TupleAtIndex i :: pathSoFar)
+                    e
+                    v
+                with
+                | Unified tst' -> go (i + 1) tst' eRest vRest
+                | other -> other
+          go 0 tst (tFirst :: tSecond :: tRest) (vFirst :: vSecond :: vRest)
+      | _ -> Undecided
+
+    // Everything else, `TCustomType` above all, can need `Types.find`.
+    | _ -> Undecided
+
+
+/// Alias unwrapping without a CE. Only a resolved custom type can be an alias, and only that case needs
+/// `Types.find`, so everything else is already the answer.
+let unwrapAliasSync (typ : TypeReference) : TypeReference voption =
+  match typ with
+  | TCustomType({ resolved = Ok _ }, _) -> ValueNone
+  | _ -> ValueSome typ
+
+
 let rec unifyValueType
   (types : Types)
   (tst : TypeSymbolTable)
@@ -23,146 +240,174 @@ let rec unifyValueType
   (expected : TypeReference)
   (actual : ValueType)
   : Ply<Result<TypeSymbolTable, ReverseTypeCheckPath>> =
-  let r = unifyValueType types
+  if unifiesTrivially expected actual then
+    Ply(Ok tst)
+  else
 
-  uply {
-    match expected, actual with
+    match expected with
+    // Hoisted out of the match below, and out of the computation expression, because it is the hot path
+    // and needs neither. ~88% of calls are into functions whose signature has a type variable, and
+    // `unifiesTrivially` never claims one, so nearly every non-trivial unification lands here. Answering it
+    // outside the CE skips both the state machine and the `(expected, actual)` pair the tuple match
+    // allocates.
+    | TVariable name ->
+      (match Map.get name tst with
+       | None -> Ply(Ok(Map.add name actual tst))
+       | Some t ->
+         // Already bound to exactly this: `Map.add` would rebuild the symbol table's spine to store the
+         // value it already holds. Dark's stdlib is heavily polymorphic, so this is the *common* path --
+         // nearly every argument check binds a type variable, and most rebind it to what it already was.
+         if t = actual then
+           Ply(Ok tst)
+         else
+           match ValueType.merge t actual with
+           | Ok merged ->
+             if merged = t then Ply(Ok tst) else Ply(Ok(Map.add name merged tst))
+           | Error() -> Ply(Error pathSoFar))
 
-    | TVariable name, _ ->
-      match Map.get name tst with
-      | None -> return Ok(Map.add name actual tst)
-      | Some t ->
-        match ValueType.merge t actual with
-        | Ok merged -> return Ok(Map.add name merged tst)
-        | Error() -> return Error pathSoFar
+    | _ ->
 
-    | _, ValueType.Unknown -> return Ok tst
+      // Bound after the fast paths: this is a partial application, so it allocates a closure on every call
+      // that reaches it, and most calls no longer do.
+      let r = unifyValueType types
 
-
-    | TUnit, ValueType.Known KTUnit -> return Ok tst
-    | TBool, ValueType.Known KTBool -> return Ok tst
-
-    | TInt8, ValueType.Known KTInt8 -> return Ok tst
-    | TUInt8, ValueType.Known KTUInt8 -> return Ok tst
-    | TInt16, ValueType.Known KTInt16 -> return Ok tst
-    | TUInt16, ValueType.Known KTUInt16 -> return Ok tst
-    | TInt32, ValueType.Known KTInt32 -> return Ok tst
-    | TUInt32, ValueType.Known KTUInt32 -> return Ok tst
-    | TInt64, ValueType.Known KTInt64 -> return Ok tst
-    | TUInt64, ValueType.Known KTUInt64 -> return Ok tst
-    | TInt128, ValueType.Known KTInt128 -> return Ok tst
-    | TUInt128, ValueType.Known KTUInt128 -> return Ok tst
-    | TInt, ValueType.Known KTInt -> return Ok tst
-
-    | TFloat, ValueType.Known KTFloat -> return Ok tst
-
-    | TChar, ValueType.Known KTChar -> return Ok tst
-    | TString, ValueType.Known KTString -> return Ok tst
-
-    | TUuid, ValueType.Known KTUuid -> return Ok tst
-    | TDateTime, ValueType.Known KTDateTime -> return Ok tst
-
-    | TBlob, ValueType.Known KTBlob -> return Ok tst
-
-    | TStream innerT, ValueType.Known(KTStream innerV) ->
-      return! r tst (TypeCheckPathPart.ListType :: pathSoFar) innerT innerV
-
-    | TList innerT, ValueType.Known(KTList innerV) ->
-      return! r tst (TypeCheckPathPart.ListType :: pathSoFar) innerT innerV
-
-    | TDict innerT, ValueType.Known(KTDict innerV) ->
-      return! r tst (TypeCheckPathPart.DictValueType :: pathSoFar) innerT innerV
-
-    | TTuple(tFirst, tSecond, tRest),
-      ValueType.Known(KTTuple(vFirst, vSecond, vRest)) ->
-      // first, make sure that the tuple lengths match
-      let expectedLen = 2 + List.length tRest
-      let actualLen = 2 + List.length vRest
-      if expectedLen <> actualLen then
-        return
-          Error(TypeCheckPathPart.TupleLength(expectedLen, actualLen) :: pathSoFar)
-      else
-        // then, make sure that the tuple elements match
-        let expected = tFirst :: tSecond :: tRest
-        let actual = vFirst :: vSecond :: vRest
-        return!
-          Ply.List.foldSequentiallyWithIndex
-            (fun i acc (e, a) ->
-              match acc with
-              | Error _ -> Ply acc
-              | Ok tst -> r tst (TypeCheckPathPart.TupleAtIndex i :: pathSoFar) e a)
-            (Ok tst)
-            (List.zip expected actual)
-
-    | TCustomType({ originalName = names; resolved = Error err }, _), _ ->
-      return RTE.ParseTimeNameResolution(names, err) |> raiseUntargetedRTE
-
-    | TCustomType({ resolved = Ok typeNameT }, typeArgsT), actual ->
-      // CLEANUP can't we assume aliases are already unwrapped?
-      // if so, we can tidy this case quite a bit
-      match! Types.find types typeNameT with
-      | None -> return Error pathSoFar
-      | Some expected ->
+      uply {
         match expected, actual with
-        | { definition = TypeDeclaration.Alias aliasType }, _ ->
-          let! expected = TypeReference.unwrapAlias types aliasType
-          return! r tst pathSoFar expected actual
 
-        | _, ValueType.Known(KTCustomType(typeNameV, typeArgsV)) ->
-          if typeNameV <> typeNameT then
-            return Error pathSoFar
-          else if List.length typeArgsT <> List.length typeArgsV then
-            // (this is really unexpected -- interpreter should prevent this)
+        | TVariable _, _ ->
+          // Unreachable: handled above. Kept so the match stays exhaustive over TypeReference.
+          return Ok tst
+
+        | _, ValueType.Unknown -> return Ok tst
+
+
+        | TUnit, ValueType.Known KTUnit -> return Ok tst
+        | TBool, ValueType.Known KTBool -> return Ok tst
+
+        | TInt8, ValueType.Known KTInt8 -> return Ok tst
+        | TUInt8, ValueType.Known KTUInt8 -> return Ok tst
+        | TInt16, ValueType.Known KTInt16 -> return Ok tst
+        | TUInt16, ValueType.Known KTUInt16 -> return Ok tst
+        | TInt32, ValueType.Known KTInt32 -> return Ok tst
+        | TUInt32, ValueType.Known KTUInt32 -> return Ok tst
+        | TInt64, ValueType.Known KTInt64 -> return Ok tst
+        | TUInt64, ValueType.Known KTUInt64 -> return Ok tst
+        | TInt128, ValueType.Known KTInt128 -> return Ok tst
+        | TUInt128, ValueType.Known KTUInt128 -> return Ok tst
+        | TInt, ValueType.Known KTInt -> return Ok tst
+
+        | TFloat, ValueType.Known KTFloat -> return Ok tst
+
+        | TChar, ValueType.Known KTChar -> return Ok tst
+        | TString, ValueType.Known KTString -> return Ok tst
+
+        | TUuid, ValueType.Known KTUuid -> return Ok tst
+        | TDateTime, ValueType.Known KTDateTime -> return Ok tst
+
+        | TBlob, ValueType.Known KTBlob -> return Ok tst
+
+        | TStream innerT, ValueType.Known(KTStream innerV) ->
+          return! r tst (TypeCheckPathPart.ListType :: pathSoFar) innerT innerV
+
+        | TList innerT, ValueType.Known(KTList innerV) ->
+          return! r tst (TypeCheckPathPart.ListType :: pathSoFar) innerT innerV
+
+        | TDict innerT, ValueType.Known(KTDict innerV) ->
+          return! r tst (TypeCheckPathPart.DictValueType :: pathSoFar) innerT innerV
+
+        | TTuple(tFirst, tSecond, tRest),
+          ValueType.Known(KTTuple(vFirst, vSecond, vRest)) ->
+          // first, make sure that the tuple lengths match
+          let expectedLen = 2 + List.length tRest
+          let actualLen = 2 + List.length vRest
+          if expectedLen <> actualLen then
             return
               Error(
-                TypeCheckPathPart.TypeArgLength(
-                  typeNameT,
-                  List.length typeArgsT,
-                  List.length typeArgsV
-                )
-                :: pathSoFar
+                TypeCheckPathPart.TupleLength(expectedLen, actualLen) :: pathSoFar
               )
           else
-            let typeArgCount = List.length typeArgsT
+            // then, make sure that the tuple elements match
+            let expected = tFirst :: tSecond :: tRest
+            let actual = vFirst :: vSecond :: vRest
             return!
-              List.zip typeArgsT typeArgsV
-              |> Ply.List.foldSequentiallyWithIndex
+              Ply.List.foldSequentiallyWithIndex
                 (fun i acc (e, a) ->
                   match acc with
-                  | Error _path -> Ply acc
+                  | Error _ -> Ply acc
                   | Ok tst ->
-                    uply {
-                      let path =
-                        TypeCheckPathPart.TypeArg(typeNameT, i, typeArgCount)
-                        :: pathSoFar
-                      match! r tst path e a with
-                      | Error path -> return Error path
-                      | Ok tst -> return Ok tst
-                    })
+                    r tst (TypeCheckPathPart.TupleAtIndex i :: pathSoFar) e a)
+                (Ok tst)
+                (List.zip expected actual)
+
+        | TCustomType({ originalName = names; resolved = Error err }, _), _ ->
+          return RTE.ParseTimeNameResolution(names, err) |> raiseUntargetedRTE
+
+        | TCustomType({ resolved = Ok typeNameT }, typeArgsT), actual ->
+          // CLEANUP can't we assume aliases are already unwrapped?
+          // if so, we can tidy this case quite a bit
+          match! Types.find types typeNameT with
+          | None -> return Error pathSoFar
+          | Some expected ->
+            match expected, actual with
+            | { definition = TypeDeclaration.Alias aliasType }, _ ->
+              let! expected = TypeReference.unwrapAlias types aliasType
+              return! r tst pathSoFar expected actual
+
+            | _, ValueType.Known(KTCustomType(typeNameV, typeArgsV)) ->
+              if typeNameV <> typeNameT then
+                return Error pathSoFar
+              else if List.length typeArgsT <> List.length typeArgsV then
+                // (this is really unexpected -- interpreter should prevent this)
+                return
+                  Error(
+                    TypeCheckPathPart.TypeArgLength(
+                      typeNameT,
+                      List.length typeArgsT,
+                      List.length typeArgsV
+                    )
+                    :: pathSoFar
+                  )
+              else
+                let typeArgCount = List.length typeArgsT
+                return!
+                  List.zip typeArgsT typeArgsV
+                  |> Ply.List.foldSequentiallyWithIndex
+                    (fun i acc (e, a) ->
+                      match acc with
+                      | Error _path -> Ply acc
+                      | Ok tst ->
+                        uply {
+                          let path =
+                            TypeCheckPathPart.TypeArg(typeNameT, i, typeArgCount)
+                            :: pathSoFar
+                          match! r tst path e a with
+                          | Error path -> return Error path
+                          | Ok tst -> return Ok tst
+                        })
+                    (Ok tst)
+
+            | _, _ -> return Error pathSoFar
+
+        | TFn(argTypes, returnType), ValueType.Known(KTFn(vArgs, vRet)) ->
+          if NEList.length argTypes <> NEList.length vArgs then
+            return Error pathSoFar // CLEANUP include the lengths in the path
+          else
+            return!
+              List.zip
+                (returnType :: (NEList.toList argTypes))
+                (vRet :: (NEList.toList vArgs))
+              |> Ply.List.foldSequentially
+                (fun acc (e, a) ->
+                  match acc with
+                  | Error _path -> Ply acc
+                  | Ok tst -> r tst pathSoFar e a)
                 (Ok tst)
 
+        | TDB innerT, ValueType.Known(KTDB innerV) ->
+          return! r tst pathSoFar innerT innerV
+
         | _, _ -> return Error pathSoFar
-
-    | TFn(argTypes, returnType), ValueType.Known(KTFn(vArgs, vRet)) ->
-      if NEList.length argTypes <> NEList.length vArgs then
-        return Error pathSoFar // CLEANUP include the lengths in the path
-      else
-        return!
-          List.zip
-            (returnType :: (NEList.toList argTypes))
-            (vRet :: (NEList.toList vArgs))
-          |> Ply.List.foldSequentially
-            (fun acc (e, a) ->
-              match acc with
-              | Error _path -> Ply acc
-              | Ok tst -> r tst pathSoFar e a)
-            (Ok tst)
-
-    | TDB innerT, ValueType.Known(KTDB innerV) ->
-      return! r tst pathSoFar innerT innerV
-
-    | _, _ -> return Error pathSoFar
-  }
+      }
 
 
 let unify
@@ -171,12 +416,15 @@ let unify
   (expected : TypeReference)
   (actual : Dval)
   : Ply<Result<TypeSymbolTable, ReverseTypeCheckPath>> =
-  uply {
-    let actualType = Dval.toValueType actual
-    match! unifyValueType types tst [] expected actualType with
-    | Error path -> return path |> Error
-    | Ok updatedTst -> return Ok updatedTst
-  }
+  let actualType = Dval.toValueType actual
+  if unifiesTrivially expected actualType then
+    Ply(Ok tst)
+  else
+    uply {
+      match! unifyValueType types tst [] expected actualType with
+      | Error path -> return path |> Error
+      | Ok updatedTst -> return Ok updatedTst
+    }
 
 // CLEANUP I wonder if this can/should happen in PT2RT instead of during interpretation
 let rec resolveType
@@ -242,6 +490,29 @@ let rec resolveType
 
 
 
+/// The unification behind both the parameter and the result checks, answered without a computation
+/// expression when it needs no type lookup.
+///
+/// Runs on every argument of every call and on every frame return, so the point is that the ordinary case
+/// allocates nothing at all: no Ply, no continuation closure, no state machine.
+///
+/// `ValueNone` means "go the async route". That covers an aliased type, a compound type needing recursion,
+/// and *any* failure: building the error message resolves the expected type, which can hit the package
+/// store. Failures are rare and already the slow path, so they are not worth a sync variant.
+let tryUnifySync
+  (tst : TypeSymbolTable)
+  (expected : TypeReference)
+  (actual : Dval)
+  : TypeSymbolTable voption =
+  match unwrapAliasSync expected with
+  | ValueNone -> ValueNone
+  | ValueSome expected ->
+    match unifyValueTypeSync tst [] expected (Dval.toValueType actual) with
+    | Unified updatedTst -> ValueSome updatedTst
+    | Mismatched _
+    | Undecided -> ValueNone
+
+
 let checkFnParam
   (types : Types)
   (fnName : FQFnName.FQFnName)
@@ -280,10 +551,13 @@ let checkFnResult
   : Ply<Result<TypeSymbolTable, RTE.Error>> =
   uply {
     let! expected = TypeReference.unwrapAlias types expected
-    let! expectedVT = TypeReference.toVT types tst expected
     match! unify types tst expected actual with
     | Ok updatedTst -> return Ok updatedTst
     | Error _path ->
+      // Resolved here rather than before the unify: it exists only to render the error, and computing it
+      // eagerly meant every successful return -- which is nearly all of them -- paid a full type
+      // resolution (`toVT` walks the reference and can hit `Types.find`) to build a message nobody sees.
+      let! expectedVT = TypeReference.toVT types tst expected
       return
         RTE.Applications.FnResultNotExpectedType(
           fnName,

--- a/backend/src/Prelude/NonBlockingConsole.fs
+++ b/backend/src/Prelude/NonBlockingConsole.fs
@@ -40,18 +40,26 @@ type private Private() =
   static do
     let f () =
       while true do
+        let mutable wrote = false
+
         lock mLock (fun () ->
           try
             let mutable v = null
             // Don't block (eg with `Take`) while holding the lock
             if mQueue.TryTake(&v) then
               System.Console.Write(v)
-            else
-              System.Threading.Thread.Sleep 1 // 1ms
+              wrote <- true
           with e ->
             System.Console.WriteLine(
               $"Exception in blocking queue thread: {e.Message}"
             ))
+
+        // Sleep OUTSIDE the lock. Sleeping inside means holding `mLock` for essentially the whole
+        // millisecond of every idle iteration, and `wait()` spins acquiring the same lock; .NET's Monitor
+        // isn't fair, so `wait()` loses that race repeatedly and a two-line command can spend ~100 ms in
+        // it. Taking and writing an item stays inside the lock, so `wait()` still cannot return between a
+        // value leaving the queue and reaching the console, which is the invariant the lock exists for.
+        if not wrote then System.Threading.Thread.Sleep 1
 
 
     // Background threads aren't supported in Blazor

--- a/backend/src/Prelude/Ply.fs
+++ b/backend/src/Prelude/Ply.fs
@@ -21,6 +21,16 @@ let bind (f : 'a -> Ply<'b>) (v : Ply<'a>) : Ply<'b> =
 
 let toTask (v : Ply<'a>) : Task<'a> = Ply.TplPrimitives.runPlyAsTask v
 
+/// The value of a `Ply` that has already finished, or `ValueNone` if it still has to wait.
+///
+/// Worth the ceremony on hot paths because this builder allocates a continuation closure for every `let!`
+/// it reaches, whether or not the awaited thing had to wait -- and in the interpreter most of them don't:
+/// a cache hit, a pure builtin, a type that resolves without a store lookup. Asking first lets the caller
+/// skip the bind rather than pay for a suspension it never uses. Only pays off where the answer is usually
+/// yes; elsewhere it's just noise around a `let!`.
+let inline trySync (v : Ply<'a>) : 'a voption =
+  if v.IsCompletedSuccessfully then ValueSome v.Result else ValueNone
+
 
 // These functions are sequential versions of List/Map functions like map/iter/etc.
 // They await each list item before they process the next.  This ensures each

--- a/backend/src/Prelude/Telemetry.fs
+++ b/backend/src/Prelude/Telemetry.fs
@@ -39,9 +39,14 @@ let private writeLine (line : string) : unit =
       with _ ->
         ())
 
-/// Get monotonic timestamp in microseconds.
-let private nowUs () : int64 =
-  Stopwatch.GetTimestamp() * 1_000_000L / Stopwatch.Frequency
+/// Convert a Stopwatch-tick DELTA to microseconds.
+///
+/// Deltas, never absolute timestamps. `GetTimestamp() * 1_000_000L` overflows int64 once the tick count
+/// passes ~9.2e12, which on a 1 GHz-tick clocksource is **2.56 hours of uptime**. Past that the product
+/// wraps, and any span whose start and end straddle a wrap boundary records a wildly wrong duration,
+/// including large negative ones. A delta is small, so scaling it is safe: an hour-long span is 3.6e18
+/// after scaling, still inside int64.
+let private toUs (ticks : int64) : int64 = ticks * 1_000_000L / Stopwatch.Frequency
 
 /// Get wall-clock ISO 8601 timestamp.
 let private wallClock () : string =
@@ -61,6 +66,44 @@ let private formatCtx (ctx : (string * string) list) : string =
     |> String.concat ","
     |> fun s -> "{" + s + "}"
 
+/// Counters for things that happen many times per run, where a span each would cost more than the thing
+/// being measured and would drown the log. Read them at exit with `counterSnapshot`.
+///
+/// Here to answer one question: how many package items does a single command actually decode? "The CLI is
+/// slow because it loads its package closure" is only actionable once you know whether that closure is
+/// hundreds of items or thousands.
+let private counters =
+  System.Collections.Concurrent.ConcurrentDictionary<string, int64 ref>()
+
+let count (name : string) : unit =
+  if logPath <> "" then
+    let r = counters.GetOrAdd(name, (fun _ -> ref 0L))
+    System.Threading.Interlocked.Increment(r) |> ignore<int64>
+
+/// Accumulated microseconds for a repeated operation. Same reasoning as `count`: a span per call would cost
+/// more than the call. Pair them -- a count without a total can't tell you whether 96 loads are the problem.
+let private timers =
+  System.Collections.Concurrent.ConcurrentDictionary<string, int64 ref>()
+
+let addUs (name : string) (us : int64) : unit =
+  if logPath <> "" then
+    let r = timers.GetOrAdd(name, (fun _ -> ref 0L))
+    System.Threading.Interlocked.Add(r, us) |> ignore<int64>
+
+let timerSnapshot () : (string * int64) list =
+  timers
+  |> Seq.map (fun kv -> kv.Key, kv.Value.Value)
+  |> Seq.sortBy fst
+  |> Seq.toList
+
+
+let counterSnapshot () : (string * int64) list =
+  counters
+  |> Seq.map (fun kv -> kv.Key, kv.Value.Value)
+  |> Seq.sortBy fst
+  |> Seq.toList
+
+
 /// Log a point-in-time event (no duration).
 let event (name : string) (ctx : (string * string) list) : unit =
   if logPath <> "" then
@@ -71,13 +114,13 @@ let event (name : string) (ctx : (string * string) list) : unit =
 
 /// A span that measures elapsed time and logs on Dispose.
 type Span(name : string, ctx : (string * string) list) =
-  let startUs = nowUs ()
+  let startTicks = Stopwatch.GetTimestamp()
   let wall = wallClock ()
 
   interface System.IDisposable with
     member _.Dispose() =
       if logPath <> "" then
-        let elapsedUs = nowUs () - startUs
+        let elapsedUs = toUs (Stopwatch.GetTimestamp() - startTicks)
         let ms = elapsedUs / 1000L
         let ctxJson = formatCtx ctx
         writeLine

--- a/backend/tests/Tests/CliTraces.Tests.fs
+++ b/backend/tests/Tests/CliTraces.Tests.fs
@@ -712,6 +712,53 @@ let private testTracesRejectsFlagAsTraceId =
 // Re-enable trace recording for this suite — Tests.fs defaults to `Off`
 // so the rest of the test run doesn't waste cycles writing trace rows
 // we never read back.
+/// A trace that hits the event cap must still be a walkable tree.
+///
+/// Events are recorded when a call *completes*, so they arrive innermost-first and the entry point is
+/// last. A cap that simply stops at N therefore keeps the deepest calls and drops every one of their
+/// ancestors, and since the viewer renders by walking down from a root, it ends up with nothing to walk
+/// from: the whole trace renders as the truncation marker and nothing else. That is what this once did.
+///
+/// `addEvent` avoids it by reserving a slot for every frame still on the stack, which are exactly the
+/// ancestors of whatever is completing. The observable consequence, asserted here, is that a truncated
+/// trace still shows its root.
+let private testTracesTruncatedStillShowsRoot =
+  testSequenced
+  <| testTask "a truncated trace still renders its root" {
+    do!
+      withState (fun state ->
+        task {
+          // Set both here rather than relying on the suite's ordering, so the test still means something
+          // when run on its own.
+          LibDB.Tracing.TraceDetail.setForTesting LibDB.Tracing.TraceDetail.On
+          LibDB.Tracing.TraceLimits.useMaxEventsForTesting 20
+          try
+            let! _ = runCli state [ "traces"; "delete"; "--all"; "--yes" ]
+            // Comfortably over the cap of 20: each element costs a lambda call and an add.
+            let! evalOut =
+              runCli
+                state
+                [ "eval"
+                  "Stdlib.List.length (Stdlib.List.map (Stdlib.List.range 1 40) (fun x -> x + 1))" ]
+            Expect.stringContains evalOut "40" "the eval itself succeeded"
+            let! listJson = runCli state [ "traces"; "list"; "1"; "--json" ]
+            let tid = parseTraceID listJson
+            let! view = runCli state [ "traces"; "view"; tid ]
+
+            Expect.stringContains
+              view
+              "trace truncated"
+              "the marker says the trace was capped"
+            Expect.stringContains
+              view
+              "eval"
+              "the root is still there, so the tree can be walked down from it"
+          finally
+            LibDB.Tracing.TraceLimits.resetMaxEventsForTesting ()
+        })
+  }
+
+
 let tests =
   testSequenced
   <| testList
@@ -753,4 +800,5 @@ let tests =
       testTracesArgOrderingsWork
       testTracesArity1Catchalls
       testTracesRouteEmptyRejection
-      testTracesFindEscapesLikeWildcards ]
+      testTracesFindEscapesLikeWildcards
+      testTracesTruncatedStillShowsRoot ]

--- a/backend/tests/Tests/Interpreter.Tests.fs
+++ b/backend/tests/Tests/Interpreter.Tests.fs
@@ -780,6 +780,115 @@ module CapsGate =
   let tests = testList "CapsGate" [ denied; allowed ]
 
 
+/// The synchronous unifier must never disagree with the computation-expression one.
+///
+/// `TypeChecker.tryUnifySync` exists purely to answer the ordinary cases without allocating a
+/// continuation, so the only acceptable behaviours are "same answer as the slow path" or "declined, go
+/// ask the slow path". A `ValueSome` that disagrees would silently change what type-checks, which is the
+/// one way this optimisation could be dangerous rather than merely ineffective.
+module SyncUnify =
+  /// Every shape worth crossing: scalars against themselves and each other, containers at one and two
+  /// levels, tuples of matching and differing arity, `Unknown`, and type variables both unbound and
+  /// already bound.
+  let private expectations : List<RT.TypeReference> =
+    [ RT.TUnit
+      RT.TBool
+      RT.TInt64
+      RT.TInt
+      RT.TFloat
+      RT.TChar
+      RT.TString
+      RT.TUuid
+      RT.TVariable "a"
+      RT.TVariable "b"
+      RT.TList RT.TInt64
+      RT.TList RT.TString
+      RT.TList(RT.TVariable "a")
+      RT.TList(RT.TList RT.TInt64)
+      RT.TDict RT.TInt64
+      RT.TDict(RT.TVariable "a")
+      RT.TStream RT.TInt64
+      RT.TTuple(RT.TInt64, RT.TString, [])
+      RT.TTuple(RT.TInt64, RT.TString, [ RT.TBool ])
+      RT.TTuple(RT.TVariable "a", RT.TVariable "b", []) ]
+
+  let private actuals : List<RT.Dval> =
+    [ RT.DUnit
+      RT.DBool true
+      RT.DInt64 1L
+      LibExecution.Dval.int 1I
+      RT.DFloat 1.0
+      RT.DChar "c"
+      RT.DString "s"
+      RT.DUuid(System.Guid.NewGuid())
+      RT.DList(RT.ValueType.Known RT.KTInt64, [ RT.DInt64 1L ])
+      RT.DList(RT.ValueType.Known RT.KTString, [ RT.DString "s" ])
+      RT.DList(RT.ValueType.Unknown, [])
+      RT.DList(RT.ValueType.Known(RT.KTList(RT.ValueType.Known RT.KTInt64)), [])
+      RT.DDict(RT.ValueType.Known RT.KTInt64, Map.empty)
+      RT.DTuple(RT.DInt64 1L, RT.DString "s", [])
+      RT.DTuple(RT.DInt64 1L, RT.DString "s", [ RT.DBool true ]) ]
+
+  let private symbolTables : List<RT.TypeSymbolTable> =
+    [ Map.empty
+      Map.ofList [ "a", RT.ValueType.Known RT.KTInt64 ]
+      Map.ofList [ "a", RT.ValueType.Unknown ]
+      Map.ofList
+        [ "a", RT.ValueType.Known RT.KTString; "b", RT.ValueType.Known RT.KTInt64 ] ]
+
+  let agreesWithAsyncPath =
+    testTask "sync unifier agrees with the async one, or declines" {
+      let! (exeState : RT.ExecutionState) =
+        executionStateFor TestValues.pm false Map.empty
+      let mutable asyncAccepted = 0
+      let mutable answeredWhenAccepted = 0
+
+      for tst in symbolTables do
+        for expected in expectations do
+          for actual in actuals do
+            let sync = LibExecution.TypeChecker.tryUnifySync tst expected actual
+            let! async' =
+              LibExecution.TypeChecker.checkFnParam
+                exeState.types
+                (RT.FQFnName.fqBuiltin "test" 0)
+                tst
+                0
+                "p"
+                expected
+                actual
+              |> Ply.toTask
+
+            match async' with
+            | Ok asyncTst ->
+              asyncAccepted <- asyncAccepted + 1
+              match sync with
+              | ValueNone -> () // declining is always allowed; the caller falls back
+              | ValueSome syncTst ->
+                answeredWhenAccepted <- answeredWhenAccepted + 1
+                Expect.equal
+                  syncTst
+                  asyncTst
+                  $"same symbol table for {expected} vs {actual} under {tst}"
+            | Error _ ->
+              match sync with
+              | ValueNone -> () // correct: failures go to the slow path for error rendering
+              | ValueSome _ ->
+                Exception.raiseInternal
+                  "sync unifier accepted what the async path rejected"
+                  [ "expected", expected; "actual", actual; "tst", tst ]
+
+      // Most of the matrix is deliberately mismatched pairs, which decline correctly. The ratio that
+      // matters is how much of what the slow path *accepts* the fast path also answers: if that fell to
+      // nothing the optimisation would be silently inert and this test would still pass on agreement.
+      Expect.isGreaterThan
+        (answeredWhenAccepted * 10)
+        (asyncAccepted * 8)
+        $"fast path should answer most accepted unifications ({answeredWhenAccepted} of {asyncAccepted})"
+    }
+
+  let tests = testList "SyncUnify" [ agreesWithAsyncPath ]
+
+
 let tests =
   testList
     "Interpreter"
@@ -801,4 +910,5 @@ let tests =
       Infix.tests
       Lambdas.tests
       Fns.tests
-      Statement.tests ]
+      Statement.tests
+      SyncUnify.tests ]

--- a/backend/tests/Tests/Tests.fs
+++ b/backend/tests/Tests/Tests.fs
@@ -53,7 +53,7 @@ let main (args : string array) : int =
         // wall-clock to include in the default suite. Re-enable
         // once the capture moves to per-call buffers and
         // sequencing can come off.
-        // Tests.CliTraces.tests
+        Tests.CliTraces.tests
         Tests.Toplevels.tests
 
         // cross-cutting

--- a/packages/darklang/cli/core.dark
+++ b/packages/darklang/cli/core.dark
@@ -54,6 +54,15 @@ type AppState =
     /// Cached completion hint — skip recompute when prompt text unchanged
     cachedHintInput: String
     cachedHintValue: String
+    /// Completion results for the current *context* (command + completed args), which is what an expensive
+    /// completion actually depends on. Keyed by `Registry.completionContextKey`, so it survives every
+    /// keystroke of the word being typed rather than being thrown away on each character.
+    cachedCompletionKey: String
+    cachedCompletionItems: List<Completion.CompletionItem>
+    /// The last partial token filtered and what it produced, so the next keystroke can narrow from it
+    /// instead of re-filtering the whole context list. Empty partial means "no usable base".
+    cachedFilterPartial: String
+    cachedFilterItems: List<Completion.CompletionItem>
     /// Cached command list and option strings — built once at startup
     allCommandsCache: List<Registry.CommandHandler>
     commandOptionsCache: List<String>
@@ -63,8 +72,10 @@ type AppState =
 let locationStr (state: AppState) : String =
   Packages.formatLocation state.packageData.currentLocation
 
-let commandOptions () : List<String> =
-  let commands = Registry.allCommands ()
+/// Takes the command list rather than calling `Registry.allCommands ()` itself: `initState` needs both the
+/// list and the options, and building the list is 60 records of 6 fields including 3 fn refs each. Calling it
+/// twice per process start was pure duplicate work, on every invocation including `dark version`.
+let commandOptions (commands: List<Registry.CommandHandler>) : List<String> =
   let allNames = Stdlib.List.map commands (fun cmd -> cmd.name)
   let allAliases = Stdlib.List.fold commands [] (fun acc cmd -> Stdlib.List.append acc cmd.aliases)
   Stdlib.List.append allNames allAliases
@@ -126,6 +137,7 @@ let resolveStartingBranch () : Uuid =
 let initState () : AppState =
   let (accountID, accountName) = restoreSessionAccount ()
   let branchId = resolveStartingBranch ()
+  let commands = Registry.allCommands ()
   AppState
     { isExiting = false
       prompt = Prompt.initState ()
@@ -139,8 +151,12 @@ let initState () : AppState =
       nonInteractive = false
       cachedHintInput = ""
       cachedHintValue = ""
-      allCommandsCache = Registry.allCommands ()
-      commandOptionsCache = commandOptions ()
+      cachedCompletionKey = ""
+      cachedCompletionItems = []
+      cachedFilterPartial = ""
+      cachedFilterItems = []
+      allCommandsCache = commands
+      commandOptionsCache = commandOptions commands
       telemetryEnabled = (Builtin.environmentGet "DARK_TELEMETRY") == Stdlib.Option.Option.Some "1" }
 
 type Msg =

--- a/packages/darklang/cli/installation/helpers.dark
+++ b/packages/darklang/cli/installation/helpers.dark
@@ -6,7 +6,12 @@ let cliVersion () : String =
   let hash = Builtin.getBuildHash ()
   "alpha-" ++ hash
 
-let getVersionInfo () : String =
+/// The local version plus a check against the latest published release.
+///
+/// Costs a network round trip, which dominates the command. That's deliberate: both callers (`version`
+/// and `install-status`) exist to tell you whether your install is current, so the check is the point
+/// rather than a side errand. Worth knowing it's there before adding a third caller.
+let versionInfoWithUpdateCheck () : String =
   let currentVersion = cliVersion ()
   match GitHub.Releases.getLatestReleaseBuildHash () with
   | Ok latestVersion ->
@@ -16,3 +21,8 @@ let getVersionInfo () : String =
       "Darklang CLI " ++ currentVersion ++ " (latest: " ++ latestVersion ++ " - update available!)"
   | Error _ ->
     "Darklang CLI " ++ currentVersion ++ " (unable to check for updates)"
+
+/// CLEANUP alias for `versionInfoWithUpdateCheck`, kept because `install-status` and the old_notes
+/// command still call it. Fold them over and delete this.
+let getVersionInfo () : String =
+  versionInfoWithUpdateCheck ()

--- a/packages/darklang/cli/installation/version.dark
+++ b/packages/darklang/cli/installation/version.dark
@@ -2,8 +2,9 @@ module Darklang.Cli.Installation.Version
 
 
 let execute (state: AppState) (args: List<String>) : AppState =
-  let versionInfo = Helpers.getVersionInfo ()
-  Stdlib.printLine versionInfo
+  // Checks GitHub for a newer release, which dominates the command. Deliberate: knowing you're out of
+  // date is the point of the command, not a side errand.
+  Stdlib.printLine (Helpers.versionInfoWithUpdateCheck ())
 
   // Store-format coordinate — the on-disk data shape this Dark speaks vs what your local data is stamped at.
   // (This is what the boot-time migrator + sync's wire-version key off; see `dark update`.) It is NOT a product
@@ -41,7 +42,8 @@ let complete (_state: AppState) (_args: List<String>) : List<Completion.Completi
 let help (_state: AppState) : Unit =
   [
     "Usage: version"
-    "Display CLI version and installation information."
+    "Display CLI version and store-format information."
     ""
-    "Shows current version, installation mode, and location."
+    "Shows the current version, whether a newer release exists, and whether your data"
+    "matches this binary's store format."
   ] |> Stdlib.printLines

--- a/packages/darklang/cli/loop.dark
+++ b/packages/darklang/cli/loop.dark
@@ -338,13 +338,39 @@ let runInteractiveLoop (state: AppState) : Int =
 
     let tHint = if state.telemetryEnabled then Telemetry.now () else 0
     let hintCached = state.cachedHintInput == state.prompt.text
-    let hint =
-      if hintCached then
-        state.cachedHintValue
+    // Two tiers. The exact-text tier serves repaints (a resize, a redraw with no typing). The context tier
+    // serves *typing*: "Sta" typed one key at a time is three different prompt strings but one completion
+    // context, so the DB-hitting half runs once for the word instead of once per character.
+    let contextKey = Registry.completionContextKey location state.prompt.text
+    let contextCached = state.cachedCompletionKey == contextKey
+    let contextItems =
+      if contextCached then
+        state.cachedCompletionItems
       else
-        Registry.getCompletionHint state state.prompt.text
+        Registry.getCompletionsForContext state state.prompt.text
+    // The narrowing base is only meaningful within one context; a context change invalidates it.
+    let (prevPartial, prevItems) =
+      if contextCached then
+        (state.cachedFilterPartial, state.cachedFilterItems)
+      else
+        ("", [])
+    let (hint, filterPartial, filterItems) =
+      if hintCached then
+        // `prevPartial`/`prevItems`, not the raw cached fields: a context change has to invalidate the
+        // narrowing base here too, or a cache hit on the prompt text would carry the previous context's
+        // items forward. Unreachable today (changing location goes through a command, which also changes
+        // the prompt text), but it's one edit away from being live and the failure would be wrong
+        // completions rather than slow ones.
+        (state.cachedHintValue, prevPartial, prevItems)
+      else
+        Registry.getCompletionHintFromContext
+          state
+          state.prompt.text
+          contextItems
+          prevPartial
+          prevItems
     if state.telemetryEnabled then
-      Telemetry.logWithContext "completionHint" tHint [("inputLen", Stdlib.Int.toString (Stdlib.String.length state.prompt.text)); ("cached", Stdlib.Bool.toString hintCached)]
+      Telemetry.logWithContext "completionHint" tHint [("inputLen", Stdlib.Int.toString (Stdlib.String.length state.prompt.text)); ("cached", Stdlib.Bool.toString hintCached); ("contextCached", Stdlib.Bool.toString contextCached)]
 
     // Display current page
     let tRender = if state.telemetryEnabled then Telemetry.now () else 0
@@ -352,17 +378,23 @@ let runInteractiveLoop (state: AppState) : Int =
     let renderedState =
       match state.currentPage with
       | MainPrompt ->
+        let tView = if state.telemetryEnabled then Telemetry.now () else 0
         let promptView =
           withModeHint
             state
             (Prompt.Display.viewAtSize state.prompt location hint size)
+        if state.telemetryEnabled then
+          Telemetry.log "render.buildView" tView
         match state.promptTerminal with
         | Some terminal ->
+          let tPresent = if state.telemetryEnabled then Telemetry.now () else 0
           let nextTerminal =
             Tui.TerminalSession.presentAtSize
               terminal
               size
               promptView
+          if state.telemetryEnabled then
+            Telemetry.log "render.present" tPresent
           { state with
               promptTerminal =
                 Stdlib.Option.Option.Some nextTerminal }
@@ -433,6 +465,9 @@ let runInteractiveLoop (state: AppState) : Int =
       // start. `pageStack` depth changes on every push and pop, so it's the cheap signal for "we're somewhere
       // else now"; `isExiting` covers leaving altogether.
       let startingDepth = Stdlib.List.length renderedState.pageStack
+      // Sampled BEFORE the fold, which is the work being measured. Sampling after it and passing that as
+      // the start instead times the preceding log call, and reports ~0 ms no matter how slow the fold is.
+      let tUpdate = if renderedState.telemetryEnabled then Telemetry.now () else 0
       let newState =
         Stdlib.List.range 1 times
         |> Stdlib.List.fold renderedState (fun st _i ->
@@ -441,8 +476,7 @@ let runInteractiveLoop (state: AppState) : Int =
 
       if renderedState.telemetryEnabled then
         Telemetry.logWithContext "readKey" tReadKey [("char", keyInput.keyChar)]
-        let tUpdate = Telemetry.now ()
-        Telemetry.logWithContext "update" tUpdate [("char", keyInput.keyChar)]
+        Telemetry.logWithContext "update" tUpdate [("char", keyInput.keyChar); ("repeats", Stdlib.Int.toString times)]
         let loopWorkMs = (Telemetry.elapsedMs tLoopStart) - (Telemetry.elapsedMs tReadKey)
         let interpStats = Builtin.interpreterStatsGet ()
         Telemetry.logWithContext "loopWork" tLoopStart [("workMs", Stdlib.Int.toString loopWorkMs); ("interp", interpStats)]
@@ -451,4 +485,8 @@ let runInteractiveLoop (state: AppState) : Int =
         newState with
           cachedHintInput = renderedState.prompt.text
           cachedHintValue = hint
+          cachedCompletionKey = contextKey
+          cachedCompletionItems = contextItems
+          cachedFilterPartial = filterPartial
+          cachedFilterItems = filterItems
       }

--- a/packages/darklang/cli/packages/listing.dark
+++ b/packages/darklang/cli/packages/listing.dark
@@ -14,53 +14,39 @@ let listModule
     | Value v -> Stdlib.List.append [v.owner] v.modules
     | Function f -> Stdlib.List.append [f.owner] f.modules
 
-  // Search for contents at this location, then apply deprecation visibility.
-  let rawResults = Query.allDirectDescendants branchId modulePath
+  // Names and hashes only: a listing shows a name and a deprecation mark, and materializing each item's
+  // full definition to read those was most of the command's cost once startup got cheap.
+  let (allSubmodules, rawTypes, rawValues, rawFns) =
+    Query.allDirectDescendantNamesAndHashes branchId modulePath
   let depSets = Query.loadDeprecationSets branchId
-  let results = Query.filterDeprecated rawResults depSets includeDeprecated
+  let types = Query.filterDeprecatedPairs rawTypes depSets includeDeprecated
+  let values = Query.filterDeprecatedPairs rawValues depSets includeDeprecated
+  let fns = Query.filterDeprecatedPairs rawFns depSets includeDeprecated
 
   // Display module path
   let locationStr = Packages.formatLocation location
   Stdlib.printLine $"Contents of {locationStr}:"
   Stdlib.printLine ""
 
-  // Display submodules
-  let currentPathLength = Stdlib.List.length modulePath
-  let directSubmodules = Query.getDirectSubmodules results currentPathLength
-
   // Display in order: modules, types, values, functions
-  if Stdlib.Bool.not (Stdlib.List.isEmpty directSubmodules) then
+  if Stdlib.Bool.not (Stdlib.List.isEmpty allSubmodules) then
     Stdlib.printLine (Display.getSectionHeader "module")
-    directSubmodules
+    allSubmodules
     |> Stdlib.List.iter (fun name -> Stdlib.printLine $"  {name}/")
     Stdlib.printLine ""
 
-  // Display types
-  if Stdlib.Bool.not (Stdlib.List.isEmpty results.types) then
-    Stdlib.printLine (Display.getSectionHeader "type")
-    results.types
-    |> Stdlib.List.iter (fun t ->
-      let mark = Query.deprecationMarker depSets t.entity.hash
-      Stdlib.printLine $"  {t.location.name}{mark}")
-    Stdlib.printLine ""
+  let printSection (header: String) (items: List<(String * LanguageTools.ProgramTypes.Hash)>) : Unit =
+    if Stdlib.Bool.not (Stdlib.List.isEmpty items) then
+      Stdlib.printLine (Display.getSectionHeader header)
+      items
+      |> Stdlib.List.iter (fun (name, hash) ->
+        let mark = Query.deprecationMarker depSets hash
+        Stdlib.printLine $"  {name}{mark}")
+      Stdlib.printLine ""
 
-  // Display values
-  if Stdlib.Bool.not (Stdlib.List.isEmpty results.values) then
-    Stdlib.printLine (Display.getSectionHeader "value")
-    results.values
-    |> Stdlib.List.iter (fun v ->
-      let mark = Query.deprecationMarker depSets v.entity.hash
-      Stdlib.printLine $"  {v.location.name}{mark}")
-    Stdlib.printLine ""
-
-  // Display functions
-  if Stdlib.Bool.not (Stdlib.List.isEmpty results.fns) then
-    Stdlib.printLine (Display.getSectionHeader "function")
-    results.fns
-    |> Stdlib.List.iter (fun fn ->
-      let mark = Query.deprecationMarker depSets fn.entity.hash
-      Stdlib.printLine $"  {fn.location.name}{mark}")
-    Stdlib.printLine ""
+  printSection "type" types
+  printSection "value" values
+  printSection "function" fns
 
 
 let execute (state: AppState) (args: List<String>) : AppState =

--- a/packages/darklang/cli/packages/query.dark
+++ b/packages/darklang/cli/packages/query.dark
@@ -16,6 +16,61 @@ let allDirectDescendants
   LanguageTools.PackageManager.Search.search branchId query
 
 
+/// Names of everything directly under `modulePath`, grouped by kind:
+/// (direct submodules, types, values, fns). Submodules are already reduced and sorted.
+///
+/// This is what completion wants -- `allDirectDescendants` materializes every matched item's full
+/// definition to hand back names.
+let allDirectDescendantNames
+  (branchId: Uuid)
+  (modulePath: List<String>)
+  : (List<String> * List<String> * List<String> * List<String>) =
+  let query =
+    LanguageTools.ProgramTypes.Search.SearchQuery
+      { currentModule = modulePath
+        text = ""
+        searchDepth = LanguageTools.ProgramTypes.Search.SearchDepth.OnlyDirectDescendants
+        entityTypes = []
+        exactMatch = false }
+
+  LanguageTools.PackageManager.Search.searchNames branchId query
+
+
+/// Names and hashes of everything directly under `modulePath`:
+/// (direct submodules, types, values, fns). Submodules are already reduced and sorted.
+///
+/// For listings, which need the hash to render the deprecation mark but never the definition.
+let allDirectDescendantNamesAndHashes
+  (branchId: Uuid)
+  (modulePath: List<String>)
+  : (List<String> *
+     List<(String * LanguageTools.ProgramTypes.Hash)> *
+     List<(String * LanguageTools.ProgramTypes.Hash)> *
+     List<(String * LanguageTools.ProgramTypes.Hash)>) =
+  let query =
+    LanguageTools.ProgramTypes.Search.SearchQuery
+      { currentModule = modulePath
+        text = ""
+        searchDepth = LanguageTools.ProgramTypes.Search.SearchDepth.OnlyDirectDescendants
+        entityTypes = []
+        exactMatch = false }
+
+  LanguageTools.PackageManager.Search.searchNamesAndHashes branchId query
+
+
+/// Drop items that are deprecated-and-hidden, for a (name, hash) listing.
+let filterDeprecatedPairs
+  (items: List<(String * LanguageTools.ProgramTypes.Hash)>)
+  (sets: DeprecationSets)
+  (includeDeprecated: Bool)
+  : List<(String * LanguageTools.ProgramTypes.Hash)> =
+  if includeDeprecated then
+    items
+  else
+    items
+    |> Stdlib.List.filter (fun (_name, hash) -> Stdlib.Bool.not (isHidden sets hash))
+
+
 /// Search for a specific entity by name in a given module path (exact match)
 let searchExactMatch
   (branchId: Uuid)

--- a/packages/darklang/cli/packages/traversal.dark
+++ b/packages/darklang/cli/packages/traversal.dark
@@ -175,26 +175,26 @@ let getAvailableItems
   (prefixText: String)
   : List<Cli.Completion.CompletionItem> =
   let currentPath = getCurrentModulePath location
-  // Get all available entities in this module
-  let allResults = Query.allDirectDescendants branchId currentPath
-
-  let currentPathLength = Stdlib.List.length currentPath
+  // Names only: completion shows a name and an icon, and materializing each item's full definition to
+  // read `.location.name` was the single worst hitch while typing (115 ms at the store root).
+  let (submoduleNames, typeNames, valueNames, fnNames) =
+    Query.allDirectDescendantNames branchId currentPath
 
   let moduleItems =
-    (Query.getDirectSubmodules allResults currentPathLength)
+    submoduleNames
     |> Stdlib.List.map (fun name -> Cli.Completion.withIcon EntityType.Module name)
 
   let typeItems =
-    allResults.types
-    |> Stdlib.List.map (fun item -> Cli.Completion.withIcon EntityType.Type item.location.name)
+    typeNames
+    |> Stdlib.List.map (fun name -> Cli.Completion.withIcon EntityType.Type name)
 
   let fnItems =
-    allResults.fns
-    |> Stdlib.List.map (fun item -> Cli.Completion.withIcon EntityType.Function item.location.name)
+    fnNames
+    |> Stdlib.List.map (fun name -> Cli.Completion.withIcon EntityType.Function name)
 
   let valueItems =
-    allResults.values
-    |> Stdlib.List.map (fun item -> Cli.Completion.withIcon EntityType.Value item.location.name)
+    valueNames
+    |> Stdlib.List.map (fun name -> Cli.Completion.withIcon EntityType.Value name)
 
   let flatItems = Stdlib.List.flatten [moduleItems; typeItems; fnItems; valueItems]
   let allItems = flatItems |> Stdlib.List.sortBy (fun item -> item.value)

--- a/packages/darklang/cli/packages/tree.dark
+++ b/packages/darklang/cli/packages/tree.dark
@@ -185,21 +185,15 @@ let displayTree
       | Value v -> Stdlib.List.append [v.owner] v.modules
       | Function f -> Stdlib.List.append [f.owner] f.modules
 
-    // Get all entities, then apply deprecation visibility.
-    let rawResults = Query.allDirectDescendants branchId modulePath
-    let results = Query.filterDeprecated rawResults depSets includeDeprecated
-
-    // Get submodules
-    let currentPathLength = Stdlib.List.length modulePath
-    let submoduleNames = Query.getDirectSubmodules results currentPathLength
+    // Names and hashes only. This runs once per module *per level* of the walk, so materializing every
+    // item's full definition to read its name compounded: `tree Darklang.Stdlib` was 547 ms.
+    let (submoduleNames, rawTypes, rawValues, rawFns) =
+      Query.allDirectDescendantNamesAndHashes branchId modulePath
 
     // Entity names paired with their hash, so we can mark deprecated rows.
-    let fnEntries =
-      results.fns |> Stdlib.List.map (fun f -> (f.location.name, f.entity.hash))
-    let typeEntries =
-      results.types |> Stdlib.List.map (fun t -> (t.location.name, t.entity.hash))
-    let valueEntries =
-      results.values |> Stdlib.List.map (fun v -> (v.location.name, v.entity.hash))
+    let fnEntries = Query.filterDeprecatedPairs rawFns depSets includeDeprecated
+    let typeEntries = Query.filterDeprecatedPairs rawTypes depSets includeDeprecated
+    let valueEntries = Query.filterDeprecatedPairs rawValues depSets includeDeprecated
 
     // Combine all entities with their types in proper order: modules, types, values, functions.
     // Modules have no hash, use an empty-string placeholder.

--- a/packages/darklang/cli/packages/view.dark
+++ b/packages/darklang/cli/packages/view.dark
@@ -73,11 +73,13 @@ let sourceRows (source: String) : List<String> =
 let entityRows (branchId: Uuid) (location: PackageLocation) : List<String> =
   match location with
   | Module path ->
-    let results = Query.allDirectDescendants branchId path
+    // Names only. This listing prints each item's name and nothing else, so materializing every matched
+    // item's full definition to read `.location.name` is work thrown away. Submodules come back already
+    // reduced to the direct children of `path`.
+    let (directSubmodules, typeNames, valueNames, fnNames) =
+      Query.allDirectDescendantNames branchId path
 
     let locationStr = Packages.formatLocation location
-    let currentPathLength = Stdlib.List.length path
-    let directSubmodules = Query.getDirectSubmodules results currentPathLength
 
     let submoduleRows =
       if Stdlib.List.isEmpty directSubmodules then
@@ -91,35 +93,32 @@ let entityRows (branchId: Uuid) (location: PackageLocation) : List<String> =
         ]
 
     let typeRows =
-      if Stdlib.List.isEmpty results.types then
+      if Stdlib.List.isEmpty typeNames then
         []
       else
         Stdlib.List.flatten [
           [ Display.getSectionHeader "type" ]
-          results.types
-          |> Stdlib.List.map (fun item -> $"  {item.location.name}")
+          typeNames |> Stdlib.List.map (fun name -> $"  {name}")
           [ "" ]
         ]
 
     let valueRows =
-      if Stdlib.List.isEmpty results.values then
+      if Stdlib.List.isEmpty valueNames then
         []
       else
         Stdlib.List.flatten [
           [ Display.getSectionHeader "value" ]
-          results.values
-          |> Stdlib.List.map (fun item -> $"  {item.location.name}")
+          valueNames |> Stdlib.List.map (fun name -> $"  {name}")
           [ "" ]
         ]
 
     let functionRows =
-      if Stdlib.List.isEmpty results.fns then
+      if Stdlib.List.isEmpty fnNames then
         []
       else
         Stdlib.List.flatten [
           [ Display.getSectionHeader "function" ]
-          results.fns
-          |> Stdlib.List.map (fun item -> $"  {item.location.name}")
+          fnNames |> Stdlib.List.map (fun name -> $"  {name}")
           [ "" ]
         ]
 
@@ -217,48 +216,240 @@ let viewEntity (branchId: Uuid) (location: PackageLocation) : Unit =
   entityRows branchId location |> Stdlib.printLines
 
 
-// VIEW command - view modules, functions, types, or constants
+/// What `view` shows. Source is the default and the only one that works for every kind of item; the
+/// other two are compiler views of a function.
+type ViewMode =
+  | Source
+  /// The ProgramTypes tree the parser built, before compilation.
+  | Ast
+  /// The register-machine instructions the function actually runs.
+  | Instructions
+
+
+let modeName (mode: ViewMode) : String =
+  match mode with
+  | Source -> "source"
+  | Ast -> "--ast"
+  | Instructions -> "--instructions"
+
+
+/// Flags are accepted in any position, so `view --ast List.last` and `view List.last --ast` both work.
+/// Returns the path (if given) and the mode, or an error naming the bad flag.
+let parseArgs
+  (args: List<String>)
+  : Stdlib.Result.Result<(Stdlib.Option.Option<String> * ViewMode), String> =
+  let isFlag (a: String) : Bool = Stdlib.String.startsWith a "-"
+  let flags = Stdlib.List.filter args (fun a -> isFlag a)
+  let paths = Stdlib.List.filter args (fun a -> Stdlib.Bool.not (isFlag a))
+
+  let modeResult =
+    Stdlib.List.fold flags (Stdlib.Result.Result.Ok ViewMode.Source) (fun acc flag ->
+      match acc with
+      | Error e -> Stdlib.Result.Result.Error e
+      | Ok _ ->
+        match flag with
+        | "--ast" -> Stdlib.Result.Result.Ok ViewMode.Ast
+        | "--instructions" -> Stdlib.Result.Result.Ok ViewMode.Instructions
+        | "--instrs" -> Stdlib.Result.Result.Ok ViewMode.Instructions
+        | other -> Stdlib.Result.Result.Error $"unknown option `{other}`")
+
+  match modeResult with
+  | Error e -> Stdlib.Result.Result.Error e
+  | Ok mode ->
+    match paths with
+    | [] -> Stdlib.Result.Result.Ok((Stdlib.Option.Option.None, mode))
+    | [ p ] -> Stdlib.Result.Result.Ok((Stdlib.Option.Option.Some p, mode))
+    | _ -> Stdlib.Result.Result.Error "expected at most one path"
+
+
+/// The function at a location, if the location names one. `--ast` and `--instructions` are function-only
+/// views, and saying which kind of thing you actually pointed at beats a bare "not found".
+let fnAt
+  (branchId: Uuid)
+  (location: PackageLocation)
+  : Stdlib.Result.Result<LanguageTools.ProgramTypes.PackageFn.PackageFn, String> =
+  match location with
+  | Function name ->
+    let modulePath = Stdlib.List.append [ name.owner ] name.modules
+    let results = Query.searchExactMatch branchId modulePath name.name
+
+    match results.fns with
+    | item :: _ -> Stdlib.Result.Result.Ok item.entity
+    | [] ->
+      let loc = Packages.formatLocation location
+      Stdlib.Result.Result.Error $"Function '{loc}' not found."
+  | Module _ ->
+    Stdlib.Result.Result.Error "that's a module; this view is for functions"
+  | Type _ -> Stdlib.Result.Result.Error "that's a type; this view is for functions"
+  | Value _ ->
+    Stdlib.Result.Result.Error "that's a value; this view is for functions"
+
+
+/// The ProgramTypes tree, indented by depth. Node kinds are coloured and payloads dimmed, so the shape
+/// reads at a glance and the detail is there when you look for it.
+let astRows
+  (branchId: Uuid)
+  (name: String)
+  (fn: LanguageTools.ProgramTypes.PackageFn.PackageFn)
+  : List<String> =
+  let ctx = PrettyPrinter.ProgramTypes.Context.forBranch branchId
+
+  PrettyPrinter.ProgramTypes.Ast.packageFn ctx name fn
+  |> Stdlib.List.map (fun l ->
+    // The signature is depth 0 and the body starts at depth 0 too, so the tree reads as a block under
+    // the signature rather than being pushed a level in by scaffolding that isn't there any more.
+    let indent = Stdlib.String.repeat "  " l.depth
+    let label = Colors.keyword l.label
+
+    if l.detail == "" then
+      $"{indent}{label}"
+    else
+      $"{indent}{label} {Colors.dimText l.detail}")
+
+
+/// The disassembly, plus any lambdas defined inside it. Lambdas get their own section rather than being
+/// inlined, because `CreateLambda` is otherwise a dead end in the listing.
+let instructionRows
+  (branchId: Uuid)
+  (instrs: LanguageTools.RuntimeTypes.Instructions)
+  : List<String> =
+  let renderBody (is: LanguageTools.RuntimeTypes.Instructions) : List<String> =
+    let opcodeWidth =
+      is.instructions
+      |> Stdlib.List.map (fun i ->
+        Stdlib.String.length (PrettyPrinter.RuntimeTypes.Instructions.opcode i))
+      |> Stdlib.List.fold 0 (fun acc n -> if n > acc then n else acc)
+
+    is.instructions
+      |> Stdlib.List.indexedMap (fun index i ->
+        let idx =
+          Colors.dimText
+            (PrettyPrinter.RuntimeTypes.Instructions.padFrom 4 (Stdlib.Int.toString index))
+        // Width of the widest opcode actually in this body, not a fixed 22. Most functions use short
+        // opcodes, and a fixed column leaves a corridor of blanks between them and their operands.
+        let op =
+          Colors.command
+            (PrettyPrinter.RuntimeTypes.Instructions.padTo
+              opcodeWidth
+              (PrettyPrinter.RuntimeTypes.Instructions.opcode i))
+        let ops = PrettyPrinter.RuntimeTypes.Instructions.operands branchId index i
+        $"  {idx}  {op} {ops}")
+
+  let lambdaSections =
+    PrettyPrinter.RuntimeTypes.Instructions.lambdas instrs
+    |> Stdlib.List.map (fun l ->
+      let header =
+        PrettyPrinter.RuntimeTypes.Instructions.header l.instructions
+      Stdlib.List.flatten
+        [ [ ""
+            Colors.hint $"lambda#{Stdlib.UInt64.toString l.exprId}"
+            Colors.dimText $"  {header}"
+            "" ]
+          renderBody l.instructions ])
+    |> Stdlib.List.flatten
+
+  Stdlib.List.flatten
+    [ [ Colors.dimText
+          $"  {PrettyPrinter.RuntimeTypes.Instructions.header instrs}"
+        "" ]
+      renderBody instrs
+      lambdaSections ]
+
+
+/// Render one of the compiler views of the function at <param location>.
+let viewCompiled
+  (branchId: Uuid)
+  (location: PackageLocation)
+  (mode: ViewMode)
+  : Unit =
+  match fnAt branchId location with
+  | Error e -> Stdlib.printLine (Colors.error $"Cannot {modeName mode}: {e}")
+  | Ok fn ->
+    let title = Colors.boldText (Packages.formatLocation location)
+    Stdlib.printLine title
+    Stdlib.printLine ""
+
+    match mode with
+    | Ast ->
+      let shortName =
+        match location with
+        | Function name -> name.name
+        | _ -> ""
+      astRows branchId shortName fn |> Stdlib.printLines
+    | Instructions ->
+      match Builtin.pmFnInstructions fn.hash with
+      | Some instrs -> instructionRows branchId instrs |> Stdlib.printLines
+      | None ->
+        Stdlib.printLine
+          (Colors.error "No compiled instructions stored for this function.")
+    | Source -> viewEntity branchId location
+
+
+// VIEW command - view modules, functions, types, or constants, as source, AST, or instructions
 let execute (state: AppState) (args: List<String>) : AppState =
   let branchId = state.currentBranchId
-  match args with
-  | [] ->
-    // No args - view current location
-    viewEntity branchId state.packageData.currentLocation
+
+  match parseArgs args with
+  | Error e ->
+    Stdlib.printLine (Colors.error $"Cannot view: {e}")
+    help state
     state
-  | [pathArg] ->
-    // Navigate to the path and view
-    match Traversal.traverse branchId state.packageData.currentLocation pathArg with
+  | Ok parsed ->
+    let (pathArg, mode) = parsed
+
+    let locationResult =
+      match pathArg with
+      | None -> Stdlib.Result.Result.Ok state.packageData.currentLocation
+      | Some p -> Traversal.traverse branchId state.packageData.currentLocation p
+
+    match locationResult with
     | Error errorMsg ->
       Stdlib.printLine (Colors.error $"Cannot view: {errorMsg}")
       state
-    | Ok newLocation ->
-      viewEntity branchId newLocation
+    | Ok location ->
+      match mode with
+      | Source -> viewEntity branchId location
+      | _ -> viewCompiled branchId location mode
+
       state
-  | _ ->
-    help state
-    state
 
 let complete (state: AppState) (args: List<String>) : List<Completion.CompletionItem> =
   let branchId = state.currentBranchId
-  match args with
-  | [] ->
+  // Complete the path as before, and offer the view flags once something is typed. Flags are filtered
+  // out of the path completion so `view List.last --a` completes the flag, not a package path.
+  let flagCompletions (partial: String) : List<Completion.CompletionItem> =
+    [ "--ast"; "--instructions" ]
+    |> Stdlib.List.filter (fun name -> Stdlib.String.startsWith name partial)
+    |> Stdlib.List.map (fun name -> Completion.simple name)
+
+  match Stdlib.List.last args with
+  | Some lastArg ->
+    if Stdlib.String.startsWith lastArg "-" then
+      flagCompletions lastArg
+    else
+      Traversal.completePartialPath branchId state.packageData.currentLocation lastArg
+  | None ->
     Traversal.completePartialPath branchId state.packageData.currentLocation ""
-  | [partialPath] ->
-    Traversal.completePartialPath branchId state.packageData.currentLocation partialPath
-  | _ -> []
 
 
 let help (_state: AppState) : Unit =
   [
-    "Usage: view [path]"
+    "Usage: view [path] [--ast | --instructions]"
     "View detailed information about functions, types, values, or modules."
     ""
     "With path: View the specified entity with syntax highlighting."
     "Without path: View current location."
     ""
+    "Options (functions only):"
+    "  --ast             The ProgramTypes tree the parser built, before compilation."
+    "  --instructions    The register-machine instructions the function actually runs."
+    "                    Aliased as --instrs."
+    ""
     "Examples:"
-    "  view                    - View current location"
-    "  view List.head          - View the List.head function"
-    "  view Option             - View the Option type"
-    "  view Stdlib.List        - View contents of Stdlib.List module"
+    "  view                            - View current location"
+    "  view List.head                  - View the List.head function"
+    "  view Option                     - View the Option type"
+    "  view Stdlib.List                - View contents of Stdlib.List module"
+    "  view List.last --ast            - View List.last as a syntax tree"
+    "  view List.map --instructions    - Disassemble List.map"
   ] |> Stdlib.printLines

--- a/packages/darklang/cli/registry.dark
+++ b/packages/darklang/cli/registry.dark
@@ -247,6 +247,47 @@ module Registry =
     groupsText ++ "\n\n" ++ footer
 
 
+  /// Identifies what a completion request depends on, *ignoring* the partial token the user is mid-way
+  /// through typing. Typing "Sta" one key at a time produces three different prompt strings but the same
+  /// context: command `nav`, no completed args. That's the point; see `getCompletionsForContext`.
+  /// `loc` is the caller's already-formatted location string. It's part of the key because `nav`/`ls`
+  /// complete against wherever you are, so the same command with the same completed args means something
+  /// different after a `cd`. Taken as a parameter rather than recomputed, because the loop already has it.
+  let completionContextKey (loc: String) (input: String) : String =
+    let parsed = Completion.parseInput input
+    if parsed.isCompletingCommand then
+      // Command-name completion reads `state.commandOptionsCache`, which is already built once at startup,
+      // so there's nothing expensive to key on. One constant bucket.
+      "cmd\u0000" ++ loc
+    else
+      let completedArgs =
+        match Stdlib.List.last parsed.args with
+        | Some _ -> Stdlib.List.dropLast parsed.args
+        | None -> []
+      // \u0000 can't occur in a typed token, so joining is unambiguous.
+      Stdlib.String.join
+        (Stdlib.List.append [ loc; parsed.commandName ] completedArgs)
+        "\u0000"
+
+  /// The half of completion that depends only on the command and its *completed* arguments. For `nav`/`ls`
+  /// that means a package DB query, which is far too expensive to repeat per keystroke -- and a cache keyed
+  /// on the whole prompt text misses on every character of a word. The partial token filters this result
+  /// afterwards, and filtering a list is cheap.
+  let getCompletionsForContext
+    (state: AppState)
+    (input: String)
+    : List<Completion.CompletionItem> =
+    let parsed = Completion.parseInput input
+    if parsed.isCompletingCommand then
+      state.commandOptionsCache |> Stdlib.List.map Completion.simple
+    else
+      let handler = findCommandIn state.allCommandsCache parsed.commandName
+      let completedArgs =
+        match Stdlib.List.last parsed.args with
+        | Some _ -> Stdlib.List.dropLast parsed.args
+        | None -> []
+      handler.complete state completedArgs
+
   let getCompletions (state: AppState) (input: String) : List<Completion.CompletionItem> =
     let parsed = Completion.parseInput input
 
@@ -296,8 +337,10 @@ module Registry =
         | _ :: _ -> filtered
         | [] -> completeFunc state parsed.args
 
-  let getCompletionHint (state: AppState) (input: String) : String =
-    let completions = getCompletions state input
+  let hintFromCompletions
+    (input: String)
+    (completions: List<Completion.CompletionItem>)
+    : String =
     let parsed = Completion.parseInput input
 
     let partial =
@@ -310,6 +353,76 @@ module Registry =
 
     let completionValues = completions |> Stdlib.List.map (fun item -> item.value)
     Completion.getHintFromCompletions partial completionValues
+
+  /// The hint, given an already-computed context result. This is what the interactive loop calls on each
+  /// keystroke, passing its cached context.
+  /// Returns `(hint, partialUsed, filteredItems)`. The caller keeps the last two so the *next* keystroke can
+  /// narrow from them instead of re-filtering the whole context list: typing `c` then `cd` filters the ~8
+  /// survivors rather than all ~120 command names. Prefix filtering is transitive, so narrowing from the
+  /// previous result gives exactly the same answer as filtering the full list.
+  ///
+  /// Parses `input` once and does both halves rather than composing a context lookup with
+  /// `hintFromCompletions`, which each re-parse; this runs on every keystroke.
+  let getCompletionHintFromContext
+    (state: AppState)
+    (input: String)
+    (contextCompletions: List<Completion.CompletionItem>)
+    (prevPartial: String)
+    (prevItems: List<Completion.CompletionItem>)
+    : (String * String * List<Completion.CompletionItem>) =
+    let parsed = Completion.parseInput input
+
+    let (filterPartial, hintPartial) =
+      if parsed.isCompletingCommand then
+        (Completion.getPartialCompletion parsed, parsed.commandName)
+      else
+        let lastArg =
+          match Stdlib.List.last parsed.args with
+          | Some lastArg -> lastArg
+          | None -> ""
+        (lastArg, lastArg)
+
+    let hintOf (items: List<Completion.CompletionItem>) : String =
+      Completion.getHintFromCompletions
+        hintPartial
+        (items |> Stdlib.List.map (fun item -> item.value))
+
+    if Stdlib.String.isEmpty filterPartial then
+      (hintOf contextCompletions, "", contextCompletions)
+    else
+      // Narrow from the previous result only when this partial extends it and it was non-empty. An empty
+      // previous result is unusable as a base, and so is a fallback result (see below), which is why the
+      // fallback reports "" back to the caller.
+      let canNarrow =
+        (Stdlib.Bool.not (Stdlib.String.isEmpty prevPartial))
+        && (Stdlib.String.startsWith filterPartial prevPartial)
+        && (match prevItems with
+            | _ :: _ -> true
+            | [] -> false)
+
+      let narrowBase = if canNarrow then prevItems else contextCompletions
+
+      let filtered =
+        narrowBase
+        |> Stdlib.List.filter (fun item ->
+          Stdlib.String.startsWith item.value filterPartial)
+
+      match filtered with
+      | _ :: _ -> (hintOf filtered, filterPartial, filtered)
+      | [] ->
+        // Centralized filtering found nothing, so re-ask the handler with the full args. This supports
+        // commands with smart matching (path traversal), genuinely depends on the partial, and its result
+        // is not a prefix-filtered subset -- so it must not become a narrowing base.
+        let fallback =
+          if parsed.isCompletingCommand then
+            []
+          else
+            let handler = findCommandIn state.allCommandsCache parsed.commandName
+            handler.complete state parsed.args
+        (hintOf fallback, "", [])
+
+  let getCompletionHint (state: AppState) (input: String) : String =
+    hintFromCompletions input (getCompletions state input)
 
 
 module Commands =

--- a/packages/darklang/cli/tests/tests-runner.dark
+++ b/packages/darklang/cli/tests/tests-runner.dark
@@ -16,6 +16,17 @@ let allTests (): List<String * TestFunction> =
     ("Eval String Length", fun () -> testEvalStringLength ())
     ("Eval List Length", fun () -> testEvalListLength ())
 
+    ("View AST", fun () -> testViewAst ())
+    ("View Instructions", fun () -> testViewInstructions ())
+    ("View Instructions Lambdas", fun () -> testViewInstructionsShowsLambdas ())
+    ("View Compiler Views Reject Non-Fns", fun () -> testViewCompilerViewsRejectNonFunctions ())
+    ("View Flag Before Path", fun () -> testViewFlagBeforePath ())
+    ("View Unknown Flag", fun () -> testViewUnknownFlag ())
+
+    ("Native List Edge Cases", fun () -> testNativeListEdgeCases ())
+    ("GetAt None Is Still None", fun () -> testGetAtNoneIsStillNone ())
+    ("Explicit Type Args", fun () -> testExplicitTypeArgs ())
+
     ("List Functions", fun () -> testListFunctions ())
     ("View Function", fun () -> testViewFunction ())
     ("List Types", fun () -> testListTypes ())

--- a/packages/darklang/cli/tests/tests.dark
+++ b/packages/darklang/cli/tests/tests.dark
@@ -167,3 +167,160 @@ let testEvalStringExpression (): TestResult =
     TestResult.Pass
   else
     TestResult.Fail $"Expected 'helloworld', got '{output}'"
+
+
+// ---------------------------------------------------------------- compiler views
+// `view --ast` and `view --instructions`. These assert on structure rather than exact text, because
+// register numbers and instruction counts change whenever the compiler does, and a test that pins them
+// fails on every unrelated codegen improvement.
+
+let testViewAst (): TestResult =
+  let output = runWithCommand ["view"; "Stdlib.List.last"; "--ast"]
+
+  // A signature line, then the body tree with its node kinds. `Match`/`Arg` are what `last` is made of.
+  // Label and detail are coloured separately, so a row's text isn't contiguous in the output. Match on
+  // the pieces rather than on a whole rendered line.
+  if Stdlib.String.contains output "last<'a> (list: List<'a>) ->"
+    && Stdlib.String.contains output "Match"
+    && Stdlib.String.contains output "on Arg #0, 2 cases"
+    && Stdlib.String.contains output "head :: tail"
+  then
+    TestResult.Pass
+  else
+    TestResult.Fail $"Expected an AST tree with signature rows and node kinds, got: {output}"
+
+
+let testViewInstructions (): TestResult =
+  let output = runWithCommand ["view"; "Stdlib.List.push"; "--instructions"]
+
+  // `push` is a thin wrapper over a builtin, so it must load the builtin and apply it.
+  if Stdlib.String.contains output "instructions"
+    && Stdlib.String.contains output "registers"
+    && Stdlib.String.contains output "LoadVal"
+    && Stdlib.String.contains output "Apply"
+    && Stdlib.String.contains output "listPush"
+  then
+    TestResult.Pass
+  else
+    TestResult.Fail $"Expected an instruction listing for List.push, got: {output}"
+
+
+let testViewInstructionsShowsLambdas (): TestResult =
+  // `filter` is `fold` plus a lambda, and a listing that stopped at `CreateLambda` would be a dead end.
+  let output = runWithCommand ["view"; "Stdlib.List.filter"; "--instructions"]
+
+  if Stdlib.String.contains output "CreateLambda"
+    && Stdlib.String.contains output "lambda#"
+    && Stdlib.String.contains output "JumpByIfFalse"
+  then
+    TestResult.Pass
+  else
+    TestResult.Fail $"Expected the lambda's own listing under filter's, got: {output}"
+
+
+let testViewCompilerViewsRejectNonFunctions (): TestResult =
+  // Both views are function-only, and saying which kind of thing you pointed at beats "not found".
+  let typeOutput = runWithCommand ["view"; "Stdlib.Option.Option"; "--ast"]
+  let moduleOutput = runWithCommand ["view"; "Stdlib.List"; "--instructions"]
+
+  if Stdlib.String.contains typeOutput "type"
+    && Stdlib.String.contains moduleOutput "module"
+  then
+    TestResult.Pass
+  else
+    TestResult.Fail
+      $"Expected kind-specific refusals, got type: {typeOutput}, module: {moduleOutput}"
+
+
+let testViewFlagBeforePath (): TestResult =
+  // Flags are position-independent; this is the ordering people actually type.
+  let output = runWithCommand ["view"; "--ast"; "Stdlib.List.push"]
+
+  if Stdlib.String.contains output "push" && Stdlib.String.contains output "->" then
+    TestResult.Pass
+  else
+    TestResult.Fail $"Expected --ast to work before the path, got: {output}"
+
+
+let testViewUnknownFlag (): TestResult =
+  let output = runWithCommand ["view"; "Stdlib.List.push"; "--nope"]
+
+  if Stdlib.String.contains output "--nope" && Stdlib.String.contains output "Usage" then
+    TestResult.Pass
+  else
+    TestResult.Fail $"Expected an unknown-option error naming the flag plus usage, got: {output}"
+
+
+// ---------------------------------------------------------------- native list rewrites
+// These five moved from Dark to builtins for speed. The edge cases are the point: an out-of-bounds or
+// negative index, an empty list, and nested empties are exactly where a reimplementation drifts.
+
+let testNativeListEdgeCases (): TestResult =
+  let cases =
+    [ ("Stdlib.List.getAt [1;2;3] 0", "1")
+      ("Stdlib.List.getAt [1;2;3] 2", "3")
+      ("Stdlib.List.getAt [1;2;3] 3", "None")
+      ("Stdlib.List.getAt [1;2;3] (-1)", "None")
+      ("Stdlib.List.getAt [] 0", "None")
+      ("Stdlib.List.reverse [1;2;3]", "[3, 2, 1]")
+      ("Stdlib.List.reverse []", "[]")
+      ("Stdlib.List.push [2;3] 1", "[1, 2, 3]")
+      ("Stdlib.List.push [] 1", "[1]")
+      ("Stdlib.List.pushBack [1;2] 3", "[1, 2, 3]")
+      ("Stdlib.List.pushBack [] 1", "[1]")
+      ("Stdlib.List.flatten [[1;2];[3]]", "[1, 2, 3]")
+      ("Stdlib.List.flatten []", "[]")
+      ("Stdlib.List.flatten [[];[1];[]]", "[1]") ]
+
+  let failures =
+    cases
+    |> Stdlib.List.filterMap (fun pair ->
+      let (expr, expected) = pair
+      let output = runWithCommand ["eval"; expr]
+
+      if Stdlib.String.contains output expected then
+        Stdlib.Option.Option.None
+      else
+        Stdlib.Option.Option.Some $"`{expr}` expected `{expected}`, got `{output}`")
+
+  match failures with
+  | [] -> TestResult.Pass
+  | _ -> TestResult.Fail (Stdlib.String.join failures "; ")
+
+
+/// A `None` from `getAt` must still compare and match as a plain `None`. The native version threads the
+/// list's element type through, so the repr gained a type argument; this pins that the change is
+/// display-only.
+/// Calls carrying an EXPLICIT type argument take a different path through Apply than the usual inferred
+/// case: resolving the type argument is the one step that can need the package store before anything has
+/// run, so it hands off to `callBuiltinAsync`/`callPackageAsync` instead of staying synchronous.
+///
+/// Nothing else in either suite exercises that, and it has already been wrong once: an earlier version
+/// awaited and then retried the synchronous path, which never terminates for a type argument that isn't
+/// in the store, because cache misses aren't cached. A scalar type arg, a container one and a custom one
+/// each resolve differently, so all three are here.
+let testExplicitTypeArgs (): TestResult =
+  let scalar = runWithCommand ["eval"; "Stdlib.Json.parse<Int64> \"3\""]
+  let container = runWithCommand ["eval"; "Stdlib.Json.parse<List<Int64>> \"[1,2]\""]
+  let custom = runWithCommand ["eval"; "Stdlib.Json.parse<Stdlib.Uuid.ParseError> \"{}\""]
+
+  if
+    Stdlib.String.contains scalar "Ok" && Stdlib.String.contains scalar "3"
+      && Stdlib.String.contains container "Ok"
+      && Stdlib.String.contains container "[1, 2]"
+      && Stdlib.String.contains custom "ParseError"
+  then
+    TestResult.Pass
+  else
+    TestResult.Fail
+      $"Expected explicit type args to resolve; got scalar: {scalar}, container: {container}, custom: {custom}"
+
+
+let testGetAtNoneIsStillNone (): TestResult =
+  let eq = runWithCommand ["eval"; "(Stdlib.List.getAt [1;2;3] 99) == Stdlib.Option.Option.None"]
+  let dflt = runWithCommand ["eval"; "Stdlib.Option.withDefault (Stdlib.List.getAt [1;2;3] 99) 0"]
+
+  if Stdlib.String.contains eq "true" && Stdlib.String.contains dflt "0" then
+    TestResult.Pass
+  else
+    TestResult.Fail $"Expected out-of-bounds None to behave as None, got eq: {eq}, default: {dflt}"

--- a/packages/darklang/cli/tui/text.dark
+++ b/packages/darklang/cli/tui/text.dark
@@ -144,130 +144,22 @@ let fitToWidth (text: String) (targetWidth: Int) : String =
   clipped ++ Stdlib.String.repeat " " padding
 
 
-let nextActiveStyle (active: String) (sequence: String) : String =
-  if sequence == "\u001b[0m" then
-    ""
-  else
-    active ++ sequence
-
-
-let wrapStyledChars
-  (chars: List<Char>)
-  (width: Int)
-  (activeStyle: String)
-  (current: String)
-  (currentWidth: Int)
-  (wrapPending: Bool)
-  (completed: List<String>)
-  : List<String> =
-  match chars with
-  | [] ->
-    Stdlib.List.reverse (Stdlib.List.push completed current)
-  | char :: remaining ->
-    let text = Stdlib.Char.toString char
-
-    if text == "\u001b" then
-      let (sequence, afterSequence) = consumeEscape remaining
-      wrapStyledChars
-        afterSequence
-        width
-        (nextActiveStyle activeStyle sequence)
-        (current ++ sequence)
-        currentWidth
-        wrapPending
-        completed
-    else if isControl char then
-      wrapStyledChars
-        remaining
-        width
-        activeStyle
-        current
-        currentWidth
-        wrapPending
-        completed
-    else
-      let charWidth = displayWidth text
-      let shouldWrap =
-        wrapPending
-        || (currentWidth > 0 && currentWidth + charWidth > width)
-      let nextCompleted =
-        if shouldWrap then Stdlib.List.push completed current
-        else completed
-      let row =
-        if shouldWrap then activeStyle ++ text
-        else current ++ text
-      let rowWidth =
-        if shouldWrap then charWidth
-        else currentWidth + charWidth
-
-      wrapStyledChars
-        remaining
-        width
-        activeStyle
-        row
-        rowWidth
-        (rowWidth >= width)
-        nextCompleted
-
-
 /// Wrap plain or SGR-styled text into explicit terminal-width rows.
 ///
 /// Styling that spans a wrap is reapplied at the beginning of the next row,
 /// because the frame renderer resets SGR state after writing every row.
+///
+/// Native: the Dark version recursed once per character and called `displayWidth` on each, which measured
+/// 4 ms of a 9 ms prompt view build -- paid on every keystroke.
 let wrapStyled (text: String) (maxWidth: Int) : List<String> =
-  let width = Stdlib.Int.max 1 maxWidth
-  wrapStyledChars
-    (Stdlib.String.toList text)
-    width
-    ""
-    ""
-    0
-    false
-    []
-
-
-let positionAfterChars
-  (chars: List<Char>)
-  (width: Int)
-  (row: Int)
-  (column: Int)
-  (wrapPending: Bool)
-  : (Int * Int) =
-  match chars with
-  | [] ->
-    if wrapPending then (row + 1, 0)
-    else (row, column)
-  | char :: remaining ->
-    let text = Stdlib.Char.toString char
-    let charWidth = displayWidth text
-    let startRow = if wrapPending then row + 1 else row
-    let startColumn = if wrapPending then 0 else column
-    let shouldWrap =
-      startColumn > 0 && startColumn + charWidth > width
-    let nextRow = if shouldWrap then startRow + 1 else startRow
-    let nextColumn =
-      if shouldWrap then charWidth
-      else startColumn + charWidth
-
-    positionAfterChars
-      remaining
-      width
-      nextRow
-      nextColumn
-      (nextColumn >= width)
+  Builtin.cliTerminalWrapStyled text maxWidth
 
 
 /// Return the zero-based terminal cursor immediately after plain text.
 ///
 /// A cursor exactly after the final column is represented at column zero of
 /// the following row, matching terminal wrap behavior.
-let positionAfter
-  (text: String)
-  (maxWidth: Int)
-  : (Int * Int) =
-  positionAfterChars
-    (Stdlib.String.toList text)
-    (Stdlib.Int.max 1 maxWidth)
-    0
-    0
-    false
+///
+/// Native for the same reason as `wrapStyled`: one call per character on the interactive hot path.
+let positionAfter (text: String) (maxWidth: Int) : (Int * Int) =
+  Builtin.cliTerminalPositionAfter text maxWidth

--- a/packages/darklang/cli/utils/completion.dark
+++ b/packages/darklang/cli/utils/completion.dark
@@ -103,23 +103,19 @@ let getHintFromCompletions (partial: String) (completions: List<String>) : Strin
 
 // Standard completion for commands that complete with other command names
 // (right now, just `help`)
-let commandNamesCompletion (_state: AppState) (args: List<String>) : List<CompletionItem> =
+// Uses `state.commandOptionsCache` rather than rebuilding from `Registry.allCommands ()`. This runs on the
+// completion path, so the old version rebuilt all 60 command records and re-folded their aliases while the
+// user was mid-keystroke; the cache is the same list, built once at startup.
+let commandNamesCompletion (state: AppState) (args: List<String>) : List<CompletionItem> =
   match args with
   | [] ->
     // Suggest all command names and aliases
-    let commands = Registry.allCommands ()
-    let commandNames = Stdlib.List.map commands (fun cmd -> cmd.name)
-    let allAliases = Stdlib.List.fold commands [] (fun acc cmd -> Stdlib.List.append acc cmd.aliases)
-    let allOptions = Stdlib.List.append commandNames allAliases
-    allOptions |> Stdlib.List.map simple
+    state.commandOptionsCache |> Stdlib.List.map simple
   | [partialArg] ->
     // Filter by partial match
-    let commands = Registry.allCommands ()
-    let commandNames = Stdlib.List.map commands (fun cmd -> cmd.name)
-    let allAliases = Stdlib.List.fold commands [] (fun acc cmd -> Stdlib.List.append acc cmd.aliases)
-    let allOptions = Stdlib.List.append commandNames allAliases
-    let filtered = Stdlib.List.filter allOptions (fun name -> Stdlib.String.startsWith name partialArg)
-    filtered |> Stdlib.List.map simple
+    state.commandOptionsCache
+    |> Stdlib.List.filter (fun name -> Stdlib.String.startsWith name partialArg)
+    |> Stdlib.List.map simple
   | _ ->
     // Only complete first argument
     []

--- a/packages/darklang/languageTools/packageManager.dark
+++ b/packages/darklang/languageTools/packageManager.dark
@@ -175,6 +175,31 @@ module Search =
         values = searchResults.values
         fns = searchResults.fns }
 
+
+  /// Search returning only names: (direct submodules, types, values, fns).
+  ///
+  /// `search` converts every matched item's full definition, parameters and body AST included, into Dark
+  /// values. Completion reads `.location.name` and throws the rest away, which is most of a millisecond
+  /// per item. Submodules come back already reduced to the direct children of the query's module, because
+  /// doing that reduction in Dark means walking every module path under the store root.
+  let searchNames
+    (branchId: Uuid)
+    (query: ProgramTypes.Search.SearchQuery)
+    : (List<String> * List<String> * List<String> * List<String>) =
+    Builtin.pmSearchNames branchId query
+
+
+  /// Like `searchNames`, but keeps each item's hash. Listings need it for the deprecation mark; completion
+  /// doesn't, and pays nothing for it.
+  let searchNamesAndHashes
+    (branchId: Uuid)
+    (query: ProgramTypes.Search.SearchQuery)
+    : (List<String> *
+       List<(String * ProgramTypes.Hash)> *
+       List<(String * ProgramTypes.Hash)> *
+       List<(String * ProgramTypes.Hash)>) =
+    Builtin.pmSearchNamesAndHashes branchId query
+
 /// Create a PackageManager
 let pm () : ProgramTypes.PackageManager.PackageManager =
   ProgramTypes.PackageManager.PackageManager

--- a/packages/darklang/languageTools/runtimeTypes.dark
+++ b/packages/darklang/languageTools/runtimeTypes.dark
@@ -147,9 +147,82 @@ type Register = Int32
 
 type DvalMap = Dict<Dval>
 
+type StringSegment =
+  | Text of String
+  | Interpolated of Register
+
+
+/// The register-machine instruction set the interpreter actually runs.
+///
+/// Mirrors `LibExecution.RuntimeTypes.Instruction`. Dark code compiles to this, so it's what a
+/// disassembly view shows; see `PrettyPrinter.RuntimeTypes.instructions`.
+///
+/// Jump offsets are relative to the jumping instruction, so a listing has to add the index back to make
+/// them readable.
+type Instruction =
+  | LoadVal of loadTo: Register * value: Dval
+  | CopyVal of copyTo: Register * copyFrom: Register
+  | Or of createTo: Register * lhs: Register * rhs: Register
+  | And of createTo: Register * lhs: Register * rhs: Register
+  | CreateString of createTo: Register * segments: List<StringSegment>
+  | CheckLetPatternAndExtractVars of valueReg: Register * pat: LetPattern
+  | JumpByIfFalse of instrsToJump: Int32 * conditionReg: Register
+  | JumpBy of instrsToJump: Int32
+  | CheckMatchPatternAndExtractVars of
+    valueReg: Register *
+    pat: MatchPattern *
+    failJump: Int32
+  | MatchUnmatched of valueReg: Register
+  | CreateTuple of
+    createTo: Register *
+    first: Register *
+    second: Register *
+    theRest: List<Register>
+  | CreateList of createTo: Register * itemsToAdd: List<Register>
+  | CreateDict of createTo: Register * entries: List<(String * Register)>
+  | CreateRecord of
+    createTo: Register *
+    typeName: FQTypeName.FQTypeName *
+    typeArgs: List<TypeReference> *
+    fields: List<(String * Register)>
+  | CloneRecordWithUpdates of
+    createTo: Register *
+    originalRecordReg: Register *
+    updates: List<(String * Register)>
+  | GetRecordField of
+    targetReg: Register *
+    recordReg: Register *
+    fieldName: String
+  | CreateEnum of
+    createTo: Register *
+    typeName: FQTypeName.FQTypeName *
+    typeArgs: List<TypeReference> *
+    caseName: String *
+    fields: List<Register>
+  | LoadValue of createTo: Register * value: FQValueName.FQValueName
+  | CreateLambda of createTo: Register * lambda: LambdaImpl
+  | Apply of
+    createTo: Register *
+    thingToApply: Register *
+    typeArgs: List<TypeReference> *
+    args: List<Register>
+  | RaiseNRE of names: List<String> * error: NameResolutionError
+  | VarNotFound of targetRegIfDB: Register * name: String
+  | CheckIfFirstExprIsUnit of reg: Register
+
+
+type Instructions =
+  { registerCount: Int32
+    instructions: List<Instruction>
+    resultIn: Register }
+
+
 type LambdaImpl =
-  // TODO: fill in more?
-  { patterns: List<LetPattern> }
+  { exprId: ID
+    patterns: List<LetPattern>
+    registersToCloseOver: List<(Register * Register)>
+    selfRegister: Option<Register>
+    instructions: Instructions }
 
 type ApplicableNamedFn =
   { name: FQFnName.FQFnName

--- a/packages/darklang/prettyPrinter/ast.dark
+++ b/packages/darklang/prettyPrinter/ast.dark
@@ -1,0 +1,348 @@
+/// The ProgramTypes tree of a function, as a tree rather than as source.
+///
+/// `PrettyPrinter.ProgramTypes` renders a function back into Dark you could paste into a file. This
+/// renders the same tree as structure: which node holds which, what the parser actually built. It's the
+/// other half of the question the instruction listing answers, one stage earlier.
+///
+/// Lines carry a depth rather than pre-baked indentation, so a caller can draw guides, fold, or colour
+/// the node kind separately from its payload.
+module Darklang.PrettyPrinter.ProgramTypes.Ast
+
+/// <field label> is the node kind (`ELet`, `EApply`); <field detail> is the scalar payload it carries
+/// (a variable name, a literal, an operator), which is what makes a tree readable without expanding it.
+type Line =
+  { depth: Int
+    label: String
+    detail: String }
+
+
+let line (depth: Int) (label: String) (detail: String) : Line =
+  Line { depth = depth; label = label; detail = detail }
+
+
+let clip (s: String) : String =
+  let s = Stdlib.String.replaceAll s "\n" "\\n"
+
+  if (Stdlib.String.length s) <= 48 then
+    s
+  else
+    (Stdlib.String.slice s 0 45) ++ "..."
+
+
+let letPattern (pat: LanguageTools.ProgramTypes.LetPattern) : String =
+  match pat with
+  | LPVariable(_, name) -> name
+  | LPWildcard _ -> "_"
+  | LPUnit _ -> "()"
+  | LPTuple(_, first, second, theRest) ->
+    let parts =
+      (Stdlib.List.append [ first; second ] theRest)
+      |> Stdlib.List.map (fun p -> letPattern p)
+      |> Stdlib.String.join ", "
+    $"({parts})"
+
+
+let matchPattern (pat: LanguageTools.ProgramTypes.MatchPattern) : String =
+  match pat with
+  | MPVariable(_, name) -> name
+  | MPUnit _ -> "()"
+  | MPBool(_, b) -> Stdlib.Bool.toString b
+  | MPInt8(_, i) -> Stdlib.Int8.toString i
+  | MPUInt8(_, i) -> Stdlib.UInt8.toString i
+  | MPInt16(_, i) -> Stdlib.Int16.toString i
+  | MPUInt16(_, i) -> Stdlib.UInt16.toString i
+  | MPInt32(_, i) -> Stdlib.Int32.toString i
+  | MPUInt32(_, i) -> Stdlib.UInt32.toString i
+  | MPInt64(_, i) -> Stdlib.Int64.toString i
+  | MPUInt64(_, i) -> Stdlib.UInt64.toString i
+  | MPInt128(_, i) -> Stdlib.Int128.toString i
+  | MPUInt128(_, i) -> Stdlib.UInt128.toString i
+  | MPInt(_, i) -> Stdlib.Int.toString i
+  | MPFloat(_, sign, whole, part) ->
+    let s = PrettyPrinter.sign sign
+    $"{s}{whole}.{part}"
+  | MPChar(_, c) -> $"'{c}'"
+  | MPString(_, s) -> "\"" ++ (clip s) ++ "\""
+  | MPList(_, items) ->
+    let parts =
+      (Stdlib.List.map items (fun p -> matchPattern p)) |> Stdlib.String.join "; "
+    $"[{parts}]"
+  | MPListCons(_, head, tail) -> $"{matchPattern head} :: {matchPattern tail}"
+  | MPTuple(_, first, second, theRest) ->
+    let parts =
+      (Stdlib.List.append [ first; second ] theRest)
+      |> Stdlib.List.map (fun p -> matchPattern p)
+      |> Stdlib.String.join ", "
+    $"({parts})"
+  | MPEnum(_, caseName, fields) ->
+    if Stdlib.List.isEmpty fields then
+      caseName
+    else
+      let parts =
+        (Stdlib.List.map fields (fun p -> matchPattern p)) |> Stdlib.String.join ", "
+      $"{caseName}({parts})"
+  | MPOr(_, pats) ->
+    (Stdlib.List.map pats (fun p -> matchPattern p)) |> Stdlib.String.join " | "
+
+
+let typeArgsSuffix (ctx: PrettyPrinter.ProgramTypes.Context) (typeArgs: List<LanguageTools.ProgramTypes.TypeReference>) : String =
+  if Stdlib.List.isEmpty typeArgs then
+    ""
+  else
+    let parts =
+      typeArgs
+      |> Stdlib.List.map (fun t -> PrettyPrinter.ProgramTypes.typeReference ctx t)
+      |> Stdlib.String.join ", "
+    $"<{parts}>"
+
+
+let expr (ctx: PrettyPrinter.ProgramTypes.Context) (depth: Int) (e: LanguageTools.ProgramTypes.Expr) : List<Line> =
+  let here (label: String) (detail: String) : List<Line> = [ line depth label detail ]
+  let child (e: LanguageTools.ProgramTypes.Expr) : List<Line> = expr ctx (depth + 1) e
+
+  let children (es: List<LanguageTools.ProgramTypes.Expr>) : List<Line> =
+    (Stdlib.List.map es (fun e -> child e)) |> Stdlib.List.flatten
+
+  match e with
+  | EUnit _ -> here "Unit" ""
+  | EBool(_, b) -> here "Bool" (Stdlib.Bool.toString b)
+  | EInt8(_, i) -> here "EInt8" (Stdlib.Int8.toString i)
+  | EUInt8(_, i) -> here "EUInt8" (Stdlib.UInt8.toString i)
+  | EInt16(_, i) -> here "EInt16" (Stdlib.Int16.toString i)
+  | EUInt16(_, i) -> here "EUInt16" (Stdlib.UInt16.toString i)
+  | EInt32(_, i) -> here "EInt32" (Stdlib.Int32.toString i)
+  | EUInt32(_, i) -> here "EUInt32" (Stdlib.UInt32.toString i)
+  | EInt64(_, i) -> here "EInt64" (Stdlib.Int64.toString i)
+  | EUInt64(_, i) -> here "EUInt64" (Stdlib.UInt64.toString i)
+  | EInt128(_, i) -> here "EInt128" (Stdlib.Int128.toString i)
+  | EUInt128(_, i) -> here "EUInt128" (Stdlib.UInt128.toString i)
+  | EInt(_, i) -> here "Int" (Stdlib.Int.toString i)
+  | EFloat(_, sign, whole, part) ->
+    let s = PrettyPrinter.sign sign
+    here "Float" $"{s}{whole}.{part}"
+  | EChar(_, c) -> here "Char" $"'{c}'"
+  | EVariable(_, name) -> here "Variable" name
+  | EArg(_, index) -> here "Arg" $"#{Stdlib.Int.toString index}"
+  | ESelf _ -> here "Self" ""
+
+  | EFnName(_, name) ->
+    here
+      "FnName"
+      (PrettyPrinter.ProgramTypes.NameResolution.fnName ctx name)
+
+  | EValue(_, name) ->
+    here
+      "Value"
+      (PrettyPrinter.ProgramTypes.NameResolution.valueName ctx name)
+
+  | EString(_, segments) ->
+    let segLines =
+      segments
+      |> Stdlib.List.map (fun seg ->
+        match seg with
+        | StringText t -> [ line (depth + 1) "Text" ("\"" ++ (clip t) ++ "\"") ]
+        | StringInterpolation e ->
+          Stdlib.List.append
+            [ line (depth + 1) "Interpolation" "" ]
+            (expr ctx (depth + 2) e))
+      |> Stdlib.List.flatten
+    Stdlib.List.append (here "String" "") segLines
+
+  | EIf(_, cond, thenExpr, elseExpr) ->
+    let elseLines =
+      match elseExpr with
+      | None -> []
+      | Some e ->
+        Stdlib.List.append
+          [ line (depth + 1) "else" "" ]
+          (expr ctx (depth + 2) e)
+    Stdlib.List.flatten
+      [ here "If" ""
+        [ line (depth + 1) "cond" "" ]
+        expr ctx (depth + 2) cond
+        [ line (depth + 1) "then" "" ]
+        expr ctx (depth + 2) thenExpr
+        elseLines ]
+
+  | ELet(_, pat, rhs, body) ->
+    Stdlib.List.flatten [ here "Let" (letPattern pat); child rhs; child body ]
+
+  | EList(_, items) ->
+    let n = Stdlib.Int.toString (Stdlib.List.length items)
+    Stdlib.List.append (here "List" $"{n} items") (children items)
+
+  | EDict(_, pairs) ->
+    let n = Stdlib.Int.toString (Stdlib.List.length pairs)
+    let pairLines =
+      pairs
+      |> Stdlib.List.map (fun pair ->
+        let (key, value) = pair
+        Stdlib.List.append
+          [ line (depth + 1) "key" key ]
+          (expr ctx (depth + 2) value))
+      |> Stdlib.List.flatten
+    Stdlib.List.append (here "Dict" $"{n} entries") pairLines
+
+  | ETuple(_, first, second, theRest) ->
+    Stdlib.List.append
+      (here "Tuple" "")
+      (children (Stdlib.List.append [ first; second ] theRest))
+
+  | EApply(_, fn, typeArgs, args) ->
+    Stdlib.List.flatten
+      [ here "Apply" (typeArgsSuffix ctx typeArgs)
+        child fn
+        children args ]
+
+  | ELambda(_, pats, body) ->
+    let ps =
+      (Stdlib.List.map pats (fun p -> letPattern p)) |> Stdlib.String.join " "
+    Stdlib.List.append (here "Lambda" ps) (child body)
+
+  | EInfix(_, op, lhs, rhs) ->
+    let opStr = PrettyPrinter.ProgramTypes.infix op
+    Stdlib.List.flatten [ here "Infix" opStr; child lhs; child rhs ]
+
+  | ERecordFieldAccess(_, record, fieldName) ->
+    Stdlib.List.append (here "RecordFieldAccess" $".{fieldName}") (child record)
+
+  | EStatement(_, first, next) ->
+    Stdlib.List.flatten [ here "Statement" ""; child first; child next ]
+
+  | EMatch(_, arg, cases) ->
+    let n = Stdlib.Int.toString (Stdlib.List.length cases)
+    let caseLines =
+      cases
+      |> Stdlib.List.map (fun c ->
+        let guardLines =
+          match c.whenCondition with
+          | None -> []
+          | Some g ->
+            Stdlib.List.append
+              [ line (depth + 2) "when" "" ]
+              (expr ctx (depth + 3) g)
+        Stdlib.List.flatten
+          [ [ line (depth + 1) "case" (matchPattern c.pat) ]
+            guardLines
+            expr ctx (depth + 2) c.rhs ])
+      |> Stdlib.List.flatten
+    // A scrutinee that renders to one line goes on the `Match` line. Left below it, it sits at the same
+    // indent as the cases and reads like one of them.
+    match child arg with
+    | [ only ] ->
+      let scrutinee =
+        if only.detail == "" then only.label else $"{only.label} {only.detail}"
+      Stdlib.List.append (here "Match" $"on {scrutinee}, {n} cases") caseLines
+    | argLines -> Stdlib.List.flatten [ here "Match" $"{n} cases"; argLines; caseLines ]
+
+  | ERecord(_, typeName, typeArgs, fields) ->
+    let n = PrettyPrinter.ProgramTypes.NameResolution.typeName ctx typeName
+    let fieldLines =
+      fields
+      |> Stdlib.List.map (fun pair ->
+        let (name, value) = pair
+        Stdlib.List.append
+          [ line (depth + 1) "field" name ]
+          (expr ctx (depth + 2) value))
+      |> Stdlib.List.flatten
+    Stdlib.List.append
+      (here "Record" (n ++ (typeArgsSuffix ctx typeArgs)))
+      fieldLines
+
+  | ERecordUpdate(_, record, updates) ->
+    let updateLines =
+      updates
+      |> Stdlib.List.map (fun pair ->
+        let (name, value) = pair
+        Stdlib.List.append
+          [ line (depth + 1) "field" name ]
+          (expr ctx (depth + 2) value))
+      |> Stdlib.List.flatten
+    Stdlib.List.flatten
+      [ here "RecordUpdate" ""; child record; updateLines ]
+
+  | EEnum(_, typeName, typeArgs, caseName, fields) ->
+    let n = PrettyPrinter.ProgramTypes.NameResolution.typeName ctx typeName
+    let ta = typeArgsSuffix ctx typeArgs
+    Stdlib.List.append (here "Enum" $"{n}{ta}.{caseName}") (children fields)
+
+  | EPipe(_, lhs, parts) ->
+    let n = Stdlib.Int.toString (Stdlib.List.length parts)
+    let partLines =
+      (Stdlib.List.map parts (fun p -> pipeExpr ctx (depth + 1) p))
+      |> Stdlib.List.flatten
+    Stdlib.List.flatten [ here "Pipe" $"{n} stages"; child lhs; partLines ]
+
+
+let pipeExpr (ctx: PrettyPrinter.ProgramTypes.Context) (depth: Int) (p: LanguageTools.ProgramTypes.PipeExpr) : List<Line> =
+  match p with
+  | EPipeLambda(_, pats, body) ->
+    let ps =
+      (Stdlib.List.map pats (fun p -> letPattern p)) |> Stdlib.String.join " "
+    Stdlib.List.append
+      [ line depth "PipeLambda" ps ]
+      (expr ctx (depth + 1) body)
+
+  | EPipeInfix(_, op, e) ->
+    let opStr = PrettyPrinter.ProgramTypes.infix op
+    Stdlib.List.append
+      [ line depth "PipeInfix" opStr ]
+      (expr ctx (depth + 1) e)
+
+  | EPipeFnCall(_, name, typeArgs, args) ->
+    let n = PrettyPrinter.ProgramTypes.NameResolution.fnName ctx name
+    let argLines =
+      (Stdlib.List.map args (fun a -> expr ctx (depth + 1) a))
+      |> Stdlib.List.flatten
+    Stdlib.List.append
+      [ line depth "PipeFnCall" (n ++ (typeArgsSuffix ctx typeArgs)) ]
+      argLines
+
+  | EPipeEnum(_, typeName, caseName, fields) ->
+    let n = PrettyPrinter.ProgramTypes.NameResolution.typeName ctx typeName
+    let fieldLines =
+      (Stdlib.List.map fields (fun f -> expr ctx (depth + 1) f))
+      |> Stdlib.List.flatten
+    Stdlib.List.append [ line depth "PipeEnum" $"{n}.{caseName}" ] fieldLines
+
+  | EPipeVariable(_, varName, args) ->
+    let argLines =
+      (Stdlib.List.map args (fun a -> expr ctx (depth + 1) a))
+      |> Stdlib.List.flatten
+    Stdlib.List.append [ line depth "PipeVariable" varName ] argLines
+
+
+/// A whole function: signature first, then the body tree.
+/// The signature as one line, in the shape it's written in source, rather than a `parameters` /
+/// `typeParams` / `returnType` block. Four lines of scaffolding to say what one line says.
+let signature
+  (ctx: PrettyPrinter.ProgramTypes.Context)
+  (name: String)
+  (fn: LanguageTools.ProgramTypes.PackageFn.PackageFn)
+  : String =
+  let typeParams =
+    if Stdlib.List.isEmpty fn.typeParams then
+      ""
+    else
+      "<" ++ (fn.typeParams |> Stdlib.List.map (fun p -> "'" ++ p) |> Stdlib.String.join ", ") ++ ">"
+
+  let parameters =
+    fn.parameters
+    |> Stdlib.List.map (fun p ->
+      let t = PrettyPrinter.ProgramTypes.typeReference ctx p.typ
+      $"({p.name}: {t})")
+    |> Stdlib.String.join " "
+
+  let returnType = PrettyPrinter.ProgramTypes.typeReference ctx fn.returnType
+  $"{name}{typeParams} {parameters} -> {returnType}"
+
+
+
+let packageFn
+  (ctx: PrettyPrinter.ProgramTypes.Context)
+  (name: String)
+  (fn: LanguageTools.ProgramTypes.PackageFn.PackageFn)
+  : List<Line> =
+  Stdlib.List.flatten
+    [ [ line 0 (signature ctx name fn) "" ]
+      expr ctx 0 fn.body ]

--- a/packages/darklang/prettyPrinter/instructions.dark
+++ b/packages/darklang/prettyPrinter/instructions.dark
@@ -1,0 +1,245 @@
+/// Disassembly: the register-machine instructions a function actually runs.
+///
+/// Dark compiles to `RuntimeTypes.Instructions`, so what executes is several steps removed from what you
+/// wrote. When the question is "why does mapping five elements cost 33 package calls", the instruction
+/// listing is the only place the answer is legible.
+///
+/// `opcode` and `operands` are separate functions rather than one rendered line, so a caller can align
+/// the columns and colour them independently. `listing` is the plain-text version for anyone who just
+/// wants the text.
+module Darklang.PrettyPrinter.RuntimeTypes.Instructions
+
+let register (r: LanguageTools.RuntimeTypes.Register) : String =
+  "r" ++ (Stdlib.Int32.toString r)
+
+let registers (rs: List<LanguageTools.RuntimeTypes.Register>) : String =
+  (Stdlib.List.map rs (fun r -> register r)) |> Stdlib.String.join ", "
+
+let namedRegisters (prs: List<(String * LanguageTools.RuntimeTypes.Register)>) : String =
+  prs
+  |> Stdlib.List.map (fun pair ->
+    let (name, r) = pair
+    $"{name}: {register r}")
+  |> Stdlib.String.join ", "
+
+
+/// Register-aware pattern rendering. `PrettyPrinter.RuntimeTypes.letPattern` prints `LPVariable` as
+/// "[variable]" because it has no register vocabulary; in a listing the register is the whole point.
+let letPattern (pat: LanguageTools.RuntimeTypes.LetPattern) : String =
+  match pat with
+  | LPVariable reg -> register reg
+  | LPWildcard -> "_"
+  | LPUnit -> "()"
+  | LPTuple(first, second, theRest) ->
+    let parts =
+      (Stdlib.List.append [ first; second ] theRest)
+      |> Stdlib.List.map (fun p -> letPattern p)
+      |> Stdlib.String.join ", "
+    $"({parts})"
+
+
+let matchPattern (pat: LanguageTools.RuntimeTypes.MatchPattern) : String =
+  match pat with
+  | MPVariable reg -> register reg
+  | MPUnit -> "()"
+  | MPBool b -> Stdlib.Bool.toString b
+  | MPInt8 i -> Stdlib.Int8.toString i
+  | MPUInt8 i -> Stdlib.UInt8.toString i
+  | MPInt16 i -> Stdlib.Int16.toString i
+  | MPUInt16 i -> Stdlib.UInt16.toString i
+  | MPInt32 i -> Stdlib.Int32.toString i
+  | MPUInt32 i -> Stdlib.UInt32.toString i
+  | MPInt64 i -> Stdlib.Int64.toString i
+  | MPUInt64 i -> Stdlib.UInt64.toString i
+  | MPInt128 i -> Stdlib.Int128.toString i
+  | MPUInt128 i -> Stdlib.UInt128.toString i
+  | MPInt i -> Stdlib.Int.toString i
+  | MPFloat f -> Stdlib.Float.toString f
+  | MPChar c -> $"'{c}'"
+  | MPString s -> $"\"{s}\""
+  | MPList items ->
+    let parts =
+      (Stdlib.List.map items (fun p -> matchPattern p)) |> Stdlib.String.join "; "
+    $"[{parts}]"
+  | MPListCons(head, tail) -> $"{matchPattern head} :: {matchPattern tail}"
+  | MPTuple(first, second, theRest) ->
+    let parts =
+      (Stdlib.List.append [ first; second ] theRest)
+      |> Stdlib.List.map (fun p -> matchPattern p)
+      |> Stdlib.String.join ", "
+    $"({parts})"
+  | MPEnum(caseName, fields) ->
+    if Stdlib.List.isEmpty fields then
+      caseName
+    else
+      let parts =
+        (Stdlib.List.map fields (fun p -> matchPattern p)) |> Stdlib.String.join ", "
+      $"{caseName}({parts})"
+  | MPOr pats ->
+    (Stdlib.List.map pats (fun p -> matchPattern p)) |> Stdlib.String.join " | "
+
+
+let segment (branchId: Uuid) (s: LanguageTools.RuntimeTypes.StringSegment) : String =
+  match s with
+  | Text t -> "\"" ++ (Stdlib.String.replaceAll t "\n" "\\n") ++ "\""
+  | Interpolated r -> register r
+
+
+/// Values baked into the instruction stream, rendered short. A listing is for reading, and one 4 KB
+/// docstring pushes everything else off the page, so anything long is summarised by shape instead.
+let inlineDval (branchId: Uuid) (dv: LanguageTools.RuntimeTypes.Dval) : String =
+  let clip (s: String) : String =
+    if (Stdlib.String.length s) <= 40 then
+      s
+    else
+      (Stdlib.String.slice s 0 37) ++ "..."
+
+  match dv with
+  | DUnit -> "unit"
+  | DBool b -> Stdlib.Bool.toString b
+  | DString s -> "\"" ++ (clip (Stdlib.String.replaceAll s "\n" "\\n")) ++ "\""
+  | DChar c -> $"'{c}'"
+  | DInt64 i -> Stdlib.Int64.toString i
+  | DInt i -> Stdlib.Int.toString i
+  | DFloat f -> Stdlib.Float.toString f
+  | DList(_, items) -> $"[{Stdlib.Int.toString (Stdlib.List.length items)} items]"
+  | DDict(_, entries) ->
+    let n = Stdlib.List.length (Stdlib.Dict.keys entries)
+    $"{{{Stdlib.Int.toString n} entries}}"
+  | DRecord(_, typeName, _, fields) ->
+    let n = Stdlib.List.length (Stdlib.Dict.keys fields)
+    let t = PrettyPrinter.RuntimeTypes.typeName branchId typeName
+    $"{t} {{{Stdlib.Int.toString n} fields}}"
+  | DEnum(_, typeName, _, caseName, fields) ->
+    let t = PrettyPrinter.RuntimeTypes.typeName branchId typeName
+    if Stdlib.List.isEmpty fields then
+      $"{t}.{caseName}"
+    else
+      let n = Stdlib.Int.toString (Stdlib.List.length fields)
+      $"{t}.{caseName} ({n})"
+  | DApplicable app ->
+    match app with
+    | AppNamedFn fn -> "&" ++ (PrettyPrinter.RuntimeTypes.fnName branchId fn.name)
+    | AppLambda l -> $"&lambda#{Stdlib.UInt64.toString l.exprId}"
+  | other -> PrettyPrinter.RuntimeTypes.dval branchId other
+
+
+/// The opcode name on its own, so callers can colour or align it.
+let opcode (i: LanguageTools.RuntimeTypes.Instruction) : String =
+  match i with
+  | LoadVal(_, _) -> "LoadVal"
+  | CopyVal(_, _) -> "CopyVal"
+  | Or(_, _, _) -> "Or"
+  | And(_, _, _) -> "And"
+  | CreateString(_, _) -> "CreateString"
+  | CheckLetPatternAndExtractVars(_, _) -> "CheckLetPattern"
+  | JumpByIfFalse(_, _) -> "JumpByIfFalse"
+  | JumpBy _ -> "JumpBy"
+  | CheckMatchPatternAndExtractVars(_, _, _) -> "CheckMatchPattern"
+  | MatchUnmatched _ -> "MatchUnmatched"
+  | CreateTuple(_, _, _, _) -> "CreateTuple"
+  | CreateList(_, _) -> "CreateList"
+  | CreateDict(_, _) -> "CreateDict"
+  | CreateRecord(_, _, _, _) -> "CreateRecord"
+  | CloneRecordWithUpdates(_, _, _) -> "CloneRecordWithUpdates"
+  | GetRecordField(_, _, _) -> "GetRecordField"
+  | CreateEnum(_, _, _, _, _) -> "CreateEnum"
+  | LoadValue(_, _) -> "LoadValue"
+  | CreateLambda(_, _) -> "CreateLambda"
+  | Apply(_, _, _, _) -> "Apply"
+  | RaiseNRE(_, _) -> "RaiseNRE"
+  | VarNotFound(_, _) -> "VarNotFound"
+  | CheckIfFirstExprIsUnit _ -> "CheckIfFirstExprIsUnit"
+
+
+/// Everything after the opcode. <param index> is the instruction's own position: jump offsets are stored
+/// relative, and a relative jump is unreadable in a listing, so they're shown both ways.
+let operands (branchId: Uuid) (index: Int) (i: LanguageTools.RuntimeTypes.Instruction) : String =
+  match i with
+  | LoadVal(r, v) -> $"{register r} <- {inlineDval branchId v}"
+  | CopyVal(t, s) -> $"{register t} <- {register s}"
+  | Or(t, l, r) -> $"{register t} <- {register l} || {register r}"
+  | And(t, l, r) -> $"{register t} <- {register l} && {register r}"
+  | CreateString(t, segs) ->
+    let parts =
+      (Stdlib.List.map segs (fun s -> segment branchId s))
+      |> Stdlib.String.join " ++ "
+    $"{register t} <- {parts}"
+  | CheckLetPatternAndExtractVars(v, p) -> $"{letPattern p} <- {register v}"
+  | JumpByIfFalse(n, c) ->
+    let target = Stdlib.Int.toString (index + (Stdlib.Int.fromInt32 n) + 1)
+    $"{register c} -> +{Stdlib.Int32.toString n} -> {target}"
+  | JumpBy n ->
+    let target = Stdlib.Int.toString (index + (Stdlib.Int.fromInt32 n) + 1)
+    $"+{Stdlib.Int32.toString n} -> {target}"
+  | CheckMatchPatternAndExtractVars(v, p, failJump) ->
+    let target = Stdlib.Int.toString (index + (Stdlib.Int.fromInt32 failJump) + 1)
+    $"{register v} ~ {matchPattern p}  else -> {target}"
+  | MatchUnmatched v -> register v
+  | CreateTuple(t, first, second, theRest) ->
+    let all = registers (Stdlib.List.append [ first; second ] theRest)
+    $"{register t} <- ({all})"
+  | CreateList(t, items) -> $"{register t} <- [{registers items}]"
+  | CreateDict(t, entries) -> $"{register t} <- {{{namedRegisters entries}}}"
+  | CreateRecord(t, typeName, _, fields) ->
+    let n = PrettyPrinter.RuntimeTypes.typeName branchId typeName
+    $"{register t} <- {n} {{{namedRegisters fields}}}"
+  | CloneRecordWithUpdates(t, orig, updates) ->
+    $"{register t} <- {{{register orig} with {namedRegisters updates}}}"
+  | GetRecordField(t, r, fieldName) -> $"{register t} <- {register r}.{fieldName}"
+  | CreateEnum(t, typeName, _, caseName, fields) ->
+    let n = PrettyPrinter.RuntimeTypes.typeName branchId typeName
+    $"{register t} <- {n}.{caseName}({registers fields})"
+  | LoadValue(t, v) ->
+    let n = PrettyPrinter.RuntimeTypes.valueName branchId v
+    $"{register t} <- {n}"
+  | CreateLambda(t, l) ->
+    let n = Stdlib.Int.toString (Stdlib.List.length l.patterns)
+    $"{register t} <- lambda#{Stdlib.UInt64.toString l.exprId} ({n} params)"
+  | Apply(t, fnReg, _, args) ->
+    $"{register t} <- {register fnReg}({registers args})"
+  | RaiseNRE(names, _) -> Stdlib.String.join names "."
+  | VarNotFound(t, name) -> $"{register t} <- ${name}"
+  | CheckIfFirstExprIsUnit r -> register r
+
+
+/// Every lambda defined inside these instructions, flattened, so a listing isn't a dead end at
+/// `CreateLambda`. A lambda inside a lambda gets its own entry rather than nesting.
+let lambdas (instrs: LanguageTools.RuntimeTypes.Instructions) : List<LanguageTools.RuntimeTypes.LambdaImpl> =
+  instrs.instructions
+  |> Stdlib.List.filterMap (fun i ->
+    match i with
+    | CreateLambda(_, l) -> Stdlib.Option.Option.Some l
+    | _ -> Stdlib.Option.Option.None)
+  |> Stdlib.List.map (fun l -> Stdlib.List.append [ l ] (lambdas l.instructions))
+  |> Stdlib.List.flatten
+
+
+let header (instrs: LanguageTools.RuntimeTypes.Instructions) : String =
+  let n = Stdlib.Int.toString (Stdlib.List.length instrs.instructions)
+  let regs = Stdlib.Int32.toString instrs.registerCount
+  $"{n} instructions, {regs} registers, result in {register instrs.resultIn}"
+
+
+/// `Stdlib.String.padStart`/`padEnd` return a `Result` (they can reject a multi-character pad), which
+/// is noise for a fixed single-space pad. These just widen.
+let padTo (width: Int) (s: String) : String =
+  let n = width - (Stdlib.String.length s)
+  if n <= 0 then s else s ++ (Stdlib.String.repeat " " n)
+
+let padFrom (width: Int) (s: String) : String =
+  let n = width - (Stdlib.String.length s)
+  if n <= 0 then s else (Stdlib.String.repeat " " n) ++ s
+
+
+/// Plain-text listing, for callers that don't want to lay it out themselves.
+let listing (branchId: Uuid) (instrs: LanguageTools.RuntimeTypes.Instructions) : String =
+  let body =
+    instrs.instructions
+    |> Stdlib.List.indexedMap (fun index i ->
+      let idx = padFrom 4 (Stdlib.Int.toString index)
+      let op = padTo 24 (opcode i)
+      $"{idx}  {op} {operands branchId index i}")
+    |> Stdlib.String.join "\n"
+
+  (header instrs) ++ "\n" ++ body

--- a/packages/darklang/stdlib/list.dark
+++ b/packages/darklang/stdlib/list.dark
@@ -33,12 +33,12 @@ let append (as_: List<'a>) (bs: List<'a>) : List<'a> =
 
 /// Add element <param value> to front of <type list> <param list>
 let push (list: List<'a>) (value: 'a) : List<'a> =
-  append [ value ] list
+  Builtin.listPush list value
 
 
 /// Add element <param val> to back of <type list> <param list>
 let pushBack (list: List<'a>) (value: 'a) : List<'a> =
-  append list [ value ]
+  Builtin.listPushBack list value
 
 
 /// Returns the last value in <param list>, wrapped in an option (<paramNone> if the list is empty)
@@ -53,12 +53,7 @@ let last (list: List<'a>) : Option.Option<'a> =
 
 /// Returns a reversed copy of <param list>
 let reverse (list: List<'a>) : List<'a> =
-  let reverseHelper (list: List<'a>) (acc: List<'a>) : List<'a> =
-    match list with
-    | [] -> acc
-    | head :: tail -> reverseHelper tail (push acc head)
-
-  reverseHelper list []
+  Builtin.listReverse list
 
 
 /// Returns {{Some firstMatch}} where <var firstMatch> is the first value of the
@@ -134,9 +129,7 @@ let fold (list: List<'a>) (init: 'b) (fn: 'b -> 'a -> 'b) : 'b =
 /// Returns a single list containing the values of every list directly in <paramlist>
 /// (does not recursively flatten nested lists)
 let flatten (list: List<List<'a>>) : List<'a> =
-  match list with
-  | [] -> []
-  | head :: tail -> append head (flatten tail)
+  Builtin.listFlatten list
 
 
 /// Returns a single list containing the values of <param list> separated by <param sep>
@@ -516,16 +509,7 @@ let unzip (pairs: List<('a * 'b)>) : (List<'a> * List<'b>) =
 /// Returns {{Some value}} at <param index> in <param list> if <param index> is
 /// less than the length of the list otherwise returns {{None}}.
 let getAt (list: List<'a>) (index: Int) : Option.Option<'a> =
-  if index < 0 then
-    Option.Option.None
-  else
-    match list with
-    | [] -> Option.Option.None
-    | head :: tail ->
-      if index == 0 then
-        Option.Option.Some head
-      else
-        getAt tail (index - 1)
+  Builtin.listGetAt list index
 
 
 /// Returns {{Just <var randomValue>}}, where <var randomValue> is a randomly

--- a/scripts/run-in-docker
+++ b/scripts/run-in-docker
@@ -16,7 +16,10 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )"/.. && pwd )"
 ARGS=()
 for arg in "$@"
 do
-  ARGS+=( "$(echo "$arg" | fix_dir_stdin)" )
+  # `printf '%s'`, not `echo`: bash's builtin echo eats an argument that is exactly `-n` (and `-e`/`-E`),
+  # treating it as its own flag and emitting nothing. Any script here taking a `-n` option would silently
+  # receive an empty string in its place and then choke on the value that followed it.
+  ARGS+=( "$(printf '%s' "$arg" | fix_dir_stdin)" )
 done
 
 # shellcheck source=scripts/devcontainer/_container-for-clone

--- a/scripts/testing/perf-bench
+++ b/scripts/testing/perf-bench
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+. ./scripts/devcontainer/_assert-in-container "$0" "$@"
+
+# Repeatable CLI timing. See scripts/testing/perf_bench.py for what it does and why.
+#
+#   scripts/testing/perf-bench fixture save      snapshot the current store as the fixture
+#   scripts/testing/perf-bench run <scenario>    one scenario, N runs, against the fixture
+#   scripts/testing/perf-bench ab <a> <b>        two variants, interleaved, paired difference
+#   scripts/testing/perf-bench scenarios         list what's runnable
+
+set -euo pipefail
+exec python3 scripts/testing/perf_bench.py "$@"

--- a/scripts/testing/perf_bench.py
+++ b/scripts/testing/perf_bench.py
@@ -1,0 +1,678 @@
+#!/usr/bin/env python3
+"""Repeatable CLI timing for the perf campaign.
+
+A number you can't reproduce is not a measurement. Four things go wrong without this, and all four have
+bitten this project:
+
+  - The store drifts. Traces and ops accumulate run over run, so the same command gets slower for reasons
+    that have nothing to do with the code. Every run here starts from a byte-identical fixture.
+  - `config/dev` sets DARK_CONFIG_TRACE_DETAIL=on, so a dev run records a full execution trace and a user's
+    never does. Inherited silently, it lands in every number. Pinned explicitly here, and reported.
+  - The box is shared. Four dark containers have been live at once on this machine, and the historical
+    cli.execute spread is 5x on runs doing identical work. A datapoint taken while a neighbour compiles is
+    noise wearing a number's clothes, so we refuse to record one.
+  - Measure-A, change code, measure-B drifts. Comparisons here interleave two binaries A,B,A,B and report
+    the median of the PAIRED difference, which is immune to slow drift across the batch.
+
+Usage:
+  perf-bench scenarios
+  perf-bench fixture save
+  perf-bench bin save <name>
+  perf-bench run <scenario> [-n N] [--trace on|off] [--allow-noise]
+  perf-bench ab <binA> <binB> <scenario> [-n N] [--trace on|off]
+"""
+
+import argparse
+import hashlib
+import json
+import os
+import shutil
+import statistics
+import subprocess
+import sys
+import time
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+RUNDIR = os.path.join(ROOT, "rundir")
+PERFDIR = os.path.join(RUNDIR, "perf")
+FIXTURE = os.path.join(PERFDIR, "fixture.db")
+
+
+def fixture_path(name):
+    """`none` means don't restore anything: use whatever store the binary already has.
+
+    A published binary carries its own embedded seed and extracts it beside the exe, so two published
+    binaries are each already matched to their own store. Forcing a shared fixture onto them would put one
+    of them next to package code that calls builtins it doesn't have."""
+    if name == "none":
+        return None
+    """A change that spans both F# builtins and Dark packages can't be A/B'd by swapping binaries alone:
+    the store holds the package implementations, and they call builtins that only exist in one of the two
+    binaries. Old binary plus new store fails, and so does the reverse. Each side needs its own fixture,
+    captured while that side was live."""
+    return FIXTURE if name in (None, "default") else os.path.join(PERFDIR, f"fixture-{name}.db")
+BINDIR = os.path.join(PERFDIR, "bin")
+DEBUG_BIN_DIR = os.path.join(ROOT, "backend", "Build", "out", "Cli", "Debug", "net10.0")
+# Default only; the real path depends on which rundir the binary uses. See `rundir_for`.
+TELEMETRY = os.path.join(RUNDIR, "logs", "telemetry.jsonl")
+# Raw measurements are machine-local: they name a binary, a store fixture and a load average that mean
+# nothing on another box. `notes/` is gitignored in this repo anyway (the real notes live in the sibling
+# notes repo, which isn't mounted in the container), so `rundir/` is both the honest home and the reachable
+# one. Rendered summaries go to the notes repo by hand.
+SERIES = os.path.join(PERFDIR, "timeseries.jsonl")
+
+# Every scenario is one non-interactive CLI invocation. Interactive ones need a tmux driver and land once
+# the per-keystroke instrument is cheap enough to trust (see plan 6.B); measuring them now would only
+# measure the instrument.
+SCENARIOS = {
+    "version": ["version"],
+    "status": ["status"],
+    "help": ["help"],
+    "tree": ["tree"],
+    "eval-trivial": ["eval", "1L + 2L"],
+    "eval-map5": ["eval", "Stdlib.List.map [1;2;3;4;5] (fun x -> x + 1)"],
+    "eval-map1000": ["eval", "Stdlib.List.length (Stdlib.List.map (Stdlib.List.range 1 1000) (fun x -> x + 1))"],
+    # Heavy enough that the interpreter, not process startup, dominates. Startup is ~400 ms of fixed cost,
+    # so a scenario doing 20 ms of list work can't show a list-work improvement at all.
+    "eval-listheavy": ["eval",
+        "Stdlib.List.length (Stdlib.List.filter (Stdlib.List.map (Stdlib.List.range 1 2000) (fun x -> x + 1)) (fun x -> x > 5))"],
+    # Interpreter workloads, materialized by `materialize_workloads`.
+    "interp-list": ["run", "rundir/perf-workloads/steady.dark"],
+    "interp-arith": ["run", "rundir/perf-workloads/arith.dark"],
+    "eval-flatten": ["eval",
+        "Stdlib.List.length (Stdlib.List.flatten (Stdlib.List.map (Stdlib.List.range 1 400) (fun x -> Stdlib.List.range 1 20)))"],
+}
+
+# Interpreter workloads, kept as source here rather than as .dark files in the tree: anything under
+# `packages/` would be loaded as package items, and a loose file elsewhere drifts from the harness that
+# depends on it. Materialized into rundir (gitignored) on demand, so a scenario is reproducible from this
+# file alone.
+#
+# These exist because measuring the interpreter by hand is how I burned a night: script runs that timed out
+# at 90s, 240s and 500s all later ran in under a second, because the box was busy and I'd bypassed the noise
+# gate by invoking run-cli directly. Behind a scenario, they inherit the gate.
+WORKLOADS = {
+    # List pipeline: package-call heavy, shallow recursion.
+    "steady": """
+let work (n: Int) : Int =
+  Stdlib.List.length (Stdlib.List.map (Stdlib.List.range 1 n) (fun x -> x + 1))
+
+let repeat (times: Int) (n: Int) (acc: Int) : Int =
+  if times <= 0 then acc else repeat (times - 1) n (acc + (work n))
+
+let _warm = repeat 20 50 0
+let _reset = Builtin.interpreterStatsReset ()
+let t0 = Builtin.timeNowMs ()
+let result = repeat 200 50 0
+let t1 = Builtin.timeNowMs ()
+Stdlib.printLine ("elapsed_ms=" ++ (Stdlib.Int.toString (t1 - t0)) ++ " stats=" ++ (Builtin.interpreterStatsGet ()))
+""",
+    # Arithmetic: builtin-call heavy, deep recursion. A deliberately different shape from `steady`, since
+    # the two disagree substantially on per-Apply cost.
+    "arith": """
+let hot (n: Int) (acc: Int) : Int =
+  if n <= 0 then
+    acc
+  else
+    let a = acc + 1
+    let b = a + 2
+    let c = b + 3
+    let d = c + 4
+    let e = d + 5
+    hot (n - 1) e
+
+let _warm = hot 200 0
+let _reset = Builtin.interpreterStatsReset ()
+let t0 = Builtin.timeNowMs ()
+let result = hot 4000 0
+let t1 = Builtin.timeNowMs ()
+Stdlib.printLine ("elapsed_ms=" ++ (Stdlib.Int.toString (t1 - t0)) ++ " stats=" ++ (Builtin.interpreterStatsGet ()))
+""",
+}
+
+WORKLOADS["depth-shallow"] = """
+// Same total work as depth-deep, but the stack never gets deeper than ~50.
+// Three nested drivers of 16 keep level small; a single driver would itself recurse 4096 deep, which is
+// what made my first attempt at this comparison measure nothing.
+let leaf (acc: Int) : Int =
+  acc + 1
+
+let l1 (n: Int) (acc: Int) : Int =
+  if n <= 0 then acc else l1 (n - 1) (leaf acc)
+
+let l2 (n: Int) (acc: Int) : Int =
+  if n <= 0 then acc else l2 (n - 1) (l1 16 acc)
+
+let l3 (n: Int) (acc: Int) : Int =
+  if n <= 0 then acc else l3 (n - 1) (l2 16 acc)
+
+let _warm = l3 2 0
+let t0 = Builtin.timeNowMs ()
+let r = l3 16 0
+let t1 = Builtin.timeNowMs ()
+Stdlib.printLine ("elapsed_ms=" ++ (Stdlib.Int.toString (t1 - t0)) ++ " leafCalls=" ++ (Stdlib.Int.toString r))
+"""
+
+WORKLOADS["depth-deep"] = """
+// Same 4096 leaf calls, but all in one chain, so 4096 frames are live at the deepest point.
+let leaf (acc: Int) : Int =
+  acc + 1
+
+let chain (n: Int) (acc: Int) : Int =
+  if n <= 0 then acc else chain (n - 1) (leaf acc)
+
+let _warm = chain 32 0
+let t0 = Builtin.timeNowMs ()
+let r = chain 4096 0
+let t1 = Builtin.timeNowMs ()
+Stdlib.printLine ("elapsed_ms=" ++ (Stdlib.Int.toString (t1 - t0)) ++ " leafCalls=" ++ (Stdlib.Int.toString r))
+"""
+
+SCENARIOS["depth-shallow"] = ["run", "rundir/perf-workloads/depth-shallow.dark"]
+SCENARIOS["depth-deep"] = ["run", "rundir/perf-workloads/depth-deep.dark"]
+
+WORKLOAD_DIR = os.path.join(RUNDIR, "perf-workloads")
+
+
+def materialize_workloads():
+    os.makedirs(WORKLOAD_DIR, exist_ok=True)
+    for name, src in WORKLOADS.items():
+        with open(os.path.join(WORKLOAD_DIR, f"{name}.dark"), "w") as f:
+            f.write(src.lstrip())
+
+
+# A run slower than this is assumed to have hit something pathological (a lock, a neighbour's compile
+# landing mid-run) and is reported rather than silently folded into the median.
+OUTLIER_FACTOR = 3.0
+
+
+# ---------------------------------------------------------------- environment
+
+
+def load_average():
+    with open("/proc/loadavg") as f:
+        return float(f.read().split()[0])
+
+
+def noise_report():
+    """What's competing with us right now. Load average is the host's; container namespaces don't
+    virtualise it, which is exactly what we want to know."""
+    la = load_average()
+    cpus = os.cpu_count() or 1
+    # dotnet/msbuild running anywhere on the box means a neighbour clone is compiling.
+    try:
+        out = subprocess.run(
+            ["pgrep", "-af", "dotnet|MSBuild|ilc"],
+            capture_output=True, text=True, timeout=10,
+        ).stdout
+        compilers = [l for l in out.splitlines() if "perf_bench" not in l and "pgrep" not in l]
+    except Exception:
+        compilers = []
+    return {"loadavg1": la, "cpus": cpus, "load_per_cpu": la / cpus, "compilers": len(compilers)}
+
+
+def noise_gate(allow):
+    n = noise_report()
+    # A quarter of the box busy is enough to move a median. The threshold is deliberately strict: a
+    # rejected batch costs minutes, a bad number costs a day chasing it.
+    noisy = n["load_per_cpu"] > 0.25 or n["compilers"] > 0
+    if noisy and not allow:
+        print(
+            f"REFUSING to measure: loadavg {n['loadavg1']:.1f} over {n['cpus']} cpus "
+            f"({n['load_per_cpu']:.2f}/cpu), {n['compilers']} compiler processes running.\n"
+            f"Wait for the box to settle, or pass --allow-noise to record anyway (the row is "
+            f"flagged noisy and should not be compared against a quiet one).",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+    return n, noisy
+
+
+# ---------------------------------------------------------------- fixture
+
+
+def sha256(path):
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def fixture_save(name=None):
+    os.makedirs(PERFDIR, exist_ok=True)
+    dest = fixture_path(name)
+    src = os.path.join(RUNDIR, "data.db")
+    if not os.path.exists(src):
+        sys.exit("no rundir/data.db to snapshot")
+    # Checkpoint first so the fixture is one self-contained file rather than a db plus a WAL whose
+    # contents would be silently dropped by the copy.
+    subprocess.run(
+        ["sqlite3", src, "PRAGMA wal_checkpoint(TRUNCATE);"],
+        check=False, capture_output=True,
+    )
+    shutil.copy2(src, dest)
+    digest = sha256(dest)
+    with open(dest + ".sha256", "w") as f:
+        f.write(digest + "\n")
+    print(f"fixture saved: {dest}")
+    print(f"  {os.path.getsize(dest):,} bytes")
+    print(f"  sha256 {digest}")
+
+
+def rundir_for(binary):
+    """Which store a given binary actually uses.
+
+    Not always this repo's `rundir`. A published binary carries an embedded seed, and
+    `EmbeddedResources.extract()` sets DARK_CONFIG_RUNDIR to `<exe dir>/.darklang` unconditionally --
+    it ignores any value already in the environment, so this can't be redirected, only discovered.
+    A Debug build has no embedded resource, skips that branch, and uses the repo rundir.
+
+    Getting this wrong silently compares two binaries against two different stores, which is how a
+    harness ends up lying more convincingly than no harness at all."""
+    adjacent = os.path.join(os.path.dirname(os.path.abspath(binary)), ".darklang")
+    return adjacent if os.path.isdir(adjacent) else RUNDIR
+
+
+def fixture_restore(rundir, fixture=None):
+    if fixture == "SKIP":
+        return
+    """Byte-identical store before every run. The `-wal` and `-shm` must go too: leaving them turns the
+    restored db into a db plus someone else's journal, which is a different store and sometimes a corrupt
+    one."""
+    fixture = fixture or FIXTURE
+    if not os.path.exists(fixture):
+        sys.exit(f"no fixture at {fixture}; run `perf-bench fixture save [name]` first")
+    for suffix in ("", "-wal", "-shm"):
+        p = os.path.join(rundir, "data.db" + suffix)
+        if os.path.exists(p):
+            os.remove(p)
+    shutil.copy2(fixture, os.path.join(rundir, "data.db"))
+
+
+# ---------------------------------------------------------------- binaries
+
+
+def bin_save(name):
+    os.makedirs(BINDIR, exist_ok=True)
+    dst = os.path.join(BINDIR, name)
+    if not os.path.isdir(DEBUG_BIN_DIR):
+        sys.exit(f"no build at {DEBUG_BIN_DIR}")
+    if os.path.exists(dst):
+        shutil.rmtree(dst)
+    # The whole output directory, not just the exe: the deps and runtimeconfig travel with it, which is
+    # what makes an old binary runnable next to a new one.
+    shutil.copytree(DEBUG_BIN_DIR, dst)
+    print(f"binary saved: {dst} (from {DEBUG_BIN_DIR})")
+
+
+def resolve_bin(name):
+    """A saved snapshot name, the live build, or a path to any other Cli."""
+    if name in ("current", "live"):
+        return os.path.join(DEBUG_BIN_DIR, "Cli")
+    # A path lets you A/B against something published elsewhere (a Release build, an R2R publish)
+    # without copying it into the snapshot dir first.
+    if "/" in name:
+        p = name if os.path.basename(name) == "Cli" else os.path.join(name, "Cli")
+        if not os.path.exists(p):
+            sys.exit(f"no Cli at {p}")
+        return os.path.abspath(p)
+    p = os.path.join(BINDIR, name, "Cli")
+    if not os.path.exists(p):
+        sys.exit(f"no saved binary {name!r} (looked in {p})")
+    return p
+
+
+# ---------------------------------------------------------------- running
+
+
+def run_once(binary, argv, trace, telemetry, fixture="UNSET"):
+    rundir = rundir_for(binary)
+    fixture_restore(rundir, "SKIP" if fixture is None else (None if fixture == "UNSET" else fixture))
+    tel_path = os.path.join(rundir, "logs", "telemetry.jsonl")
+    if os.path.exists(tel_path):
+        os.remove(tel_path)
+    env = dict(os.environ)
+    # Pinned, never inherited: config/dev turns tracing on for the container, so a run that doesn't say
+    # otherwise is measuring the traced path without meaning to.
+    env["DARK_CONFIG_TRACE_DETAIL"] = trace
+    if telemetry:
+        env["DARK_TELEMETRY"] = "1"
+    else:
+        env.pop("DARK_TELEMETRY", None)
+
+    t0 = time.perf_counter()
+    proc = subprocess.run(
+        [binary] + argv, capture_output=True, text=True, env=env, cwd=ROOT
+    )
+    wall_ms = (time.perf_counter() - t0) * 1000.0
+    return wall_ms, proc.returncode, read_telemetry(tel_path) if telemetry else {}
+
+
+def read_telemetry(path):
+    """Phase spans and counters from the run that just finished. Durations only; the counter events carry
+    their value in ctx instead."""
+    out = {}
+    if not os.path.exists(path):
+        return out
+    with open(path) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                e = json.loads(line)
+            except Exception:
+                continue
+            name = e.get("event")
+            if "ms" in e:
+                out[name] = e["ms"]
+            ctx = e.get("ctx") or {}
+            for k in ("count", "instructions", "packageCalls", "builtinCalls", "framePushes"):
+                if k in ctx:
+                    out[f"{name}.{k}" if k == "count" else k] = int(ctx[k])
+    return out
+
+
+def summarise(samples):
+    s = sorted(samples)
+    n = len(s)
+    if n == 0:
+        return {}
+    q1 = s[n // 4]
+    q3 = s[(3 * n) // 4]
+    return {
+        "n": n,
+        "min": round(s[0], 2),
+        "median": round(statistics.median(s), 2),
+        "p90": round(s[min(n - 1, int(0.9 * n))], 2),
+        "max": round(s[-1], 2),
+        "iqr": round(q3 - q1, 2),
+    }
+
+
+def commit():
+    try:
+        return subprocess.run(
+            ["git", "rev-parse", "--short", "HEAD"],
+            capture_output=True, text=True, cwd=ROOT,
+        ).stdout.strip()
+    except Exception:
+        return "unknown"
+
+
+def fixture_digest():
+    p = FIXTURE + ".sha256"
+    return open(p).read().strip()[:12] if os.path.exists(p) else "none"
+
+
+class DevStore:
+    """Put the developer's store back when the batch ends.
+
+    Every measured run overwrites `rundir/data.db` with a fixture and leaves it there, so after a batch the
+    working tree is sitting on whichever store the last run used. If that fixture predates a `packages/`
+    change, the tree is now mismatched with the binary's regenerated PackageRefs, and the symptom is a
+    `FnNotFound` on `RuntimeError.toString` -- i.e. every subsequent error fails to stringify and reports
+    the wrong thing. That cost me hours before I noticed the harness was the cause."""
+
+    def __init__(self):
+        self.saved = None
+
+    def __enter__(self):
+        src = os.path.join(RUNDIR, "data.db")
+        if os.path.exists(src):
+            self.saved = os.path.join(PERFDIR, "devstore-backup.db")
+            os.makedirs(PERFDIR, exist_ok=True)
+            shutil.copy2(src, self.saved)
+        return self
+
+    def __exit__(self, *exc):
+        if self.saved and os.path.exists(self.saved):
+            for suffix in ("", "-wal", "-shm"):
+                p = os.path.join(RUNDIR, "data.db" + suffix)
+                if os.path.exists(p):
+                    os.remove(p)
+            shutil.move(self.saved, os.path.join(RUNDIR, "data.db"))
+            print("\n(restored the dev store)")
+        return False
+
+
+def record(row):
+    row.setdefault("fixture", fixture_digest())
+    os.makedirs(os.path.dirname(SERIES), exist_ok=True)
+    with open(SERIES, "a") as f:
+        f.write(json.dumps(row, sort_keys=True) + "\n")
+
+
+# ---------------------------------------------------------------- commands
+
+
+def cmd_run(args):
+    materialize_workloads()
+    with DevStore():
+        if args.scenario not in SCENARIOS:
+            sys.exit(f"unknown scenario {args.scenario!r}; try `perf-bench scenarios`")
+        argv = SCENARIOS[args.scenario]
+        binary = resolve_bin(args.binary)
+        noise, noisy = noise_gate(args.allow_noise)
+
+        print(f"scenario {args.scenario}: {' '.join(argv)}")
+        print(f"binary   {binary}")
+        print(f"trace    {args.trace}   telemetry off for timing, one extra run with it on for the breakdown")
+        print(f"box      loadavg {noise['loadavg1']:.2f} over {noise['cpus']} cpus, {noise['compilers']} compilers")
+        print()
+
+        # Warmup, discarded: the first runs of a fresh binary pay JIT and page-cache costs that no later run
+        # repeats, and folding them into the median makes every batch look worse than the steady state.
+        for _ in range(args.warmup):
+            run_once(binary, argv, args.trace, False)
+
+        samples = []
+        for i in range(args.n):
+            wall, rc, _ = run_once(
+            binary, argv, args.trace, args.telemetry == "on", fixture_path(args.fixture))
+            if rc != 0:
+                sys.exit(
+                    f"\nABORT: run {i} exited {rc}. A failing run is fast, so timing it would "
+                    f"be meaningless. If you changed packages/, the fixture is stale: reload "
+                    f"packages, then `perf-bench fixture save`."
+                )
+            samples.append(wall)
+            print(f"  {wall:8.1f} ms")
+
+        stats = summarise(samples)
+        med = stats["median"]
+        outliers = [x for x in samples if x > med * OUTLIER_FACTOR]
+
+        # One instrumented run for the phase breakdown. Kept separate from the timing samples on purpose:
+        # telemetry is cheap but not free, and a number quoted as wall time should never have been taken with
+        # the instrument attached.
+        _, _, tel = run_once(binary, argv, args.trace, True, fixture_path(args.fixture))
+
+        print()
+        print(f"  median {stats['median']} ms   min {stats['min']}   p90 {stats['p90']}   IQR {stats['iqr']}")
+        if outliers:
+            print(f"  {len(outliers)} outlier(s) over {OUTLIER_FACTOR}x median: "
+                  f"{', '.join(f'{o:.0f}' for o in outliers)}")
+        if tel:
+            print("  phases (one instrumented run):")
+            for k in ("cli.total", "cli.growIfNeeded", "cli.buildState", "cli.execute"):
+                if k in tel:
+                    print(f"    {k:22s} {tel[k]:>7} ms")
+            for k in ("instructions", "packageCalls", "builtinCalls", "framePushes"):
+                if k in tel:
+                    print(f"    {k:22s} {tel[k]:>7,}")
+
+        record({
+            "kind": "run",
+            "commit": commit(),
+            "config": "Debug",
+            "scenario": args.scenario,
+            "binary": args.binary,
+            "trace": args.trace,
+            "wall_ms": stats,
+            "telemetry": tel,
+            "noise": noise,
+            "noisy": noisy,
+            "outliers": len(outliers),
+        })
+        print(f"\nrecorded to {os.path.relpath(SERIES, ROOT)}")
+
+
+def cmd_check(args):
+    materialize_workloads()
+    with DevStore():
+        """Run every scenario once per binary and report exit codes.
+
+        A scenario that errors returns in a fraction of the time a working one takes, so a broken scenario or
+        a mismatched fixture reads as an improvement. Both happened here before this existed: `eval-map1000`
+        passed Int64 to `List.range`, which takes Int, and had been failing on both sides of an A/B."""
+        binary = resolve_bin(args.binary)
+        fixture = fixture_path(args.fixture)
+        print(f"binary  {binary}")
+        print(f"fixture {os.path.basename(fixture)}\n")
+        bad = 0
+        for name, argv in SCENARIOS.items():
+            ms, rc, _ = run_once(binary, argv, "off", False, fixture)
+            status = "ok" if rc == 0 else f"EXIT {rc}"
+            if rc != 0:
+                bad += 1
+            print(f"  {name:18s} {ms:8.1f} ms   {status}")
+        print()
+        if bad:
+            print(f"{bad} scenario(s) failing. Their timings are meaningless; fix before measuring.")
+            sys.exit(1)
+        print("all scenarios run clean")
+
+
+def cmd_ab(args):
+    materialize_workloads()
+    with DevStore():
+        if args.scenario not in SCENARIOS:
+            sys.exit(f"unknown scenario {args.scenario!r}")
+        argv = SCENARIOS[args.scenario]
+        a_bin, b_bin = resolve_bin(args.a), resolve_bin(args.b)
+        noise, noisy = noise_gate(args.allow_noise)
+
+        print(f"A = {args.a}  ({a_bin})")
+        print(f"B = {args.b}  ({b_bin})")
+        print(f"scenario {args.scenario}, {args.n} interleaved pairs\n")
+
+        fa, fb = fixture_path(args.fixture_a), fixture_path(args.fixture_b)
+        for f, side in ((fa, "A"), (fb, "B")):
+            if f is not None and not os.path.exists(f):
+                sys.exit(f"no fixture for side {side}: {f}")
+        show = lambda f: "the binary's own" if f is None else os.path.basename(f)
+        print(f"fixtures  A={show(fa)}  B={show(fb)}\n")
+
+        for _ in range(args.warmup):
+            run_once(a_bin, argv, args.trace, False, fa)
+            run_once(b_bin, argv, args.trace, False, fb)
+
+        # Interleaved, and the pair is what's compared. Drift across the batch -- a neighbour starting a
+        # build halfway through -- moves both halves of a pair together and cancels in the difference, which
+        # measuring all of A then all of B would not.
+        pairs = []
+        for i in range(args.n):
+            a_ms, a_rc, _ = run_once(a_bin, argv, args.trace, False, fa)
+            b_ms, b_rc, _ = run_once(b_bin, argv, args.trace, False, fb)
+            # A failing run is FAST, so timing it silently makes a broken binary look like an optimization.
+            # This bit me: after changing stdlib/list.dark the fixture store still held the old content hashes,
+            # so the new binary died with FnNotFound in ~0.5 s and the A/B read it as a win.
+            if a_rc != 0 or b_rc != 0:
+                sys.exit(
+                    f"\nABORT: run exited non-zero (A={a_rc}, B={b_rc}) on pair {i}.\n"
+                    f"A failing run is fast, so these timings would be meaningless.\n"
+                    f"If you changed packages/, the fixture is stale: reload packages, then "
+                    f"`perf-bench fixture save`."
+                )
+            pairs.append((a_ms, b_ms))
+            print(f"  A {a_ms:8.1f}   B {b_ms:8.1f}   diff {b_ms - a_ms:+8.1f}")
+
+        a_s = summarise([p[0] for p in pairs])
+        b_s = summarise([p[1] for p in pairs])
+        diffs = [b - a for a, b in pairs]
+        d = summarise(diffs)
+        rel = (statistics.median(diffs) / a_s["median"] * 100) if a_s["median"] else 0.0
+        wins = sum(1 for x in diffs if x < 0)
+
+        print()
+        print(f"  A median {a_s['median']} ms (IQR {a_s['iqr']})")
+        print(f"  B median {b_s['median']} ms (IQR {b_s['iqr']})")
+        print(f"  paired difference: median {d['median']:+} ms ({rel:+.1f}%), IQR {d['iqr']}")
+        print(f"  B faster in {wins}/{len(diffs)} pairs")
+
+        record({
+            "kind": "ab",
+            "commit": commit(),
+            "config": "Debug",
+            "scenario": args.scenario,
+            "a": args.a, "b": args.b,
+            "trace": args.trace,
+            "a_ms": a_s, "b_ms": b_s,
+            "diff_ms": d, "diff_pct": round(rel, 2),
+            "b_faster_pairs": wins, "pairs": len(diffs),
+            "noise": noise, "noisy": noisy,
+        })
+        print(f"\nrecorded to {os.path.relpath(SERIES, ROOT)}")
+
+
+def main():
+    p = argparse.ArgumentParser(prog="perf-bench")
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    sub.add_parser("scenarios")
+
+    fx = sub.add_parser("fixture").add_subparsers(dest="fixcmd", required=True)
+    fxs = fx.add_parser("save")
+    fxs.add_argument("name", nargs="?", default=None)
+
+    bs = sub.add_parser("bin").add_subparsers(dest="bincmd", required=True)
+    bsv = bs.add_parser("save")
+    bsv.add_argument("name")
+
+    r = sub.add_parser("run")
+    r.add_argument("scenario")
+    r.add_argument("-n", type=int, default=10)
+    r.add_argument("--warmup", type=int, default=3)
+    r.add_argument("--binary", default="current")
+    r.add_argument("--trace", choices=["on", "off"], default="off")
+    r.add_argument("--allow-noise", action="store_true")
+    r.add_argument("--fixture", default=None)
+    r.add_argument("--telemetry", choices=["on", "off"], default="off",
+                   help="run the timed samples with telemetry on, to measure what the instrument costs")
+
+    ck = sub.add_parser("check")
+    ck.add_argument("--binary", default="current")
+    ck.add_argument("--fixture", default=None)
+
+    ab = sub.add_parser("ab")
+    ab.add_argument("a")
+    ab.add_argument("b")
+    ab.add_argument("scenario")
+    ab.add_argument("-n", type=int, default=15)
+    ab.add_argument("--warmup", type=int, default=3)
+    ab.add_argument("--trace", choices=["on", "off"], default="off")
+    ab.add_argument("--allow-noise", action="store_true")
+    ab.add_argument("--fixture-a", default=None, help="store fixture matching binary A")
+    ab.add_argument("--fixture-b", default=None, help="store fixture matching binary B")
+
+    args = p.parse_args()
+
+    if args.cmd == "scenarios":
+        for k, v in SCENARIOS.items():
+            print(f"  {k:16s} dark {' '.join(v)}")
+    elif args.cmd == "fixture":
+        fixture_save(args.name)
+    elif args.cmd == "bin":
+        bin_save(args.name)
+    elif args.cmd == "run":
+        cmd_run(args)
+    elif args.cmd == "check":
+        cmd_check(args)
+    elif args.cmd == "ab":
+        cmd_ab(args)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Dark's interpreter allocates a lot: over 2 MB per iteration of a loop that builds a fifty-element list. That is the main reason the CLI feels slow, and nothing measured it before this PR.

Allocation is now down about two thirds and commands are 25-50% faster. Four things: the interpreter work itself, a pile of work the CLI was doing for nobody, the instrumentation that found both, and two new views into how package items are parsed and lowered.

## Numbers

`steady.dark` is 200 iterations of `List.range 1 50 |> List.map (+1) |> List.length`: 304,280 instructions and 93,655 function calls per run. Deliberately call-and-list heavy, because that is what the CLI's own code does. `arith.dark` is a 4,000-deep integer recursion, a different shape on purpose.

| | before | after | change |
|---|---|---|---|
| **`steady.dark`** | | | |
| allocation, whole process | 867.9 MB | 273.1 MB | -69% |
| allocation, script body | 446 MB | 230 MB | -48% |
| body time, Debug | 1,162 ms | 351 ms | -70% |
| body time, Release | | 251 ms | |
| whole process, Debug | 3,850 ms | 1,117 ms | -71% |
| whole process, Release | 2,622 ms | 611 ms | -77% |
| **`arith.dark`** | | | |
| whole process, Debug | 3,280 ms | 823 ms | -75% |
| whole process, Release | 2,717 ms | 387 ms | -86% |
| **commands** | | | |
| `status`, Debug | 748 ms | 563 ms | -25% |
| `status`, Release | 390 ms | 223 ms | -43% |
| `help`, Debug | 810 ms | 568 ms | -30% |
| `help`, Release | 461 ms | 244 ms | -47% |
| `ls`, Debug | 823 ms | 571 ms | -31% |
| `ls`, Release | 473 ms | 232 ms | -51% |

For comparison, I wrote equivalent scripts in node and python. Node does the same work in **0.93 ms and 0.34 MB**, python in **0.88 ms and 0.09 MB**. Dark is still around **270x node's time and 675x its allocation**, down from 1,300x on allocation. Two structural reasons the others don't carry: a Dark function call allocates several KB of interpreter machinery, and every argument of every call is type-checked at runtime. This PR takes a large bite out of the first and leaves the second alone.

Typing latency in the interactive prompt goes from ~113 ms per keystroke to single digits. That was a plain bug: the console writer held its lock while sleeping.

The new instrumentation costs nothing unless something turns it on. A script that turns on the per-instruction counters runs the reference workload in 378 ms instead of 351, so measuring costs about 8%; allocation is unaffected either way (273.1 MB vs 272.1). Everything else is gated behind a flag that is off by default.

`Interpreter.fs` is best read with `git diff -w`, and largely as a move.

## Making the interpreter allocate less

**The root cause.** The interpreter is written in `uply { }` blocks, our lightweight async. Entering one allocates, even when nothing actually has to wait, and on the hot path almost nothing does: the type checker already has its answer, a package lookup is a cache hit, a pure builtin returns immediately. That plumbing came to ~2 KB per function call, more than half of all allocation. Removing individual `let!`s doesn't help, which I confirmed by trying. What matters is not entering the block at all.

**So both call paths now run outside it.** `callBuiltin` and `callPackage` are ordinary synchronous functions handling everything from arguments in to result checked. Worth **-46 MB for builtins and -52 MB for package fns** against a 384 MB baseline, and the biggest change in the PR.

There's one copy of each, not a fast one and a slow one that drift apart. Two things make that possible. Resolving an explicit type argument is the only step that might need the package store before anything else has happened, so it bails out and a small cold-path function does it and calls back in. Argument checking can need the store partway through, so it hands the rest of the parameter list to an async block and returns something not yet finished.

**Type checking answers without waiting.** `tryUnifySync` and friends return directly for scalars, type variables and containers. Containers matter most: a `List<Int>` argument is the common case here, and covering it alone was 18% of all allocation. Anything needing a store lookup still takes the old path, as does any failure, since building the error message needs the store anyway.

**No change to gradual typing.** Every check that ran before still runs and raises the same error; nested container type errors render identically. This removes plumbing, not checking. A differential test crosses 4 symbol tables, 20 type references and 15 values, and asserts the fast path either declines or agrees exactly, never disagrees, and never accepts what the slow path rejects.

**Per-function work is computed once.** A function's type variables were recomputed on every call. They can't change while the process runs, so they're cached, which also means a function with no type variables skips inference entirely.

**A frame records its instructions and return type when it's pushed**, instead of the loop looking them up on every iteration and re-fetching the whole function on every return.

**Eighteen of twenty-three opcodes never wait**, so they now run in a plain loop outside the async block.

**Seven functions moved from Dark to F#.** `List.push`, `pushBack`, `reverse`, `flatten`, `getAt`, and the TUI's `wrapStyled` and `positionAfter` had working Dark implementations; they're builtins now. Each runs per element or per keystroke, and an interpreted call costs a frame push and several KB however small its body. `reverse` is the clearest case: `map` and `filter` both end in one, so every list the stdlib builds paid for a Dark-level reverse, itself a Dark-level `push` per element.

This cuts against the usual direction, so the bar was narrow: small, total, no interesting behaviour of its own, on a per-element path. `map` and `filter` stay in Dark despite being hotter, because they call user code and that's worth keeping visible. Each moved function keeps its Dark wrapper, so names still resolve to package fns and tracing still records the call. The risk is a reimplementation drifting from the original, which isn't hypothetical: I got `getAt` wrong first time and caught it in review, not in a test. Hence the tests aimed at exactly that.

**Smaller wins**, each measured: struct frame parent links, nested matches instead of matching on a tuple (which allocates the pair), lockstep list walks instead of zip-and-project, cached scalar `ValueType`s, single-pass register reads, and a per-VM frame counter instead of a fresh GUID.

## Work that wasn't needed at all

Things the CLI did on every command whose results were thrown away.

**Tracing off now means off.** The collecting hooks were installed regardless of the setting, so with tracing off the CLI still built an event per frame, held every argument and result alive, and discarded all of it at the end.

**Traces cap at 10,000 events** (`DARK_CONFIG_TRACE_MAX_EVENTS`, 0 = unlimited), with a marker naming the dropped count. The cap reserves a slot for every frame still on the stack, because events are recorded on completion and so arrive innermost-first; a naive cap keeps the leaves and drops the entry point, leaving the viewer nothing to walk down from.

**The console printer no longer sleeps holding its lock**, worth ~110 ms off every command. It held the lock for essentially the whole millisecond of every idle iteration, and callers waiting on it kept losing the race.

**Tiered PGO is off for the CLI.** It profiles slow code to optimize the fast version later, and a one-second command exits before that pays off. Scoped to the CLI, not global, since `serve` is exactly what PGO is for; checked serve still behaves.

**SQLite work starts on the calling thread** rather than being handed to the thread pool, worth about 30 ms on every command, measured back to back. This changes the scheduling of every query in the process, so it's called out rather than buried; nothing in the CLI or in ASP.NET Core relies on the old behaviour.

**Fewer whole definitions loaded just to read names.** `ls`, `tree` and `view` now use name-only searches. A cache hit no longer enters the async builder either. The command registry is built once instead of three times.

**Completion caches on context, not prompt text.** Typing "Sta" one key at a time is three prompt strings but one context, so the database work runs once per word instead of once per character.

## Seeing the parsed and lowered forms of a package item

`view --ast` shows the tree the parser built; `view --instructions` shows what that tree is lowered to, which is what the interpreter actually walks. Neither was visible before. Flags work in either position.

```bash
$ dark view Darklang.Stdlib.List.last --ast

/Darklang.Stdlib.List.last (fn)

last<'a> (list: List<'a>) -> Stdlib.Option.Option<'a>
Match on Arg #0, 2 cases
  case []
    Enum Stdlib.Option.Option.None
  case head :: tail
    Match on Variable tail, 2 cases
      case []
        Enum Stdlib.Option.Option.Some
          Variable head
      case _
        Apply
          Self
          Variable tail
```

```bash
$ dark view Darklang.Stdlib.List.last --instructions

/Darklang.Stdlib.List.last (fn)

  18 instructions, 8 registers, result in r1

     0  CheckMatchPattern r0 ~ []  else -> 4
     1  CreateEnum        r2 <- Darklang.Stdlib.Option.Option.None()
     2  CopyVal           r1 <- r2
     3  JumpBy            +14 -> 18
     4  CheckMatchPattern r0 ~ r2 :: r3  else -> 17
     5  CheckMatchPattern r3 ~ []  else -> 9
     6  CreateEnum        r5 <- Darklang.Stdlib.Option.Option.Some(r2)
     7  CopyVal           r4 <- r5
     8  JumpBy            +6 -> 15
     9  CheckMatchPattern r3 ~ r5  else -> 14
    10  LoadVal           r6 <- &Darklang.Stdlib.List.last
    11  Apply             r7 <- r6(r3)
    12  CopyVal           r4 <- r7
    13  JumpBy            +1 -> 15
    14  MatchUnmatched    r3
    15  CopyVal           r1 <- r4
    16  JumpBy            +1 -> 18
    17  MatchUnmatched    r0
```

Lambdas get their own section rather than being inlined, and jumps show their absolute target because a relative offset is unreadable in a listing. Both renderers are written in Dark; the F# side only hands over the data.

## Measuring, testing, tooling

**Per-opcode and per-call-stage allocation counters**, plus per-builtin timing. These, not the sampling profiler, are what found the async plumbing: they accounted for 170 MB of 601 in named regions, which meant the rest was in the gaps between them. All SQL is counted and timed now too, and startup is broken into named phases. Telemetry is off unless `DARK_TELEMETRY=1`, which also gates per-instruction counting in the hot loop.

**Tests** for both new views, for the native list rewrites (out-of-bounds and negative indices, empty and nested-empty lists), and for calls with explicit type arguments, which take a different path and had nothing covering them. Run with `run-cli eval "Darklang.Cli.Tests.runAllTests ()"`.

**The `CliTraces` suite runs again.** It was commented out of the default run as too slow; it now costs about 5 seconds, plausibly because of the tracing fixes above, so 39 tests that were dead are live again. One is new: a trace that exceeds the event cap must still render its root, which is the bug the stack reservation exists to prevent and which nothing was checking.

`scripts/testing/perf-bench` runs interleaved A/B comparisons from an identical store fixture and refuses to record a datapoint taken while the box is loaded. `rundir/perf-workloads/measure` reports allocation and time together for a single change. Nothing runs either automatically, so this is one careless commit from regressing silently.

## Bugs found along the way

**Telemetry**: an int64 overflow after a couple of hours of uptime that made some spans report wildly wrong durations, ticks reported as microseconds, the interactive loop timing the wrong thing, and `cli.total` starting late so a slice of every command went unmeasured.

**The package-ref hash generator dropped refs**, so regenerating at the wrong moment wrote a short file and the next build failed at startup with `PackageRefs: hash not found`. It now keeps what the file already knew, and the error names its own fix.

**`search` and the dependents query had no `ORDER BY`**, so results reshuffled whenever the package set changed.

**`FnNameCache` didn't cache misses**, so a hash with no name re-queried on every reference. Failures are still not cached, so a briefly-locked store doesn't permanently degrade a process.

## Follow-ups

**The type symbol table holds at most two entries but is an `FSharpMap`**, which is three objects even when tiny. Still ~8% of allocation. A struct with empty and single-entry cases takes nearly all of that; ~80 sites, all caught by the F# compiler. Highest-confidence remaining win.

**`Ply`, our async library, is the root cause of the plumbing above.** Two ways out: move everything to F#'s built-in `task`, which is multi-week and touches every builtin signature; or rewrite just `Ply`'s internals to use F#'s newer machinery, about a week and invisible to callers. I'd do neither yet. Before this PR it was worth ~50% of interpreter allocation; with both call paths out, it's single digits. Revisit if a profile disagrees.

**Take the interpreter loop itself out of its async block.** Same reasoning, no longer the biggest number. We're well placed for it when it's worth doing, since the VM already tracks its own stack and program counter.

**Compile-time type checking.** Removing runtime checks entirely measured about -20% allocation, but this PR already took a bite out of the plumbing around them, so the remaining prize is smaller. It can only ever be partly moved: a REPL still has to decide at runtime that a value is a list of ints and reject a string in it.

**NativeAOT.** Already works: 4.3-7.1x against today's Release build, smaller binary. Blocked on per-OS CI runners, not on anything technical. This is the lever for one-shot command latency, which allocation work doesn't touch, since startup is runtime init rather than interpretation.

**Type names print ambiguously for structurally identical types.** `Uuid.ParseError` and `Float.ParseError` are one type with two names, and a value carries only the hash, so the printer picks arbitrarily. Affects 6% of types. Ordering is fixed here; name selection deliberately isn't, since it's a design decision about where a name lives.
