### PR TITLE
Ship the real package-ref hashes, and test the artifact like a user

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -341,6 +341,16 @@ jobs:
           root: "."
           paths:
             - rundir/seed.db
+            # Hand over the hash file too, not just the seed.
+            #
+            # `reload-packages` above populates it, but it is gitignored, so the
+            # build jobs' own checkout has only the empty one MSBuild creates.
+            # They then embed THAT, and every ref in the shipped binary resolves
+            # to "" -> `FnNotFound` on every command. It goes unnoticed inside a
+            # source tree, because there the file on disk wins over the embedded
+            # copy and the first run regenerates it. A user running the artifact
+            # anywhere else has only the embedded copy.
+            - backend/src/LibExecution/package-ref-hashes.txt
 
   # All four linux artifacts from one x64 runner. The cross-compiles work
   # because the release image supplies clang and cross sysroots; the stock

--- a/scripts/testing/validate-cli-artifact
+++ b/scripts/testing/validate-cli-artifact
@@ -152,6 +152,33 @@ check "ls a module"    ""    ls Darklang.Stdlib.List
 # absent from every other check here.
 check "version check"  ""    version --check
 
+# Run it the way a user does: from outside the checkout entirely.
+#
+# Everything above runs the artifact from within the source tree, and that hides
+# a whole class of bug. `PackageRefs` prefers `package-ref-hashes.txt` from the
+# tree it was COMPILED in, and falls back to the embedded copy only when that
+# path is missing. So inside the checkout a wrong or empty embedded copy is
+# invisible: the on-disk file wins, and the first run regenerates it anyway.
+#
+# That is not academic. The first tagged release shipped with an empty embedded
+# hash file and failed with `FnNotFound` on every command, while passing every
+# check above.
+echo ""
+echo "Outside the source tree (what a user actually gets):"
+
+OUTSIDE=$(mktemp -d /tmp/dark-artifact-outside.XXXXXX)
+cp "$ARTIFACT" "$OUTSIDE/dark"
+outside_rc=0
+outside_out=$( cd "$OUTSIDE" && HOME="$OUTSIDE" ./dark eval "1 + 2" 2>&1 ) || outside_rc=$?
+if [[ $outside_rc -ne 0 || "$outside_out" != *"3"* ]]; then
+  echo "  FAIL eval outside the checkout (exit $outside_rc)"
+  echo "$outside_out" | tail -15 | indent
+  failures=$((failures + 1))
+else
+  echo "  ok   eval outside the checkout"
+fi
+rm -rf "$OUTSIDE"
+
 echo ""
 echo "Dark CLI test suite:"
 


### PR DESCRIPTION
v0.0.33 was broken: every command failed with `FnNotFound`, on every platform.

seed-db runs reload-packages, which populates package-ref-hashes.txt, but it persisted only rundir/seed.db. The build jobs check out fresh, where that file is gitignored and MSBuild creates it empty, and embedded that. Every ref in the shipped binary resolved to "". It now travels with the seed.

CI could not have caught this. The validator ran the artifact from inside the checkout, where PackageRefs prefers the on-disk file from the tree it was compiled in and the first run regenerates it anyway. That is the one environment where an empty embedded copy is invisible; a user has only the embedded copy. So the validator now also runs the artifact from outside the tree entirely.

Verified both ways: a build with the hashes present passes every check including the new one, and the binary from the broken release fails it.