### PR TITLE
Reduce Builtin usages to one-package-fn-per-builtin

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -179,6 +179,15 @@ Dark-side code formats for display. Don't build `"superseded-by:<hash>"` in F# f
 caller to parse; return the `DeprecationKind` enum. F#-side stringify is only right when
 the value genuinely has no Dark-side type, which is rare.
 
+Then wrap it, once. `tests/builtin` asserts both halves of that: a builtin with two or
+more `Builtin.x` references anywhere in `packages/` fails, and so does one with no Dark
+caller anywhere in the repo. So give each builtin exactly one Dark wrapper -- a stdlib
+or CLI fn that names it, types it and documents it -- and route callers through the
+wrapper. The wrapper is where the raw builtin's `List<'a>` becomes `List<TraceSummary>`.
+The allowlists in `backend/tests/Tests/Builtin.Tests.fs` are for cases that genuinely
+can't work that way; they're down to one entry each, so adding a third needs a reason
+written next to it.
+
 ## Adding a CLI command (Darklang)
 
 1. `packages/darklang/cli/<name>.dark`

--- a/backend/tests/TestUtils/LibTest.fs
+++ b/backend/tests/TestUtils/LibTest.fs
@@ -16,13 +16,6 @@ module Dval = LibExecution.Dval
 module PT2RT = LibExecution.ProgramTypesToRuntimeTypes
 module PackageRefs = LibExecution.PackageRefs
 
-open Fumble
-open LibDB.Sqlite
-
-
-let varA = TVariable "a"
-let varB = TVariable "b"
-
 
 let values : List<BuiltInValue> =
   [ { name = value "testNan" 0
@@ -112,47 +105,6 @@ let fns () : List<BuiltInFn> =
       fn =
         (function
         | state, _, _, [| DUnit |] -> Ply(Dval.int64 state.test.sideEffectCount)
-        | _ -> incorrectArgs ())
-      sqlSpec = NotQueryable
-      previewable = Pure
-      capabilities = LibExecution.Capabilities.noCaps
-      deprecated = NotDeprecated }
-
-
-    { name = fn "testInspect" 0
-      typeParams = []
-      parameters = [ Param.make "var" varA ""; Param.make "msg" TString "" ]
-      returnType = varA
-      description = "Prints the value into stdout"
-      fn =
-        (function
-        | _, _, _, [| v; DString msg |] ->
-          print $"{msg}: {v}"
-          Ply v
-        | _ -> incorrectArgs ())
-      sqlSpec = NotQueryable
-      previewable = Pure
-      capabilities = LibExecution.Capabilities.noCaps
-      deprecated = NotDeprecated }
-
-
-    { name = fn "testDeleteUser" 0
-      typeParams = []
-      parameters = [ Param.make "username" TString "" ]
-      returnType = TypeReference.result TUnit varB
-      description = "Delete a user (test only)"
-      fn =
-        (function
-        | _, _, _, [| DString username |] ->
-          uply {
-            do!
-              // This is unsafe. A user has canvases, and canvases have traces. It
-              // will either break or cascade (haven't checked)
-              Sql.query "DELETE FROM accounts_v0 WHERE username = @username"
-              |> Sql.parameters [ "username", Sql.string (string username) ]
-              |> Sql.executeStatementAsync
-            return DUnit
-          }
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable
       previewable = Pure

--- a/backend/tests/Tests/Builtin.Tests.fs
+++ b/backend/tests/Tests/Builtin.Tests.fs
@@ -19,13 +19,21 @@ module Exe = LibExecution.Execution
 open TestUtils.TestUtils
 
 
+/// Every builtin library a running `darklang` has. `localBuiltIns` is the set
+/// the tests execute with, which leaves out CliHost -- `dark eval`, script
+/// running, the CLI's own entry points -- so the checks below would otherwise
+/// ignore that whole library.
+let private allBuiltinSets () : List<RT.Builtins> =
+  [ localBuiltIns PT.PackageManager.empty; Builtins.CliHost.Builtin.builtins () ]
+
+
 let oldFunctionsAreDeprecated =
   let builtinToString (name : RT.FQFnName.Builtin) = $"{name.name}_v{name.version}"
 
   testTask "old functions are deprecated" {
     let mutable counts = Map.empty
 
-    let fns = (localBuiltIns PT.PackageManager.empty).fns.Values |> List.ofSeq
+    let fns = allBuiltinSets () |> List.collect (fun b -> b.fns.Values |> List.ofSeq)
 
     fns
     |> List.iter (fun fn ->
@@ -47,15 +55,26 @@ let oldFunctionsAreDeprecated =
   }
 
 
+/// The name of every builtin a running `darklang` can call -- fns and values
+/// alike, since `Builtin.x` is how Dark reaches both.
+let private allBuiltinNames () : List<string> =
+  allBuiltinSets ()
+  |> List.collect (fun builtins ->
+    let fnNames = builtins.fns.Values |> Seq.map (fun fn -> fn.name.name)
+    let valueNames = builtins.values.Values |> Seq.map (fun v -> v.name.name)
+    Seq.append fnNames valueNames |> List.ofSeq)
+  |> List.distinct
+
+
 // -- Builtin access in package matter --
 //
 // Walk every .dark under packages/ and count textual references to
 // `Builtin.<name>` (or `Builtin.<name>_v<digits>`) for every registered
-// builtin fn. Anything with >1 textual reference must appear in the
-// allowlist below.
+// builtin. Anything with >1 textual reference must appear in the allowlist
+// below.
 //
-// A builtin should normally have one package wrapper. The allowlist names
-// the cases where direct multi-use is intentional.
+// A builtin should have one package wrapper, and callers should go through
+// it. The allowlist names the cases where direct multi-use is intentional.
 //
 // Infix-dispatched builtins (`+`, `==`, etc.) are dispatched through
 // operator syntax, so they have no textual `Builtin.X` references.
@@ -83,110 +102,29 @@ let private infixDispatched : Set<string> =
 
 
 /// Builtins intentionally referenced from more than one place in `packages/`.
-/// Add a short comment for each group. Keep alphabetical within each group.
-///
-/// TODO continue routing direct `Builtin.X` callers through stdlib
-/// wrappers in batches and shrink this list. Finished: delete unused,
-/// int conversions/ops, json/blob/string codecs. Remaining: CLI/IO,
-/// Posix, package-manager browsing, traces, streams, and misc runtime
-/// entry points. Route each caller through a wrapper unless direct builtin
-/// access is required.
+/// Everything else routes through a single Dark wrapper; when a builtin picks
+/// up a second caller, wrap it rather than adding it here. An entry needs a
+/// comment saying why a wrapper is the wrong answer for that one.
 let private multiUseAllowlist : Set<string> =
   Set.ofList
-    [ // `Stdlib.String.contains` and `Stdlib.String.indexOf` both call the
-      // builtin directly. `contains` stays direct because the SQL compiler
-      // maps the builtin to SQLite INSTR; the Option-returning wrapper is
-      // not queryable.
-      "stringIndexOf"
-
-      // Structured parse diagnostics used by CLI package creation,
-      // CLI-script parsing, and LSP diagnostics.
-      "parserParseDiagnostics"
-
-      // CLI / IO surface called by many CLI commands.
-      "debug"
-      "directoryCurrent"
-      "directoryList"
-      "environmentGet"
-      "fileAppendText"
-      "fileDelete"
-      "fileExists"
-      "fileIsDirectory"
-      "fileRead"
-      "fileWrite"
-      "getCurrentExecutablePath"
-      "print"
-      "printLine"
-      "stdinReadAll"
-      "stdinReadLine"
-      "timeSleep"
-      "toRepr"
-      "unwrap"
-
-      // Posix wrappers (file descriptor primitives).
-      "posixFdClose"
-      "posixFdWrite"
-      "posixReadlink"
-      "posixUname"
-
-      // Package manager browsing used by CLI, LSP, and agent code.
-      "dbListAll"
-      "depsGetDependents"
-      "getAllBuiltinFns"
-      "pmFindFn"
-      "pmFindType"
-      "pmFindValue"
-      "pmGetFn"
-      "pmGetLocationsByFn"
-      "pmGetLocationsByType"
-      "pmGetLocationsByValue"
-      "pmGetType"
-      "pmGetValue"
-      "pmScriptsGet"
-      "pmScriptsList"
-      "pmScriptsUpdate"
-      "pmSearch"
-
-      // HTTP server entry called by the `dark serve` wrapper.
-      "httpServerServe"
-
-      // Streams (CLI / agent / scripts use them directly).
-      "streamClose"
-      "streamFilter"
-      "streamMap"
-      "streamNext"
-      "streamToBlob"
-      "streamToList"
-      "streamUnfold"
-
-      // Trace surface read by CLI commands and LSP.
-      "tracesFind"
-      "tracesHotspots"
-      "tracesList"
-      "tracesStatsByHandler"
-
-      // Parser entry point used by CLI syntax highlighting, package display,
-      // LSP, and CLI-script parsing.
-      "parserParseToWrittenTypes"
-
-      // Sync conflict-review surface: the recorded-divergence log, read by the
-      // `dark conflicts` review UI and by the `dark sync` pull nudge (which
-      // counts unreviewed conflicts so last-writer-wins is never silent).
-      "conflictsList"
-
-      // Misc.
-      "interpreterStatsReset" ]
+    [ // The unwrap idiom, in 60-odd places across packages/. A generic Dark
+      // wrapper does work -- `let unwrap (value: 'optOrRes) : 'a` typechecks
+      // for both Option and Result -- but it costs a package call at every
+      // unwrap and puts itself at the bottom of every unwrap failure's call
+      // stack, one frame below the code that actually had the None.
+      "unwrap" ]
 
 
-/// Find packages/ by walking up from CWD until we hit one with darklang/.
-let private findPackagesDir () : string =
+/// Find the repo root by walking up from CWD until we hit one with
+/// packages/darklang/.
+let private findRepoRoot () : string =
   let rec walk (dir : string) : string option =
     if System.String.IsNullOrEmpty dir then
       None
     else
       let candidate = Path.Combine(dir, "packages", "darklang")
       if Directory.Exists candidate then
-        Some(Path.Combine(dir, "packages"))
+        Some dir
       else
         walk (Path.GetDirectoryName dir)
 
@@ -198,6 +136,20 @@ let private findPackagesDir () : string =
       [ "cwd", Directory.GetCurrentDirectory() ]
 
 
+/// Read every .dark file under <root>, minus whole-line comments, as one string.
+/// Build output is skipped: it holds copies of files we've already read.
+let private darkTextUnder (root : string) : string =
+  Directory.EnumerateFiles(root, "*.dark", SearchOption.AllDirectories)
+  |> Seq.filter (fun path ->
+    let sep = Path.DirectorySeparatorChar
+    not (path.Contains $"{sep}Build{sep}"))
+  |> Seq.map File.ReadAllText
+  |> String.concat "\n"
+  |> String.splitOnNewline
+  |> List.filter (fun line -> not ((line.TrimStart()).StartsWith "//"))
+  |> String.concat "\n"
+
+
 /// Concatenate every .dark file under packages/ into one string, minus whole-line
 /// comments. Cached.
 ///
@@ -207,34 +159,33 @@ let private findPackagesDir () : string =
 /// entirely a comment are dropped, so a `//` inside a string literal can't swallow
 /// real code after it on the same line.
 let private packagesText : Lazy<string> =
-  lazy
-    (let root = findPackagesDir ()
-     Directory.EnumerateFiles(root, "*.dark", SearchOption.AllDirectories)
-     |> Seq.map File.ReadAllText
-     |> String.concat "\n"
-     |> String.splitOnNewline
-     |> List.filter (fun line -> not ((line.TrimStart()).StartsWith "//"))
-     |> String.concat "\n")
+  lazy (darkTextUnder (Path.Combine(findRepoRoot (), "packages")))
+
+
+/// Every .dark file in the repo, minus whole-line comments. Wider than
+/// `packagesText`: it also covers test files, perf workloads and sample
+/// scripts, which is the difference between "shipped once" and "dead".
+let private repoDarkText : Lazy<string> = lazy (darkTextUnder (findRepoRoot ()))
 
 
 /// Count textual references to `Builtin.<name>` (or `Builtin.<name>_v<n>`)
 /// across packages/. The `(?![a-zA-Z0-9_])` lookahead prevents matching
 /// `Builtin.dictGet` against the prefix of `Builtin.dictGetItem`.
-let private countReferences (builtinName : string) : int =
+let private countReferencesIn (corpus : string) (builtinName : string) : int =
   let escaped = Regex.Escape builtinName
   let pattern = $@"Builtin\.{escaped}(?:_v[0-9]+)?(?![a-zA-Z0-9_])"
   let regex = Regex(pattern, RegexOptions.Compiled)
-  regex.Matches(packagesText.Value).Count
+  regex.Matches(corpus).Count
+
+let private countReferences (builtinName : string) : int =
+  countReferencesIn packagesText.Value builtinName
 
 
 let builtinAccessInPackageMatter =
   testTask "builtin access in package matter" {
-    let fns = (localBuiltIns PT.PackageManager.empty).fns.Values |> List.ofSeq
-
     let offenders =
-      fns
-      |> Seq.choose (fun fn ->
-        let name = fn.name.name
+      allBuiltinNames ()
+      |> Seq.choose (fun name ->
         if Set.contains name multiUseAllowlist then
           None
         elif Set.contains name infixDispatched then
@@ -254,12 +205,59 @@ let builtinAccessInPackageMatter =
         false
         ("Some builtins are referenced from more than one place in packages/:\n"
          + lines
-         + "\n\nPrefer wrapping the builtin in a single Dark package fn (e.g. a Stdlib/Cli helper) and routing "
-         + "all callers through it, so the builtin is referenced once. Only add to `multiUseAllowlist` as a "
-         + "last resort, when direct builtin access from several places is genuinely required (e.g. the SQL "
-         + "compiler needs the raw builtin). The goal is to shrink that list, not grow it.")
+         + "\n\nWrap the builtin in one Dark package fn -- a Stdlib or Cli helper that names it, types it "
+         + "and documents it -- and route the callers through that. `multiUseAllowlist` is for the cases "
+         + "where a wrapper is the wrong answer, and it is down to one entry; a new one needs its reason "
+         + "written next to it.")
+  }
+
+
+// -- Unused builtins --
+//
+// The mirror of the test above: a builtin nothing calls is dead F# we keep
+// compiling, serializing and documenting. Every registered builtin should be
+// reachable from Dark somewhere in the repo -- packages/, test files, perf
+// workloads or sample scripts.
+
+/// Builtins with no Dark caller anywhere, kept deliberately.
+/// Each one needs a reason; without one, delete the builtin instead.
+let private unusedAllowlist : Set<string> =
+  Set.ofList
+    [ // Test-harness escape hatch for the cases that expect an exception to
+      // reach the reporter. The harness still reads the count it sets; the
+      // testfile cases that set it are currently commented out.
+      "testSetExpectedExceptionCount" ]
+
+
+let everyBuiltinIsReferenced =
+  testTask "every builtin is referenced from Dark" {
+    let unused =
+      allBuiltinNames ()
+      |> Seq.filter (fun name ->
+        not (Set.contains name unusedAllowlist)
+        && not (Set.contains name infixDispatched)
+        && countReferencesIn repoDarkText.Value name = 0)
+      |> List.ofSeq
+
+    if not (List.isEmpty unused) then
+      let lines =
+        unused
+        |> List.sort
+        |> List.map (fun name -> $"  {name}")
+        |> String.concat "\n"
+      Expect.isTrue
+        false
+        ("Some builtins have no Dark caller anywhere in the repo:\n"
+         + lines
+         + "\n\nDelete the builtin, or wire it up (a package wrapper, a test file, a perf workload). "
+         + "Add to `unusedAllowlist` only with a reason -- an uncalled builtin is dead weight in every "
+         + "build and every serialized package.")
   }
 
 
 let tests =
-  testList "builtin" [ oldFunctionsAreDeprecated; builtinAccessInPackageMatter ]
+  testList
+    "builtin"
+    [ oldFunctionsAreDeprecated
+      builtinAccessInPackageMatter
+      everyBuiltinIsReferenced ]

--- a/packages/darklang/cli/ai/agent.dark
+++ b/packages/darklang/cli/ai/agent.dark
@@ -141,13 +141,15 @@ let hasUnsafeChars (input: String) : Bool =
   Stdlib.String.contains input "$" || Stdlib.String.contains input "`"
 
 val findCliExecutable =
-  if Builtin.fileExists "./scripts/run-cli" then Stdlib.Option.Option.Some "./scripts/run-cli"
-  else if Stdlib.Cli.Unix.isCommandAvailable "dark" then Stdlib.Option.Option.Some "dark"
+  if Stdlib.Cli.FileSystem.pathExists "./scripts/run-cli" then
+    Stdlib.Option.Option.Some "./scripts/run-cli"
+  else if Stdlib.Cli.Unix.isCommandAvailable "dark" then
+    Stdlib.Option.Option.Some "dark"
   else Stdlib.Option.Option.None
 
 let confirmCommand (cmd: String) : Bool =
   Stdlib.print (Colors.warning $"Allow: {cmd}? (y/n): ")
-  let response = Stdlib.String.trim (Builtin.stdinReadLine ())
+  let response = Stdlib.String.trim (Stdlib.Cli.Stdin.readLine ())
   response == "y" || response == "Y"
 
 let runCliCommand
@@ -305,7 +307,7 @@ let runInteractiveLoop
   (history: List<Darklang.LLM.Provider.Message>)
   : Unit =
   Stdlib.print (Colors.dimText "you> ")
-  let input = Stdlib.String.trim (Builtin.stdinReadLine ())
+  let input = Stdlib.String.trim (Stdlib.Cli.Stdin.readLine ())
 
   if Stdlib.String.isEmpty input then
     runInteractiveLoop agent history

--- a/packages/darklang/cli/builtins.dark
+++ b/packages/darklang/cli/builtins.dark
@@ -95,7 +95,7 @@ let sortGroups
 
 
 let execute (state: AppState) (args: List<String>): AppState =
-  let allBuiltins = Builtin.getAllBuiltinFns ()
+  let allBuiltins = LanguageTools.allBuiltinFns ()
 
   // Parse flags
   let withSigs = Stdlib.List.any args (fun arg -> arg == "--with-sigs")

--- a/packages/darklang/cli/config.dark
+++ b/packages/darklang/cli/config.dark
@@ -11,9 +11,9 @@ let configFilePath () : String =
 
 // Read config from disk
 let readConfig () : Dict<String> =
-  match Builtin.fileExists (configFilePath ()) with
+  match Stdlib.Cli.FileSystem.pathExists (configFilePath ()) with
   | true ->
-    match Builtin.fileRead (configFilePath ()) with
+    match Stdlib.Cli.FileSystem.readFile (configFilePath ()) with
     | Ok bytes ->
       let contents = Stdlib.String.fromBlobWithReplacement bytes
 
@@ -30,7 +30,7 @@ let readConfig () : Dict<String> =
 let writeConfig (config: Dict<String>) : Unit =
   let json = Stdlib.Json.serialize<Dict<String>> config
   let jsonBytes = Stdlib.String.toBlob json
-  let _ = Builtin.fileWrite jsonBytes (configFilePath ())
+  let _ = Stdlib.Cli.FileSystem.overwriteFile (configFilePath ()) jsonBytes
   ()
 
 

--- a/packages/darklang/cli/conflicts.dark
+++ b/packages/darklang/cli/conflicts.dark
@@ -82,14 +82,14 @@ let renderContent
   // and fell to "content unavailable", even though the item is right there. Exactly one pmGet* matches a given
   // hash, so trying all three (the itemKind param is now just a legacy hint) shows both sides every time.
   let rendered =
-    match Builtin.pmGetValue hash with
+    match LanguageTools.PackageManager.Value.get hash with
     | Some e ->
       Stdlib.Option.Option.Some(PrettyPrinter.ProgramTypes.packageValue ctx e)
     | None ->
-      match Builtin.pmGetFn hash with
+      match LanguageTools.PackageManager.Function.get hash with
       | Some e -> Stdlib.Option.Option.Some(PrettyPrinter.ProgramTypes.packageFn ctx e)
       | None ->
-        match Builtin.pmGetType hash with
+        match LanguageTools.PackageManager.Type.get hash with
         | Some e ->
           Stdlib.Option.Option.Some(PrettyPrinter.ProgramTypes.packageType ctx e)
         | None -> Stdlib.Option.Option.None

--- a/packages/darklang/cli/core.dark
+++ b/packages/darklang/cli/core.dark
@@ -114,7 +114,7 @@ let resolveStartingBranch () : Uuid =
   let mainId = SCM.Branch.mainBranchId
 
   let fromEnv =
-    match Builtin.environmentGet "DARK_BRANCH" with
+    match Stdlib.Env.get "DARK_BRANCH" with
     | Some name ->
       if Stdlib.String.isEmpty name then
         Stdlib.Option.Option.None
@@ -157,7 +157,8 @@ let initState () : AppState =
       cachedFilterItems = []
       allCommandsCache = commands
       commandOptionsCache = commandOptions commands
-      telemetryEnabled = (Builtin.environmentGet "DARK_TELEMETRY") == Stdlib.Option.Option.Some "1" }
+      telemetryEnabled =
+        (Stdlib.Env.get "DARK_TELEMETRY") == Stdlib.Option.Option.Some "1" }
 
 type Msg =
   | ProcessInput of String

--- a/packages/darklang/cli/deps.dark
+++ b/packages/darklang/cli/deps.dark
@@ -1,5 +1,21 @@
 module Darklang.Cli.Deps
 
+
+/// What depends on each of <param targets>: (hash, location, kind) per
+/// dependent. Approved items plus the caller's own pending ones.
+let getDependents
+  (branchId: Uuid)
+  (targets:
+    List<
+      (LanguageTools.ProgramTypes.PackageLocation *
+      LanguageTools.ProgramTypes.ItemKind)>)
+  : List<
+      (LanguageTools.ProgramTypes.Hash *
+      LanguageTools.ProgramTypes.PackageLocation *
+      LanguageTools.ProgramTypes.ItemKind)> =
+  Builtin.depsGetDependents branchId targets
+
+
 /// Resolve hashes to display names. Returns a Dict mapping hash string to name.
 let resolveNames
   (branchId: Uuid)
@@ -31,7 +47,7 @@ let showDependents
   (targetKind: LanguageTools.ProgramTypes.ItemKind)
   (entityName: String)
   : Unit =
-  let dependents = Builtin.depsGetDependents branchId [ (targetLoc, targetKind) ]
+  let dependents = getDependents branchId [ (targetLoc, targetKind) ]
 
   match dependents with
   | [] ->
@@ -71,7 +87,7 @@ let collectTransitiveDependents
     match toProcess with
     | [] -> accumulated
     | targets ->
-      let batchResults = Builtin.depsGetDependents branchId targets
+      let batchResults = getDependents branchId targets
 
       let newDeps =
         batchResults
@@ -171,19 +187,19 @@ let resolvePath
     | Module _ ->
       Stdlib.Result.Result.Error "Cannot show dependencies for a module, only for functions, types, or values"
     | Function fnLoc ->
-      match Builtin.pmFindFn branchId fnLoc with
+      match LanguageTools.PackageManager.Function.find branchId fnLoc with
       | Some hash ->
         let name = PrettyPrinter.ProgramTypes.PackageLocation.packageLocation fnLoc
         Stdlib.Result.Result.Ok((hash, fnLoc, name, LanguageTools.ProgramTypes.ItemKind.Fn))
       | None -> Stdlib.Result.Result.Error $"Function not found: {PrettyPrinter.ProgramTypes.PackageLocation.packageLocation fnLoc}"
     | Type typeLoc ->
-      match Builtin.pmFindType branchId typeLoc with
+      match LanguageTools.PackageManager.Type.find branchId typeLoc with
       | Some hash ->
         let name = PrettyPrinter.ProgramTypes.PackageLocation.packageLocation typeLoc
         Stdlib.Result.Result.Ok((hash, typeLoc, name, LanguageTools.ProgramTypes.ItemKind.Type))
       | None -> Stdlib.Result.Result.Error $"Type not found: {PrettyPrinter.ProgramTypes.PackageLocation.packageLocation typeLoc}"
     | Value valueLoc ->
-      match Builtin.pmFindValue branchId valueLoc with
+      match LanguageTools.PackageManager.Value.find branchId valueLoc with
       | Some hash ->
         let name = PrettyPrinter.ProgramTypes.PackageLocation.packageLocation valueLoc
         Stdlib.Result.Result.Ok((hash, valueLoc, name, LanguageTools.ProgramTypes.ItemKind.Value))

--- a/packages/darklang/cli/entry.dark
+++ b/packages/darklang/cli/entry.dark
@@ -60,7 +60,7 @@ let executeCliCommand (args: List<String>) : Int =
   | [] ->
     if initialState.telemetryEnabled then
       Telemetry.logSessionStart ()
-      let _ = Builtin.interpreterStatsReset ()
+      let _ = LanguageTools.InterpreterStats.reset ()
       ()
 
     // `dark` with no args opens the workbench — that's the experience now, no chooser. DARK_CLASSIC=1 is the
@@ -70,7 +70,7 @@ let executeCliCommand (args: List<String>) : Int =
     // No screen clear and no scroll region here any more: the prompt is an inline Tui region that keeps
     // scrollback, and the workbench owns the alternate screen through its own terminal session.
     let classic =
-      match Builtin.environmentGet "DARK_CLASSIC" with
+      match Stdlib.Env.get "DARK_CLASSIC" with
       | Some "1" -> true
       | _ -> false
 

--- a/packages/darklang/cli/execution/eval.dark
+++ b/packages/darklang/cli/execution/eval.dark
@@ -2,17 +2,30 @@
 module Darklang.Cli.Eval
 
 
+/// Evaluate `expr`, keeping the failure structured. `Ok (Some printed)` for a value, `Ok None` for
+/// something that printed nothing. The one call into the host evaluator - the db commands, the workbench
+/// loaders and trace replay all come through here; <fn evaluate> is this with the error rendered.
+let evaluateRaw
+  (accountID: Stdlib.Option.Option<Uuid>)
+  (branchId: Uuid)
+  (expr: String)
+  (allowHarmful: Bool)
+  : Stdlib.Result.Result<
+      Stdlib.Option.Option<String>,
+      ExecutionError.ExecutionError> =
+  Builtin.cliEvaluateExpression accountID branchId expr allowHarmful
+
+
 /// Evaluate `expr` and hand back what it produced: `Ok (Some printed)` for a value, `Ok None` for something
-/// that printed nothing, `Error message` for a failure. The one place the `eval`/REPL path reaches for
-/// `cliEvaluateExpression` (tracing and the db commands have their own call sites) - `execute` prints what
-/// this returns, and the workbench REPL keeps it as state. Takes the whole expression as one string, so a
-/// multi-line let-chain survives.
+/// that printed nothing, `Error message` for a failure. What the `eval`/REPL path uses - `execute` prints
+/// what this returns, and the workbench REPL keeps it as state. Takes the whole expression as one string,
+/// so a multi-line let-chain survives.
 let evaluate
   (state: AppState)
   (expr: String)
   (allowHarmful: Bool)
   : Stdlib.Result.Result<Stdlib.Option.Option<String>, String> =
-  match Builtin.cliEvaluateExpression state.accountID state.currentBranchId expr allowHarmful with
+  match evaluateRaw state.accountID state.currentBranchId expr allowHarmful with
   | Ok result -> Stdlib.Result.Result.Ok result
   | Error err ->
     Stdlib.Result.Result.Error(ExecutionError.toString state.currentBranchId err)
@@ -33,7 +46,7 @@ let execute (state: AppState) (args: List<String>) : AppState =
     // callers can pipe multi-line expressions via heredoc without quoting.
     let expr =
       match args with
-      | [ "-" ] -> Builtin.stdinReadAll ()
+      | [ "-" ] -> Stdlib.Cli.Stdin.readAll ()
       | parts -> Stdlib.String.join parts " "
     match evaluate state expr allowHarmful with
     | Ok (Some s) ->

--- a/packages/darklang/cli/execution/run.dark
+++ b/packages/darklang/cli/execution/run.dark
@@ -1,5 +1,31 @@
 module Darklang.Cli.Run
 
+
+/// Parse <param code> as a script and run it, returning its exit code. The one
+/// call into the host's script runner: `run <path>` and `scripts run <name>`
+/// both come through here.
+///
+/// <param sandbox> runs the body with no capabilities at all, for code you
+/// don't trust; otherwise it runs under the host's configured grant.
+let parseAndExecute
+  (accountID: Stdlib.Option.Option<Uuid>)
+  (branchId: Uuid)
+  (filename: String)
+  (code: String)
+  (args: List<String>)
+  (allowHarmful: Bool)
+  (sandbox: Bool)
+  : Stdlib.Result.Result<Int, ExecutionError.ExecutionError> =
+  Builtin.cliParseAndExecuteScript
+    accountID
+    branchId
+    filename
+    code
+    args
+    allowHarmful
+    sandbox
+
+
 // `run-script <path> [args...]` — execute a Dark script file.
 //
 // For calling package fns, use `eval` instead.
@@ -40,7 +66,7 @@ let executeScript
   (allowHarmful: Bool)
   (sandbox: Bool)
   : AppState =
-  match Builtin.fileRead scriptPath with
+  match Stdlib.Cli.FileSystem.readFile scriptPath with
   | Error e ->
     match e with
     | NotFound ->
@@ -59,7 +85,7 @@ let executeScript
   | Ok script ->
     let scriptSourceCode = Stdlib.String.fromBlobWithReplacement script
     let result =
-      Builtin.cliParseAndExecuteScript
+      parseAndExecute
         state.accountID
         state.currentBranchId
         scriptPath
@@ -85,7 +111,7 @@ let complete (_state: AppState) (args: List<String>) : List<Completion.Completio
   match args with
   | [] ->
     let files = Stdlib.Cli.FileSystem.getDirectoryContents "."
-    let currentDir = Builtin.directoryCurrent ()
+    let currentDir = Stdlib.Cli.FileSystem.currentDirectory ()
 
     let directories =
       files

--- a/packages/darklang/cli/http/serve.dark
+++ b/packages/darklang/cli/http/serve.dark
@@ -108,7 +108,7 @@ let execute (state: Cli.AppState) (args: List<String>) : Cli.AppState =
           // In the dev container the host reaches this port on a per-clone offset, set as
           // DARK_HOST_PORT_BASE at startup. Unset outside it, so there's nothing to add.
           let hostLines =
-            match Builtin.environmentGet "DARK_HOST_PORT_BASE" with
+            match Stdlib.Env.get "DARK_HOST_PORT_BASE" with
             | None -> []
             | Some baseStr ->
               match Stdlib.Int.parse baseStr with

--- a/packages/darklang/cli/installation/README.md
+++ b/packages/darklang/cli/installation/README.md
@@ -40,7 +40,7 @@ To run the CLI executable against the local package manager:
           | Ok Linux | Ok MacOS -> "$HOME/.darklang/config.json"
 
 
-        if Stdlib.Bool.not (Builtin.fileExists configPath) then
+        if Stdlib.Bool.not (Stdlib.Cli.FileSystem.pathExists configPath) then
           Stdlib.Result.Result.Ok()
         // don't update _too_ often
         else if hasUpdatedInLastDay configPath then

--- a/packages/darklang/cli/installation/config.dark
+++ b/packages/darklang/cli/installation/config.dark
@@ -9,7 +9,7 @@ val defaultConfig =
 
 // TODO: typify the error messages
 let read (configPath: String) : Stdlib.Result.Result<Dict<String>, String> =
-  match Builtin.fileRead configPath with
+  match Stdlib.Cli.FileSystem.readFile configPath with
   | Ok content ->
     content
     |> Stdlib.String.fromBlobWithReplacement
@@ -42,7 +42,7 @@ let updateVersion
     |> Stdlib.Json.serialize<Dict<String>>
     |> Stdlib.String.toBlob
 
-  match Builtin.fileWrite serializedConfig configPath with
+  match Stdlib.Cli.FileSystem.overwriteFile configPath serializedConfig with
   | Ok _ -> Stdlib.Result.Result.Ok()
   | Error err -> Stdlib.Result.Result.Error "Failed to update config.json"
 

--- a/packages/darklang/cli/installation/install.dark
+++ b/packages/darklang/cli/installation/install.dark
@@ -38,7 +38,7 @@ let execute (state: AppState) (args: List<String>) : AppState =
       state
 
   | Portable ->
-    let currentDir = Builtin.directoryCurrent ()
+    let currentDir = Stdlib.Cli.FileSystem.currentDirectory ()
 
     if Installation.System.globalInstallationExists host then
       if uninstallFirst then
@@ -71,7 +71,7 @@ let execute (state: AppState) (args: List<String>) : AppState =
           Stdlib.printLine "1. Copy this binary (for testing local changes)"
           Stdlib.printLine "2. Download latest release from GitHub"
           Stdlib.printLine "Choose option (1 or 2): "
-          (Builtin.stdinReadLine ()) |> Stdlib.String.trim
+          (Stdlib.Cli.Stdin.readLine ()) |> Stdlib.String.trim
 
       if choice == "1" then
         match Installation.System.installFromCurrentBinary host autoConfirm with

--- a/packages/darklang/cli/installation/status.dark
+++ b/packages/darklang/cli/installation/status.dark
@@ -13,7 +13,7 @@ let execute (state: AppState) (args: List<String>) : AppState =
       let homeDir = Config.getDarklangHomeDir host
       Colors.success "Status: " ++ "Globally installed at " ++ homeDir ++ " and ready to use"
     | Portable ->
-      let currentDir = Builtin.directoryCurrent ()
+      let currentDir = Stdlib.Cli.FileSystem.currentDirectory ()
       Colors.warning "Status: " ++ "Running in portable mode at " ++ currentDir ++ "/.darklang (run 'install' for global system-wide access)"
 
   let statusText =

--- a/packages/darklang/cli/installation/system.dark
+++ b/packages/darklang/cli/installation/system.dark
@@ -21,7 +21,7 @@ let installationModeToString (mode: InstallationMode) : String =
 
 /// Detect current CLI installation mode based on executable location
 let getInstallationMode () : InstallationMode =
-  let executablePath = Builtin.getCurrentExecutablePath ()
+  let executablePath = Stdlib.Cli.Sys.currentExecutablePath ()
   let host = (Stdlib.Cli.Host.getRuntimeHost ()) |> Builtin.unwrap
   let darklangHomeDir = Config.getDarklangHomeDir host
 
@@ -82,8 +82,8 @@ let globalInstallationExists (host: Stdlib.Cli.Host.Host) : Bool =
 /// Install CLI by copying the current binary (for development/testing)
 /// If autoConfirm is true, skips prompts and uses fresh database
 let installFromCurrentBinary (host: Stdlib.Cli.Host.Host) (autoConfirm: Bool) : Stdlib.Result.Result<String, String> =
-  let currentBinaryPath = Builtin.getCurrentExecutablePath ()
-  let currentDir = Builtin.directoryCurrent ()
+  let currentBinaryPath = Stdlib.Cli.Sys.currentExecutablePath ()
+  let currentDir = Stdlib.Cli.FileSystem.currentDirectory ()
   let portableDbPath = $"{currentDir}/.darklang/data.db"
 
   let darklangHomeDir = Config.getDarklangHomeDir host
@@ -144,7 +144,7 @@ let installFromCurrentBinary (host: Stdlib.Cli.Host.Host) (autoConfirm: Bool) : 
           "fresh"
         else
           Stdlib.printLine "Would you like to copy the data from this portable directory to the installation, or start fresh? (copy/fresh, default: fresh): "
-          (Builtin.stdinReadLine ()) |> Stdlib.String.trim
+          (Stdlib.Cli.Stdin.readLine ()) |> Stdlib.String.trim
 
       if migrateChoice == "copy" then
         if Stdlib.Cli.Unix.fileExists portableDbPath || Stdlib.Cli.PowerShell.fileExists portableDbPath then
@@ -162,7 +162,7 @@ let installFromCurrentBinary (host: Stdlib.Cli.Host.Host) (autoConfirm: Bool) : 
 /// Install CLI with option to migrate existing portable data
 /// If autoConfirm is true, skips prompts and uses fresh database
 let install (host: Stdlib.Cli.Host.Host) (autoConfirm: Bool) : Stdlib.Result.Result<String, String> =
-  let currentDir = Builtin.directoryCurrent ()
+  let currentDir = Stdlib.Cli.FileSystem.currentDirectory ()
   let portableDbPath = $"{currentDir}/.darklang/data.db"
 
   let choice =
@@ -174,7 +174,7 @@ let install (host: Stdlib.Cli.Host.Host) (autoConfirm: Bool) : Stdlib.Result.Res
       Stdlib.printLine "1. Fresh install (start with clean database)"
       Stdlib.printLine "2. Migrate current data to global installation"
       Stdlib.printLine "Choose option (1 or 2, default: 1): "
-      (Builtin.stdinReadLine ()) |> Stdlib.String.trim
+      (Stdlib.Cli.Stdin.readLine ()) |> Stdlib.String.trim
 
   match Download.installOrUpdateLatestRelease host with
   | Ok _ ->
@@ -202,7 +202,7 @@ let updateIfAvailable (currentVersion: String) (host: Stdlib.Cli.Host.Host) (aut
           Stdlib.printLine "You're currently running a locally-installed binary (from development)."
           Stdlib.printLine $"Latest official release is {latestVersion}."
           Stdlib.printLine "Update to the official release? (y/n): "
-          (Builtin.stdinReadLine ()) |> Stdlib.String.trim
+          (Stdlib.Cli.Stdin.readLine ()) |> Stdlib.String.trim
 
       if choice == "y" || choice == "Y" then
         match Download.installOrUpdateLatestRelease host with
@@ -231,7 +231,7 @@ let uninstallWithConfirmation (host: Stdlib.Cli.Host.Host) (autoConfirm: Bool) :
       "y"
     else
       Stdlib.printLine "Are you sure you want to uninstall the CLI? (y/n): "
-      Builtin.stdinReadLine ()
+      Stdlib.Cli.Stdin.readLine ()
 
   if response == "y" || response == "Y" then
     Stdlib.printLine "Uninstalling..."

--- a/packages/darklang/cli/installation/update.dark
+++ b/packages/darklang/cli/installation/update.dark
@@ -21,7 +21,7 @@ let execute (state: AppState) (args: List<String>) : AppState =
       Stdlib.printLine (View.formatError e)
       state
   | Portable ->
-    let message = $"Running in portable mode from {Builtin.directoryCurrent ()}/.darklang\n\nTo update this portable executable, please download the latest release manually from:\nhttps://github.com/darklang/dark/releases\n\nFor automatic updates, consider running 'install' to set up global installation."
+    let message = $"Running in portable mode from {Stdlib.Cli.FileSystem.currentDirectory ()}/.darklang\n\nTo update this portable executable, please download the latest release manually from:\nhttps://github.com/darklang/dark/releases\n\nFor automatic updates, consider running 'install' to set up global installation."
     Stdlib.printLine (View.formatSuccess message)
     state
 

--- a/packages/darklang/cli/loop.dark
+++ b/packages/darklang/cli/loop.dark
@@ -328,7 +328,7 @@ let runInteractiveLoop (state: AppState) : Int =
   else
     let tLoopStart = if state.telemetryEnabled then Telemetry.now () else 0
     if state.telemetryEnabled then
-      let _ = Builtin.interpreterStatsReset ()
+      let _ = LanguageTools.InterpreterStats.reset ()
       ()
 
     let location = locationStr state
@@ -478,7 +478,7 @@ let runInteractiveLoop (state: AppState) : Int =
         Telemetry.logWithContext "readKey" tReadKey [("char", keyInput.keyChar)]
         Telemetry.logWithContext "update" tUpdate [("char", keyInput.keyChar); ("repeats", Stdlib.Int.toString times)]
         let loopWorkMs = (Telemetry.elapsedMs tLoopStart) - (Telemetry.elapsedMs tReadKey)
-        let interpStats = Builtin.interpreterStatsGet ()
+        let interpStats = LanguageTools.InterpreterStats.get ()
         Telemetry.logWithContext "loopWork" tLoopStart [("workMs", Stdlib.Int.toString loopWorkMs); ("interp", interpStats)]
 
       runInteractiveLoop {

--- a/packages/darklang/cli/old_notes/_command.dark
+++ b/packages/darklang/cli/old_notes/_command.dark
@@ -153,7 +153,7 @@ module Command =
                     | Error _ -> "~/.darklang"
                 $"{Colors.green}Status:{Colors.reset} Globally installed at {homeDir} and ready to use"
               | Portable ->
-                let currentDir = Builtin.directoryCurrent ()
+                let currentDir = Stdlib.Cli.FileSystem.currentDirectory ()
                 $"{Colors.yellow}Status:{Colors.reset} Running in portable mode at {currentDir}/.darklang (run 'install' for global system-wide access)"
 
             let textContent =

--- a/packages/darklang/cli/outliner/main.dark
+++ b/packages/darklang/cli/outliner/main.dark
@@ -94,7 +94,7 @@ let defaultExportPath (title: String) (ext: String) : String =
     title
     |> Stdlib.String.replaceAll " " "-"
     |> Stdlib.String.toLowercase
-  let cwd = Builtin.directoryCurrent ()
+  let cwd = Stdlib.Cli.FileSystem.currentDirectory ()
   $"{cwd}/{safeTitle}{ext}"
 
 
@@ -382,14 +382,14 @@ module Persistence =
           nextDocId = state.nextDocId }
     let json = Stdlib.Json.serialize<PersistedData> data
     let jsonBytes = Stdlib.String.toBlob json
-    let _ = Builtin.fileWrite jsonBytes (dataFilePath ())
+    let _ = Stdlib.Cli.FileSystem.overwriteFile (dataFilePath ()) jsonBytes
     ()
 
   let load () : State =
     let filePath = dataFilePath ()
-    match Builtin.fileExists filePath with
+    match Stdlib.Cli.FileSystem.pathExists filePath with
     | true ->
-      match Builtin.fileRead filePath with
+      match Stdlib.Cli.FileSystem.readFile filePath with
       | Ok bytes ->
         let contents = Stdlib.String.fromBlobWithReplacement bytes
         match Stdlib.Json.parse<PersistedData> contents with

--- a/packages/darklang/cli/packages/db.dark
+++ b/packages/darklang/cli/packages/db.dark
@@ -1,6 +1,11 @@
 module Darklang.Cli.Packages.DB
 
 
+/// Every user DB on <param branchId>, as (name, typeName) pairs.
+let listAll (branchId: Uuid) : List<(String * String)> =
+  Builtin.dbListAll branchId
+
+
 let execute (state: Cli.AppState) (args: List<String>) : Cli.AppState =
   match args with
   | [] ->
@@ -45,7 +50,7 @@ let getDBTypeName
   (state: Cli.AppState)
   (dbName: String)
   : Stdlib.Option.Option<String> =
-  let dbs = Builtin.dbListAll state.currentBranchId
+  let dbs = listAll state.currentBranchId
 
   dbs
   |> Stdlib.List.filterMap (fun db ->
@@ -67,10 +72,10 @@ let getDBFieldNames
   with
   | Error _ -> []
   | Ok loc ->
-    match Builtin.pmFindType state.currentBranchId loc with
+    match LanguageTools.PackageManager.Type.find state.currentBranchId loc with
     | None -> []
     | Some typeHash ->
-      match Builtin.pmGetType typeHash with
+      match LanguageTools.PackageManager.Type.get typeHash with
       | None -> []
       | Some pkgType ->
         match pkgType.declaration.definition with
@@ -79,7 +84,7 @@ let getDBFieldNames
 
 
 let listDBs (state: Cli.AppState) : Cli.AppState =
-  let dbs = Builtin.dbListAll state.currentBranchId
+  let dbs = listAll state.currentBranchId
 
   match dbs with
   | [] ->
@@ -130,12 +135,12 @@ let viewDB (state: Cli.AppState) (dbName: String) : Cli.AppState =
     let fieldAccessors =
       fieldNames
       |> Stdlib.List.map (fun f ->
-        "(Builtin.toRepr value." ++ f ++ ")")
+        "(Stdlib.toRepr value." ++ f ++ ")")
       |> Stdlib.String.join " ++ \"|||\" ++ "
 
     let rowExpr =
       if Stdlib.List.isEmpty fieldNames then
-        "key ++ \"|||\" ++ (Builtin.toRepr value)"
+        "key ++ \"|||\" ++ (Stdlib.toRepr value)"
       else
         "key ++ \"|||\" ++ " ++ fieldAccessors
 
@@ -150,7 +155,7 @@ let viewDB (state: Cli.AppState) (dbName: String) : Cli.AppState =
       ++ nl ++ "  " ++ rowExpr ++ ")"
       ++ nl ++ "|> Stdlib.String.join \"<<<ROW>>>\""
 
-    match  Builtin.cliEvaluateExpression state.accountID state.currentBranchId expr false with
+    match Eval.evaluateRaw state.accountID state.currentBranchId expr false with
     | Ok resultOpt ->
       let result = resultOpt |> Stdlib.Option.withDefault ""
       Stdlib.printLine ""
@@ -213,7 +218,7 @@ let getDBValue
   : Cli.AppState =
   let expr = $"Stdlib.DB.get \"{key}\" {dbName}"
 
-  match  Builtin.cliEvaluateExpression state.accountID state.currentBranchId expr false with
+  match Eval.evaluateRaw state.accountID state.currentBranchId expr false with
   | Ok (Some result) ->
     Stdlib.printLine result
     state
@@ -237,7 +242,7 @@ let setDBValue
     let expr =
       $"Stdlib.DB.set ({typeName} {valueExpr}) \"{key}\" {dbName}"
 
-    match  Builtin.cliEvaluateExpression state.accountID state.currentBranchId expr false with
+    match Eval.evaluateRaw state.accountID state.currentBranchId expr false with
     | Ok _ ->
       Stdlib.printLine (Colors.success $"Set {key} in {dbName}")
       state
@@ -253,7 +258,7 @@ let deleteDBValue
   : Cli.AppState =
   let expr = $"Stdlib.DB.delete \"{key}\" {dbName}"
 
-  match  Builtin.cliEvaluateExpression state.accountID state.currentBranchId expr false with
+  match Eval.evaluateRaw state.accountID state.currentBranchId expr false with
   | Ok _ ->
     Stdlib.printLine (Colors.success $"Deleted {key} from {dbName}")
     state
@@ -269,7 +274,7 @@ let queryDB
   : Cli.AppState =
   let expr = $"Stdlib.DB.query {dbName} ({filterExpr})"
 
-  match  Builtin.cliEvaluateExpression state.accountID state.currentBranchId expr false with
+  match Eval.evaluateRaw state.accountID state.currentBranchId expr false with
   | Ok (Some result) ->
     Stdlib.printLine result
     state
@@ -296,7 +301,7 @@ let createDB (state: Cli.AppState) (dbName: String) (typeName: String) : Cli.App
     state
 
   | Ok typeLocation ->
-    match Builtin.pmFindType state.currentBranchId typeLocation with
+    match LanguageTools.PackageManager.Type.find state.currentBranchId typeLocation with
     | None ->
       let fullTypeName =
         PrettyPrinter.ProgramTypes.PackageLocation.packageLocation typeLocation
@@ -356,7 +361,7 @@ let help (_state: Cli.AppState) : String =
 
 
 let getDBNamesForCompletion (state: Cli.AppState) : List<String> =
-  (Builtin.dbListAll state.currentBranchId)
+  (listAll state.currentBranchId)
   |> Stdlib.List.map (fun db ->
     let (name, _) = db
     name)

--- a/packages/darklang/cli/packages/delete.dark
+++ b/packages/darklang/cli/packages/delete.dark
@@ -50,7 +50,7 @@ let countLiveDependents
   (targetLoc: LanguageTools.ProgramTypes.PackageLocation)
   (targetKind: LanguageTools.ProgramTypes.ItemKind)
   : Int =
-  let deps = Builtin.depsGetDependents branchId [ (targetLoc, targetKind) ]
+  let deps = Cli.Deps.getDependents branchId [ (targetLoc, targetKind) ]
   let depSets = Query.loadDeprecationSets branchId
   deps
   |> Stdlib.List.filter (fun entry ->

--- a/packages/darklang/cli/packages/deprecate.dark
+++ b/packages/darklang/cli/packages/deprecate.dark
@@ -55,18 +55,18 @@ let resolveTarget
   | Ok location ->
     match itemKind with
     | Fn ->
-      match Builtin.pmFindFn branchId location with
+      match LanguageTools.PackageManager.Function.find branchId location with
       | Some h ->
         Stdlib.Option.Option.Some (LanguageTools.ProgramTypes.Reference.PackageFn h)
       | None -> Stdlib.Option.Option.None
     | Type ->
-      match Builtin.pmFindType branchId location with
+      match LanguageTools.PackageManager.Type.find branchId location with
       | Some h ->
         Stdlib.Option.Option.Some
           (LanguageTools.ProgramTypes.Reference.PackageType h)
       | None -> Stdlib.Option.Option.None
     | Value ->
-      match Builtin.pmFindValue branchId location with
+      match LanguageTools.PackageManager.Value.find branchId location with
       | Some h ->
         Stdlib.Option.Option.Some
           (LanguageTools.ProgramTypes.Reference.PackageValue h)
@@ -233,7 +233,7 @@ let execute (state: Cli.AppState) (args: List<String>) : Cli.AppState =
               else
                 Stdlib.printLine ""
                 Stdlib.print (Colors.warning "Proceed? (y/n): ")
-                let response = Builtin.stdinReadLine ()
+                let response = Stdlib.Cli.Stdin.readLine ()
                 (response == "y") || (response == "Y")
 
             if proceed then

--- a/packages/darklang/cli/packages/fn.dark
+++ b/packages/darklang/cli/packages/fn.dark
@@ -20,7 +20,7 @@ let execute (state: Cli.AppState) (args: List<String>) : Cli.AppState =
     // can pipe multi-line bodies via heredoc without shell-quoting.
     let inlineDefinition =
       match cleanedParts with
-      | [ "-" ] -> Builtin.stdinReadAll ()
+      | [ "-" ] -> Stdlib.Cli.Stdin.readAll ()
       | parts -> Stdlib.String.join parts " "
 
     if Stdlib.String.isEmpty inlineDefinition then
@@ -77,10 +77,11 @@ let createFnInline
         $"let {location.name} {definition}"
 
     // Parse the function definition
-    match Builtin.parserParseToWrittenTypes fullSource with
+    match LanguageTools.Parser.Parse.toWrittenTypes fullSource with
     | Some(SourceFile sourceFile) ->
       // The parser may recover a tree after errors; do not save it.
-      let hasParseError = Errors.reportParseErrors (Builtin.parserParseDiagnostics fullSource)
+      let hasParseError =
+        Errors.reportParseErrors (LanguageTools.Parser.Parse.diagnostics fullSource)
       let parsedFunction =
         if hasParseError then
           Stdlib.Option.Option.None

--- a/packages/darklang/cli/packages/module.dark
+++ b/packages/darklang/cli/packages/module.dark
@@ -106,7 +106,7 @@ let execute (state: Cli.AppState) (args: List<String>) : Cli.AppState =
   let input =
     match args with
     | [ modulePath; "-" ] ->
-      Stdlib.Result.Result.Ok((modulePath, Builtin.stdinReadAll ()))
+      Stdlib.Result.Result.Ok((modulePath, Stdlib.Cli.Stdin.readAll ()))
     | [ modulePath; sourcePath ] ->
       match Stdlib.Cli.File.readText sourcePath with
       | Ok source -> Stdlib.Result.Result.Ok((modulePath, source))

--- a/packages/darklang/cli/packages/propagate.dark
+++ b/packages/darklang/cli/packages/propagate.dark
@@ -40,7 +40,7 @@ let resolveTypeName
   : Stdlib.Option.Option<LanguageTools.ProgramTypes.PackageLocation> =
   Darklang.LanguageTools.PackageManager.pickLocation
     Darklang.LanguageTools.PackageManager.PickContext.empty
-    (Builtin.pmGetLocationsByType branchId hash)
+    (LanguageTools.PackageManager.Type.locations branchId hash)
 
 
 /// Compare two lists element-wise; returns false if lengths differ.
@@ -184,8 +184,8 @@ let warnIfSignatureChanged
 
   match itemKind with
   | Fn ->
-    let oldFn = Builtin.pmGetFn previousHash
-    let newFn = Builtin.pmGetFn currentHash
+    let oldFn = LanguageTools.PackageManager.Function.get previousHash
+    let newFn = LanguageTools.PackageManager.Function.get currentHash
 
     match (oldFn, newFn) with
     | (Some oldF, Some newF) ->
@@ -201,8 +201,8 @@ let warnIfSignatureChanged
     | _ -> false
 
   | Type ->
-    let oldType = Builtin.pmGetType previousHash
-    let newType = Builtin.pmGetType currentHash
+    let oldType = LanguageTools.PackageManager.Type.get previousHash
+    let newType = LanguageTools.PackageManager.Type.get currentHash
 
     match (oldType, newType) with
     | (Some oldT, Some newT) ->

--- a/packages/darklang/cli/packages/type.dark
+++ b/packages/darklang/cli/packages/type.dark
@@ -20,7 +20,7 @@ let execute (state: Cli.AppState) (args: List<String>) : Cli.AppState =
     // can pipe multi-line definitions via heredoc without shell-quoting.
     let inlineDefinition =
       match cleanedParts with
-      | [ "-" ] -> Builtin.stdinReadAll ()
+      | [ "-" ] -> Stdlib.Cli.Stdin.readAll ()
       | parts -> Stdlib.String.join parts " "
 
     if Stdlib.String.isEmpty inlineDefinition then
@@ -70,10 +70,11 @@ let createTypeInline
     let fullSource = $"type {location.name} = {definition}"
 
     // Parse the type definition
-    match Builtin.parserParseToWrittenTypes fullSource with
+    match LanguageTools.Parser.Parse.toWrittenTypes fullSource with
     | Some(SourceFile sourceFile) ->
       // The parser may recover a tree after errors; do not save it.
-      let hasParseError = Errors.reportParseErrors (Builtin.parserParseDiagnostics fullSource)
+      let hasParseError =
+        Errors.reportParseErrors (LanguageTools.Parser.Parse.diagnostics fullSource)
       let found =
         if hasParseError then
           Stdlib.Option.Option.None

--- a/packages/darklang/cli/packages/undo.dark
+++ b/packages/darklang/cli/packages/undo.dark
@@ -172,7 +172,7 @@ let execute (state: Cli.AppState) (args: List<String>) : Cli.AppState =
               else
                 Stdlib.printLine ""
                 Stdlib.print (Colors.warning "Proceed? (y/n): ")
-                let response = Builtin.stdinReadLine ()
+                let response = Stdlib.Cli.Stdin.readLine ()
                 (response == "y") || (response == "Y")
 
           if proceed then

--- a/packages/darklang/cli/packages/value.dark
+++ b/packages/darklang/cli/packages/value.dark
@@ -20,7 +20,7 @@ let execute (state: Cli.AppState) (args: List<String>) : Cli.AppState =
     // can pipe multi-line expressions via heredoc without shell-quoting.
     let inlineDefinition =
       match cleanedParts with
-      | [ "-" ] -> Builtin.stdinReadAll ()
+      | [ "-" ] -> Stdlib.Cli.Stdin.readAll ()
       | parts -> Stdlib.String.join parts " "
 
     if Stdlib.String.isEmpty inlineDefinition then
@@ -71,10 +71,11 @@ let createValueInline
     let fullSource = $"val {location.name} = {expression}"
 
     // Parse the value definition with the unified (ranged) parser
-    match Builtin.parserParseToWrittenTypes fullSource with
+    match LanguageTools.Parser.Parse.toWrittenTypes fullSource with
     | Some(SourceFile sourceFile) ->
       // The parser may recover a tree after errors; do not save it.
-      let hasParseError = Errors.reportParseErrors (Builtin.parserParseDiagnostics fullSource)
+      let hasParseError =
+        Errors.reportParseErrors (LanguageTools.Parser.Parse.diagnostics fullSource)
       let found =
         if hasParseError then
           Stdlib.Option.Option.None

--- a/packages/darklang/cli/packages/view.dark
+++ b/packages/darklang/cli/packages/view.dark
@@ -15,9 +15,9 @@ let resolveReplacementName
     | PackageValue h -> h
   let locs =
     match ref with
-    | PackageFn h -> Builtin.pmGetLocationsByFn branchId h
-    | PackageType h -> Builtin.pmGetLocationsByType branchId h
-    | PackageValue h -> Builtin.pmGetLocationsByValue branchId h
+    | PackageFn h -> LanguageTools.PackageManager.Function.locations branchId h
+    | PackageType h -> LanguageTools.PackageManager.Type.locations branchId h
+    | PackageValue h -> LanguageTools.PackageManager.Value.locations branchId h
   match Darklang.LanguageTools.PackageManager.pickLocation
           (PrettyPrinter.ProgramTypes.Context.toPickContext ctx)
           locs with

--- a/packages/darklang/cli/scm/commit.dark
+++ b/packages/darklang/cli/scm/commit.dark
@@ -34,7 +34,7 @@ let promptYesNo (question: String) (autoConfirm: Bool) (defaultYes: Bool) : Bool
     true
   else
     Stdlib.printLine question
-    let response = Builtin.stdinReadLine ()
+    let response = Stdlib.Cli.Stdin.readLine ()
 
     if Stdlib.String.isEmpty (Stdlib.String.trim response) then
       defaultYes

--- a/packages/darklang/cli/scm/discard.dark
+++ b/packages/darklang/cli/scm/discard.dark
@@ -32,7 +32,7 @@ let execute (state: AppState) (args: List<String>) : AppState =
         true
       else
         Stdlib.printLine (Colors.warning "This cannot be undone. Proceed? (y/n): ")
-        let response = Builtin.stdinReadLine ()
+        let response = Stdlib.Cli.Stdin.readLine ()
         (response == "y") || (response == "Y")
 
     if proceed then

--- a/packages/darklang/cli/scripts.dark
+++ b/packages/darklang/cli/scripts.dark
@@ -6,6 +6,31 @@ type Script = {
   text: String
 }
 
+
+// The stored-script surface. The wrappers live here, next to the type the
+// builtins return; the LSP's script filesystem provider calls them too.
+
+/// Every stored script.
+let list () : List<Script> =
+  Builtin.pmScriptsList ()
+
+/// The stored script named <param name>, if there is one.
+let get (name: String) : Stdlib.Option.Option<Script> =
+  Builtin.pmScriptsGet name
+
+/// Store a new script. Errors if the name is taken.
+let add (name: String) (text: String) : Stdlib.Result.Result<Script, String> =
+  Builtin.pmScriptsAdd name text
+
+/// Replace an existing script's text. Errors if there's no such script.
+let update (name: String) (text: String) : Stdlib.Result.Result<Unit, String> =
+  Builtin.pmScriptsUpdate name text
+
+/// Delete a stored script. Errors if there's no such script.
+let delete (name: String) : Stdlib.Result.Result<Unit, String> =
+  Builtin.pmScriptsDelete name
+
+
 // Scripts command - manage and run stored Dark scripts
 // TODO rename to just execute
 let execute (state: AppState) (args: List<String>) : AppState =
@@ -25,7 +50,7 @@ let execute (state: AppState) (args: List<String>) : AppState =
     state
 
   | ["list"] ->
-    let scripts = Builtin.pmScriptsList ()
+    let scripts = list ()
     if Stdlib.List.isEmpty scripts then
       Stdlib.printLine "No scripts found"
       state
@@ -38,7 +63,7 @@ let execute (state: AppState) (args: List<String>) : AppState =
       state
 
   | ["view"; name] ->
-    match Builtin.pmScriptsGet name with
+    match get name with
     | Some script ->
       let output = $"Script: {script.name}\n\n{script.text}"
       Stdlib.printLine output
@@ -66,7 +91,7 @@ let execute (state: AppState) (args: List<String>) : AppState =
 
   | "add" :: name :: textParts when Stdlib.Bool.not (Stdlib.List.isEmpty textParts) ->
     let text = Stdlib.String.join textParts " "
-    match Builtin.pmScriptsAdd name text with
+    match add name text with
     | Ok script ->
       let message = $"Script '{script.name}' added successfully"
       Stdlib.printLine message
@@ -76,7 +101,7 @@ let execute (state: AppState) (args: List<String>) : AppState =
       state
 
   | ["edit"; name] ->
-    match Builtin.pmScriptsGet name with
+    match get name with
     | Some script ->
       [
         $"Current content of script '{name}':\n{script.text}"
@@ -91,7 +116,7 @@ let execute (state: AppState) (args: List<String>) : AppState =
 
   | "edit" :: name :: textParts when Stdlib.Bool.not (Stdlib.List.isEmpty textParts) ->
     let text = Stdlib.String.join textParts " "
-    match Builtin.pmScriptsUpdate name text with
+    match update name text with
     | Ok () ->
       let message = $"Script '{name}' updated successfully"
       Stdlib.printLine message
@@ -101,7 +126,7 @@ let execute (state: AppState) (args: List<String>) : AppState =
       state
 
   | ["delete"; name] ->
-    match Builtin.pmScriptsDelete name with
+    match delete name with
     | Ok () ->
       let message = $"Script '{name}' deleted successfully"
       Stdlib.printLine message
@@ -111,9 +136,17 @@ let execute (state: AppState) (args: List<String>) : AppState =
       state
 
   | ["run"; name] ->
-    match Builtin.pmScriptsGet name with
+    match get name with
     | Some script ->
-      let result = Builtin.cliParseAndExecuteScript state.accountID state.currentBranchId $"script:{name}" script.text [] false false
+      let result =
+        Run.parseAndExecute
+          state.accountID
+          state.currentBranchId
+          $"script:{name}"
+          script.text
+          []
+          false
+          false
       match result with
       | Ok 0 -> state
       | Ok exitCode ->
@@ -141,7 +174,7 @@ let complete (_state: AppState) (args: List<String>) : List<Completion.Completio
     |> Stdlib.List.map Completion.simple
   // Referencing a specific script - recommend names
   | ["view"] | ["edit"] | ["delete"] | ["run"] ->
-    let scripts = Builtin.pmScriptsList ()
+    let scripts = list ()
     scripts
     |> Stdlib.List.map (fun s -> s.name)
     |> Stdlib.List.map Completion.simple

--- a/packages/darklang/cli/telemetry.dark
+++ b/packages/darklang/cli/telemetry.dark
@@ -45,7 +45,7 @@ let logWithContext
   let wall = Stdlib.DateTime.toString (Stdlib.DateTime.now ())
   let line = $"{{\"event\":\"{label}\",\"ms\":{Stdlib.Int.toString elapsed},\"wall\":\"{wall}\",\"ctx\":{ctxJson}}}"
 
-  let _ = Builtin.fileAppendText logFilePath (line ++ "\n")
+  let _ = Stdlib.Cli.FileSystem.appendToFile logFilePath (line ++ "\n")
   ()
 
 /// Shorthand: log a timing event with no extra context
@@ -58,7 +58,7 @@ let logMessage (label: String) (message: String) : Unit =
   let escaped = Stdlib.String.replaceAll message "\"" "\\\""
   let line = $"{{\"event\":\"{label}\",\"msg\":\"{escaped}\",\"wall\":\"{wall}\"}}"
 
-  let _ = Builtin.fileAppendText logFilePath (line ++ "\n")
+  let _ = Stdlib.Cli.FileSystem.appendToFile logFilePath (line ++ "\n")
   ()
 
 /// Log the start of a session so we can separate runs in the log
@@ -66,5 +66,5 @@ let logSessionStart () : Unit =
   let wall = Stdlib.DateTime.toString (Stdlib.DateTime.now ())
   let line = $"{{\"event\":\"session_start\",\"wall\":\"{wall}\"}}"
 
-  let _ = Builtin.fileAppendText logFilePath (line ++ "\n")
+  let _ = Stdlib.Cli.FileSystem.appendToFile logFilePath (line ++ "\n")
   ()

--- a/packages/darklang/cli/tests/tests-tui.dark
+++ b/packages/darklang/cli/tests/tests-tui.dark
@@ -391,7 +391,7 @@ let testReplSplitsPastedStatements (): TestResult =
     |> Stdlib.List.filter (fun c ->
       let (input, expected) = c
       (Darklang.Cli.Repl.splitStatements input) != expected)
-    |> Stdlib.List.map (fun c -> let (input, _e) = c in Builtin.toRepr input)
+    |> Stdlib.List.map (fun c -> let (input, _e) = c in Stdlib.toRepr input)
   if Stdlib.List.isEmpty wrong then
     TestResult.Pass
   else

--- a/packages/darklang/cli/tests/tests.dark
+++ b/packages/darklang/cli/tests/tests.dark
@@ -18,7 +18,7 @@ type TestResult =
 /// build. That matters most under NativeAOT, where a trimming failure is
 /// invisible at build time and only shows up in the one command that hits it.
 let cliUnderTest () : String =
-  match Builtin.environmentGet "DARK_CLI_UNDER_TEST" with
+  match Stdlib.Env.get "DARK_CLI_UNDER_TEST" with
   | Some path -> path
   | None -> "./scripts/run-cli"
 

--- a/packages/darklang/cli/tracing.dark
+++ b/packages/darklang/cli/tracing.dark
@@ -17,7 +17,7 @@ type TraceData = Darklang.Tracing.TraceData
 /// to tell the two apart from in here until the tracesEnabled builtin, so this asks
 /// rather than guessing.
 let emptyStateHint () : String =
-  if Builtin.tracesEnabled () then
+  if Darklang.Tracing.Store.enabled () then
     "(Traces are recorded by `darklang eval`, `darklang run`, or HTTP handlers under `darklang serve`.)"
   else
     "(Recording is OFF, so this is empty whatever ran. For one command: DARK_CONFIG_TRACE_DETAIL=on darklang ...)"
@@ -97,7 +97,7 @@ let resolveTraceID (input: String) : Stdlib.Option.Option<String> =
       Stdlib.printLine (Colors.error "Trace ID must not be empty")
       Stdlib.Option.Option.None
     else
-      match Builtin.tracesResolveID trimmed with
+      match Darklang.Tracing.Store.resolveID trimmed with
       | Ok fullID -> Stdlib.Option.Option.Some fullID
       | Error msg ->
         Stdlib.printLine (Colors.error msg)
@@ -188,7 +188,7 @@ let confirmDestructive (autoConfirm: Bool) (action: String) : Bool =
     true
   else
     Stdlib.printLine $"{action} (y/n): "
-    let response = Builtin.stdinReadLine ()
+    let response = Stdlib.Cli.Stdin.readLine ()
     (response == "y") || (response == "Y")
 
 
@@ -475,7 +475,7 @@ let executeList (state: Cli.AppState) (limit: Int) : Cli.AppState =
     Stdlib.printLine (Colors.error "Limit must be ≥ 1")
     state
   else
-    let rows = Builtin.tracesList limit
+    let rows = Darklang.Tracing.Store.list limit
 
     match rows with
     | [] ->
@@ -499,7 +499,7 @@ let executeListJson (state: Cli.AppState) (limit: Int) : Cli.AppState =
     Stdlib.printLine (Colors.error "Limit must be ≥ 1")
     state
   else
-    let rows = Builtin.tracesList limit
+    let rows = Darklang.Tracing.Store.list limit
     Stdlib.printLine (Stdlib.Json.serialize<List<TraceSummary>> rows)
     state
 
@@ -517,7 +517,7 @@ let executeListByFn
     Stdlib.printLine (Colors.error "Limit must be ≥ 1")
     state
   else
-    let rows = Builtin.tracesListByFn fnName limit
+    let rows = Darklang.Tracing.Store.listByFn fnName limit
     if jsonMode then
       Stdlib.printLine (Stdlib.Json.serialize<List<TraceSummary>> rows)
       state
@@ -547,7 +547,7 @@ let executeHotspots
     Stdlib.printLine (Colors.error "Limit must be ≥ 1")
     state
   else
-    let rows = Builtin.tracesHotspots traceLimit
+    let rows = Darklang.Tracing.Store.hotspots traceLimit
 
     match rows with
     | [] ->
@@ -581,7 +581,7 @@ let executeHotspotsJson
     Stdlib.printLine (Colors.error "Limit must be ≥ 1")
     state
   else
-    let rows = Builtin.tracesHotspots traceLimit
+    let rows = Darklang.Tracing.Store.hotspots traceLimit
     let body =
       rows
       |> Stdlib.List.map (fun row ->
@@ -621,7 +621,7 @@ let executeFind
     Stdlib.printLine (Colors.error "Limit must be ≥ 1")
     state
   else
-    let rows = Builtin.tracesFind pattern limit
+    let rows = Darklang.Tracing.Store.find pattern limit
 
     match rows with
     | [] ->
@@ -653,7 +653,7 @@ let executeFindJson
     Stdlib.printLine (Colors.error "Limit must be ≥ 1")
     state
   else
-    let rows = Builtin.tracesFind pattern limit
+    let rows = Darklang.Tracing.Store.find pattern limit
     Stdlib.printLine (Stdlib.Json.serialize<List<TraceSummary>> rows)
     state
 
@@ -666,7 +666,7 @@ let executeFindView (state: Cli.AppState) (pattern: String) : Cli.AppState =
     Stdlib.printLine (Colors.error "find pattern must not be empty")
     state
   else
-    let rows = Builtin.tracesFind pattern 1
+    let rows = Darklang.Tracing.Store.find pattern 1
     match rows with
     | [] ->
       Stdlib.printLine $"No traces match '{pattern}'."
@@ -706,7 +706,7 @@ let executeTail
       match routeFilter with
       | Some _ -> 500
       | None -> n
-    let allRows = Builtin.tracesList fetch
+    let allRows = Darklang.Tracing.Store.list fetch
     let candidates =
       match routeFilter with
       | Some route ->
@@ -746,7 +746,7 @@ let executeStats (state: Cli.AppState) (limit: Int) : Cli.AppState =
     Stdlib.printLine (Colors.error "Limit must be ≥ 1")
     state
   else
-    let rows = Builtin.tracesStatsByHandler limit
+    let rows = Darklang.Tracing.Store.statsByHandler limit
 
     match rows with
     | [] ->
@@ -788,7 +788,7 @@ let executeStatsJson (state: Cli.AppState) (limit: Int) : Cli.AppState =
     Stdlib.printLine (Colors.error "Limit must be ≥ 1")
     state
   else
-    let rows = Builtin.tracesStatsByHandler limit
+    let rows = Darklang.Tracing.Store.statsByHandler limit
     let body =
       rows
       |> Stdlib.List.map (fun row ->
@@ -812,7 +812,7 @@ let followLoop
   (lastSeen: String)
   (jsonMode: Bool)
   : Unit =
-  let rows = Builtin.tracesList 50
+  let rows = Darklang.Tracing.Store.list 50
 
   let candidates =
     rows |> Stdlib.List.takeWhile (fun row -> row.traceId != lastSeen)
@@ -872,7 +872,7 @@ let executeFollow
     Stdlib.printLine ""
 
   // Anchor: ignore traces that already existed when we started.
-  let initialRows = Builtin.tracesList 1
+  let initialRows = Darklang.Tracing.Store.list 1
   let initialSeen =
     match initialRows with
     | [] -> ""
@@ -902,7 +902,7 @@ let executeListByRoute
     // unfiltered, so to find N matching we may need to pull more. Cap at
     // 500 to bound the fetch.
     let overFetch = if limit < 50 then 500 else limit * 10
-    let allRows = Builtin.tracesList overFetch
+    let allRows = Darklang.Tracing.Store.list overFetch
     let routeUpper = Stdlib.String.toUppercase route
     let matching =
       allRows
@@ -1094,7 +1094,7 @@ let executeView
   (traceID: String)
   (opts: ViewOptions)
   : Cli.AppState =
-  let result = Builtin.tracesView traceID
+  let result = Darklang.Tracing.Store.view traceID
 
   match result with
   | None ->
@@ -1121,7 +1121,7 @@ let executeView
 /// the row's input is fetched via `tracesGetInput` which returns None for
 /// non-string inputs. Each replay creates a fresh trace.
 let executeReplay (state: Cli.AppState) (traceID: String) : Cli.AppState =
-  match Builtin.tracesGetInput traceID with
+  match Darklang.Tracing.Store.getInput traceID with
   | None ->
     Stdlib.printLine
       (Colors.error
@@ -1131,7 +1131,7 @@ let executeReplay (state: Cli.AppState) (traceID: String) : Cli.AppState =
     Stdlib.printLine $"Replaying trace {traceID}..."
     Stdlib.printLine ""
     match
-      Builtin.cliEvaluateExpression
+      Eval.evaluateRaw
         state.accountID state.currentBranchId code false
     with
     | Ok outputOpt ->
@@ -1148,7 +1148,7 @@ let executeReplay (state: Cli.AppState) (traceID: String) : Cli.AppState =
 
 
 let executeClear (state: Cli.AppState) : Cli.AppState =
-  let count = Builtin.tracesClear ()
+  let count = Darklang.Tracing.Store.clear ()
   match count with
   | 0 ->
     Stdlib.printLine "No traces to clear."
@@ -1185,7 +1185,7 @@ let executeClearBefore
     let cutoffDt =
       Stdlib.DateTime.subtractSeconds now seconds
     let cutoff = Stdlib.DateTime.toString cutoffDt
-    let count = Builtin.tracesClearBefore cutoff
+    let count = Darklang.Tracing.Store.clearBefore cutoff
     match count with
     | 0 ->
       Stdlib.printLine $"No traces older than {durationStr}."
@@ -1200,7 +1200,7 @@ let executeClearBefore
 /// `traces delete <id>` — remove one trace and its fn_calls. ID accepts
 /// the same prefix-resolution as view/replay.
 let executeDelete (state: Cli.AppState) (traceID: String) : Cli.AppState =
-  let deleted = Builtin.tracesDelete traceID
+  let deleted = Darklang.Tracing.Store.delete traceID
   match deleted with
   | 0 ->
     Stdlib.printLine (Colors.error $"Trace not found: {traceID}")
@@ -1218,7 +1218,7 @@ let executePruneKeep (state: Cli.AppState) (keepN: Int) : Cli.AppState =
     Stdlib.printLine (Colors.error "--keep N must be ≥ 0")
     state
   else
-    let deleted = Builtin.tracesPruneKeep keepN
+    let deleted = Darklang.Tracing.Store.pruneKeep keepN
     match deleted with
     | 0 ->
       Stdlib.printLine

--- a/packages/darklang/cli/utils/syntaxHighlighting.dark
+++ b/packages/darklang/cli/utils/syntaxHighlighting.dark
@@ -128,7 +128,7 @@ let highlightCode (sourceCode: String) : String =
   // returns `Some` (a partial tree; precise diagnostics are reported separately)
   // for virtually all input. `None` only on a hard lex failure — fall back to
   // the uncolored source.
-  match Builtin.parserParseToWrittenTypes sourceCode with
+  match LanguageTools.Parser.Parse.toWrittenTypes sourceCode with
   | Some parsedFile ->
     applyTokenColors sourceCode (LanguageTools.SemanticTokens.ParsedFile.tokenize parsedFile)
   | None -> sourceCode

--- a/packages/darklang/cli/workbench/authoring.dark
+++ b/packages/darklang/cli/workbench/authoring.dark
@@ -46,11 +46,11 @@ let saveEditing (state: State) (es: EditingState) : Step =
   match Packages.Location.parseRelativeTo (Packages.PackageLocation.Module targetMod) leaf with
   | Error e -> keepErr ("bad name: " ++ e)
   | Ok location ->
-    let diags = Builtin.parserParseDiagnostics fullSource
+    let diags = LanguageTools.Parser.Parse.diagnostics fullSource
     if Stdlib.Bool.not (Stdlib.List.isEmpty diags) then
       keepErr "parse error - fix it, then ^s"
     else
-      match Builtin.parserParseToWrittenTypes fullSource with
+      match LanguageTools.Parser.Parse.toWrittenTypes fullSource with
       | Some(SourceFile sourceFile) ->
         let pm = LanguageTools.PackageManager.pm ()
         let ctx =

--- a/packages/darklang/cli/workbench/loaders-misc.dark
+++ b/packages/darklang/cli/workbench/loaders-misc.dark
@@ -225,7 +225,7 @@ let cronDetail (state: State) : String =
 /// preview set so the surface reads as complete rather than empty (this env records none).
 let loadTraceBodyItems () : List<BodyItem> =
   let real =
-    Builtin.tracesList 30
+    Darklang.Tracing.Store.list 30
     |> Stdlib.List.map (fun t ->
       BodyItem { name = t.handler ++ "  ·  " ++ t.timestamp; kind = "trace"; isModule = false })
   if Stdlib.Bool.not (Stdlib.List.isEmpty real) then

--- a/packages/darklang/cli/workbench/loaders.dark
+++ b/packages/darklang/cli/workbench/loaders.dark
@@ -201,7 +201,7 @@ let depsText (state: State) : String =
             let namesDict = Darklang.Cli.Deps.resolveNames state.branchId (deps |> Stdlib.List.map (fun p -> let (h, _) = p in h))
             deps |> Stdlib.List.map (fun p -> let (th, _rt) = p in "  " ++ (Darklang.Cli.Deps.getName namesDict th))
         // Dependents - what uses this item.
-        let dependents = Builtin.depsGetDependents state.branchId [ (loc, kind) ]
+        let dependents = Cli.Deps.getDependents state.branchId [ (loc, kind) ]
         let dependentLines =
           if Stdlib.List.isEmpty dependents then [ Colors.dimText "  (none)" ]
           else dependents |> Stdlib.List.map (fun t -> let (_h, sLoc, _rt) = t in "  " ++ (PrettyPrinter.ProgramTypes.PackageLocation.packageLocation sLoc))
@@ -289,7 +289,7 @@ let refreshPeek (next: State) : State =
           let fullpath =
             Stdlib.String.join (Stdlib.List.append (modulePathOf next.location) [ item.name ]) "."
           captureOutput (fun () ->
-            Builtin.cliEvaluateExpression next.accountId next.branchId (fullpath ++ " ()") false)
+            Eval.evaluateRaw next.accountId next.branchId (fullpath ++ " ()") false)
         else
           ""
       | None -> ""

--- a/packages/darklang/cli/workbench/views-misc.dark
+++ b/packages/darklang/cli/workbench/views-misc.dark
@@ -146,7 +146,7 @@ let builtinHints (state: State) : List<(String * String)> =
 /// experience. Gated on `internal.enabled` (config), so `config set internal.enabled stachu,feriel` turns the
 /// whole tier on for those two accounts and nobody else. This is the dev-tools surface #4.B asked for.
 let loadBuiltinItems () : List<BodyItem> =
-  Builtin.getAllBuiltinFns ()
+  LanguageTools.allBuiltinFns ()
   |> Stdlib.List.map (fun fn -> fn.name.name)
   |> Stdlib.List.sort
   |> Stdlib.List.map (fun n -> BodyItem { name = n; kind = "builtin"; isModule = false })
@@ -155,7 +155,7 @@ let builtinDetailLines (state: State) : List<String> =
   match Stdlib.List.getAt state.items state.selected with
   | None -> [ Colors.dimText "(nothing selected)" ]
   | Some item ->
-    let all = Builtin.getAllBuiltinFns ()
+    let all = LanguageTools.allBuiltinFns ()
     match Stdlib.List.findFirst all (fun fn -> fn.name.name == item.name) with
     | None -> [ Colors.dimText "(builtin not found)" ]
     | Some fn ->

--- a/packages/darklang/internal/dark-packages/dark-packages.dark
+++ b/packages/darklang/internal/dark-packages/dark-packages.dark
@@ -196,7 +196,7 @@ let searchHandlerFn (req: HttpRequest) : HttpResponse =
                     entityTypes = entityTypes
                     exactMatch = exactMatch }
 
-              let results = Builtin.pmSearch serverBranchId query
+              let results = LanguageTools.PackageManager.Search.search serverBranchId query
               let json = results |> Stdlib.Json.serialize<LanguageTools.ProgramTypes.Search.SearchResults>
               Stdlib.Http.responseWithJson json 200
 
@@ -231,7 +231,7 @@ let locationHandlerFn (req: HttpRequest) : HttpResponse =
               entityTypes = []
               exactMatch = false }
 
-        let results = Builtin.pmSearch serverBranchId searchQuery
+        let results = LanguageTools.PackageManager.Search.search serverBranchId searchQuery
         let json = results |> Stdlib.Json.serialize<LanguageTools.ProgramTypes.Search.SearchResults>
         Stdlib.Http.responseWithJson json 200
     else
@@ -243,19 +243,19 @@ let locationHandlerFn (req: HttpRequest) : HttpResponse =
         | Some ((hash, kind)) ->
           match kind with
           | Fn ->
-            match Builtin.pmGetFn hash with
+            match LanguageTools.PackageManager.Function.get hash with
             | Some fn ->
               let json = fn |> Stdlib.Json.serialize<LanguageTools.ProgramTypes.PackageFn.PackageFn>
               Stdlib.Http.responseWithJson json 200
             | None -> Stdlib.Http.notFound ()
           | Type ->
-            match Builtin.pmGetType hash with
+            match LanguageTools.PackageManager.Type.get hash with
             | Some t ->
               let json = t |> Stdlib.Json.serialize<LanguageTools.ProgramTypes.PackageType.PackageType>
               Stdlib.Http.responseWithJson json 200
             | None -> Stdlib.Http.notFound ()
           | Value ->
-            match Builtin.pmGetValue hash with
+            match LanguageTools.PackageManager.Value.get hash with
             | Some v ->
               let json = v |> Stdlib.Json.serialize<LanguageTools.ProgramTypes.PackageValue.PackageValue>
               Stdlib.Http.responseWithJson json 200
@@ -269,7 +269,7 @@ let locationHandlerFn (req: HttpRequest) : HttpResponse =
                 searchDepth = LanguageTools.ProgramTypes.Search.SearchDepth.OnlyDirectDescendants
                 entityTypes = []
                 exactMatch = false }
-          let results = Builtin.pmSearch serverBranchId searchQuery
+          let results = LanguageTools.PackageManager.Search.search serverBranchId searchQuery
           let json =
             results
             |> Stdlib.Json.serialize<LanguageTools.ProgramTypes.Search.SearchResults>
@@ -297,7 +297,7 @@ let typeFindHandlerFn (req: HttpRequest) : HttpResponse =
     match parseNameToLocation name with
     | Error errorMsg -> Stdlib.Http.badRequest errorMsg
     | Ok location ->
-      match Builtin.pmFindType serverBranchId location with
+      match LanguageTools.PackageManager.Type.find serverBranchId location with
       | Some hash ->
         Stdlib.Http.responseWithJson (hash |> Stdlib.Json.serialize<LanguageTools.ProgramTypes.Hash>) 200
       | None -> Stdlib.Http.notFound ()
@@ -312,7 +312,7 @@ let typeGetHandlerFn (req: HttpRequest) : HttpResponse =
   | None -> Stdlib.Http.badRequest "Missing :hash segment"
   | Some hashStr ->
     let hash = LanguageTools.ProgramTypes.Hash.Hash hashStr
-    match Builtin.pmGetType hash with
+    match LanguageTools.PackageManager.Type.get hash with
     | Some t ->
       let json = t |> Stdlib.Json.serialize<LanguageTools.ProgramTypes.PackageType.PackageType>
       Stdlib.Http.responseWithJson json 200
@@ -353,7 +353,7 @@ let valueFindHandlerFn (req: HttpRequest) : HttpResponse =
     match parseNameToLocation name with
     | Error errorMsg -> Stdlib.Http.badRequest errorMsg
     | Ok location ->
-      match Builtin.pmFindValue serverBranchId location with
+      match LanguageTools.PackageManager.Value.find serverBranchId location with
       | Some hash ->
         Stdlib.Http.responseWithJson (hash |> Stdlib.Json.serialize<LanguageTools.ProgramTypes.Hash>) 200
       | None -> Stdlib.Http.notFound ()
@@ -369,7 +369,7 @@ let valueGetHandlerFn (req: HttpRequest) : HttpResponse =
   | None -> Stdlib.Http.badRequest "Missing :hash segment"
   | Some hashStr ->
     let hash = LanguageTools.ProgramTypes.Hash.Hash hashStr
-    match Builtin.pmGetValue hash with
+    match LanguageTools.PackageManager.Value.get hash with
     | Some v ->
       let json = v |> Stdlib.Json.serialize<LanguageTools.ProgramTypes.PackageValue.PackageValue>
       Stdlib.Http.responseWithJson json 200
@@ -411,7 +411,7 @@ let functionFindHandlerFn (req: HttpRequest) : HttpResponse =
     match parseNameToLocation name with
     | Error errorMsg -> Stdlib.Http.badRequest errorMsg
     | Ok location ->
-      match Builtin.pmFindFn serverBranchId location with
+      match LanguageTools.PackageManager.Function.find serverBranchId location with
       | Some hash ->
         Stdlib.Http.responseWithJson (hash |> Stdlib.Json.serialize<LanguageTools.ProgramTypes.Hash>) 200
       | None -> Stdlib.Http.notFound ()
@@ -429,7 +429,7 @@ let functionGetHandlerFn (req: HttpRequest) : HttpResponse =
   | None -> Stdlib.Http.badRequest "Missing :hash segment"
   | Some hashStr ->
     let hash = LanguageTools.ProgramTypes.Hash.Hash hashStr
-    match Builtin.pmGetFn hash with
+    match LanguageTools.PackageManager.Function.get hash with
     | Some f ->
       let json = f |> Stdlib.Json.serialize<LanguageTools.ProgramTypes.PackageFn.PackageFn>
       Stdlib.Http.responseWithJson json 200

--- a/packages/darklang/internal/darklang-internal-mcp-server/resources.dark
+++ b/packages/darklang/internal/darklang-internal-mcp-server/resources.dark
@@ -76,7 +76,7 @@ let logs () : ModelContextProtocol.ServerBuilder.Resource =
     name = "Package Logs"
     description = "Recent package loading and compilation logs"
     handler = fun _uri ->
-      match Builtin.fileRead "rundir/logs/packages.log" with
+      match Stdlib.Cli.FileSystem.readFile "rundir/logs/packages.log" with
       | Ok bytes ->
           let content = Stdlib.String.fromBlobWithReplacement bytes
           let lines = Stdlib.String.split content "\n"

--- a/packages/darklang/internal/darklang-internal-mcp-server/tools.dark
+++ b/packages/darklang/internal/darklang-internal-mcp-server/tools.dark
@@ -8,7 +8,7 @@ let executeDarklang () : ModelContextProtocol.ServerBuilder.Tool =
     description = "Execute Darklang code and return the result"
     handler =
       fun code ->
-        match Builtin.cliEvaluateExpression (Stdlib.Option.Option.None) SCM.Branch.mainBranchId code false with
+        match Cli.Eval.evaluateRaw (Stdlib.Option.Option.None) SCM.Branch.mainBranchId code false with
         | Ok (Some result) -> $"Result: {result}"
         | Ok None -> "Result: ()"
         | Error err ->
@@ -56,7 +56,7 @@ let typecheck () : ModelContextProtocol.ServerBuilder.Tool =
     name = "typecheck"
     description = "Check Darklang code for syntax errors without executing it"
     handler = fun code ->
-      match Builtin.parserParseDiagnostics code with
+      match LanguageTools.Parser.Parse.diagnostics code with
       | [] -> "Parse check passed: no syntax errors found"
       | diagnostics ->
           let errorList =

--- a/packages/darklang/languageTools/common.dark
+++ b/packages/darklang/languageTools/common.dark
@@ -32,6 +32,11 @@ type BuiltinFunction =
     returnType: RuntimeTypes.TypeReference
     purity: BuiltinFunctionPurity }
 
+/// Every builtin fn this runtime has. The list is built fresh on each call,
+/// so hold onto it if you're looking up more than one name.
+let allBuiltinFns () : List<BuiltinFunction> =
+  Builtin.getAllBuiltinFns ()
+
 /// A Darklang builtin value
 type BuiltinValue =
   { name: RuntimeTypes.FQValueName.Builtin

--- a/packages/darklang/languageTools/interpreterStats.dark
+++ b/packages/darklang/languageTools/interpreterStats.dark
@@ -1,0 +1,24 @@
+/// The interpreter's performance counters: instruction count, call counts,
+/// frame pushes, and (when detailed timing is on) per-builtin and
+/// per-package-fn time.
+///
+/// The CLI reads these for `--stats`; perf work reads them by hand from
+/// `dark eval`.
+module Darklang.LanguageTools.InterpreterStats
+
+
+/// Zero the counters, and start counting if they weren't already.
+let reset () : Unit =
+  Builtin.interpreterStatsReset ()
+
+
+/// The counters so far, as a JSON string.
+let get () : String =
+  Builtin.interpreterStatsGet ()
+
+
+/// Also record per-expression time from here on. Off by default: on some
+/// hosts reading the clock costs more than the expression being timed, so
+/// this is a deliberate, per-run choice rather than something to leave on.
+let enableDetailedTiming () : Unit =
+  Builtin.interpreterStatsEnableDetailedTiming ()

--- a/packages/darklang/languageTools/lsp-server/docSync.dark
+++ b/packages/darklang/languageTools/lsp-server/docSync.dark
@@ -43,13 +43,13 @@ let parseAndReportDiagnostics
   // always returns `Some` (a partial tree + precise diagnostics reported below).
   // `None` is unreachable.
   let parsed =
-    match Builtin.parserParseToWrittenTypes requestText with
+    match Parser.Parse.toWrittenTypes requestText with
     | Some parsedFile -> Stdlib.Result.Result.Ok parsedFile
     | None -> Stdlib.Result.Result.Error "tokenizer failure"
 
   // the parser's precise syntax errors (empty on a clean parse) — reported
   // alongside name-resolution warnings below
-  let parseDiagnostics = Builtin.parserParseDiagnostics requestText
+  let parseDiagnostics = Parser.Parse.diagnostics requestText
 
   match parsed with
   | Ok (SourceFile sf) ->
@@ -126,7 +126,7 @@ let handleTextDocumentDidOpen
       // A recovered tree can contain EError holes, and lowering is only
       // defined for clean trees (Expr.toPT has no EError arm, by contract) —
       // so skip lowering unless the parse produced no diagnostics.
-      if Stdlib.List.isEmpty (Builtin.parserParseDiagnostics request.textDocument.text) then
+      if Stdlib.List.isEmpty (Parser.Parse.diagnostics request.textDocument.text) then
         (WrittenTypesToProgramTypes.parsedFileAsSourceFile parsedFile)
         |> Stdlib.Tuple3.first
         |> Stdlib.Option.Option.Some
@@ -196,7 +196,7 @@ let handleTextDocumentDidSave
       match parsed with
       | Ok parsedFile ->
         // Same guard as didOpen: never lower a tree with parse-error holes.
-        if Stdlib.List.isEmpty (Builtin.parserParseDiagnostics text) then
+        if Stdlib.List.isEmpty (Parser.Parse.diagnostics text) then
           (WrittenTypesToProgramTypes.parsedFileAsSourceFile parsedFile)
           |> Stdlib.Tuple3.first
           |> Stdlib.Option.Option.Some

--- a/packages/darklang/languageTools/lsp-server/fileSystemProvider.dark
+++ b/packages/darklang/languageTools/lsp-server/fileSystemProvider.dark
@@ -44,7 +44,7 @@ module ReadFile =
           nameForLookup
           |> Stdlib.String.dropFirst 7  // Drop "script/"
 
-        match Builtin.pmScriptsGet scriptName with
+        match Cli.Scripts.get scriptName with
         | Some script -> script.text
         | None -> $"Script not found: {scriptName}"
       else
@@ -239,14 +239,14 @@ module WriteFile =
         |> Stdlib.String.dropFirst 7  // Drop "script/"
 
       // Update the script content
-      match Builtin.pmScriptsUpdate scriptName content with
+      match Cli.Scripts.update scriptName content with
       | Ok () -> sendSuccessResponse state requestId [] Stdlib.Option.Option.None
       | Error err -> sendErrorResponse state requestId [ err ]
     else
       // Parse package module content
       // Parse then collect every declaration with its module path (descending into nested modules).
       let allDecls =
-        match Builtin.parserParseToWrittenTypes content with
+        match Parser.Parse.toWrittenTypes content with
         | Some(SourceFile sourceFile) ->
           sourceFile.declarations
           |> Stdlib.List.map WriteFile.sfDeclToModuleDecl

--- a/packages/darklang/languageTools/lsp-server/hoverInformation.dark
+++ b/packages/darklang/languageTools/lsp-server/hoverInformation.dark
@@ -157,7 +157,7 @@ let createCodeSnippet (text: String) : String =
 
 
 let getBuiltinFn (name: String) : Stdlib.Option.Option<BuiltinFunction> =
-  (Builtin.getAllBuiltinFns ())
+  (LanguageTools.allBuiltinFns ())
   |> Stdlib.List.findFirst (fun f -> f.name.name == name)
 
 

--- a/packages/darklang/languageTools/lsp-server/logging.dark
+++ b/packages/darklang/languageTools/lsp-server/logging.dark
@@ -5,7 +5,7 @@ val logFilePath = "/home/dark/app/rundir/logs/lsp-server.log"
 
 let log (input: String) : Unit =
   // returns Result -- ignored
-  let _logged = Builtin.fileAppendText logFilePath (input ++ "\n")
+  let _logged = Stdlib.Cli.FileSystem.appendToFile logFilePath (input ++ "\n")
 
   ()
 
@@ -22,7 +22,7 @@ let logAndSendToClient (response: String) : Unit =
     |> Stdlib.List.length
     |> Stdlib.Int.toString
 
-  Builtin.print $"Content-Length: {contentLengthInBytes}\r\n\r\n{response}"
+  Stdlib.print $"Content-Length: {contentLengthInBytes}\r\n\r\n{response}"
 
 (*
   // These are (basically) the only things we're allowed to do before

--- a/packages/darklang/languageTools/lsp-server/lsp-server.dark
+++ b/packages/darklang/languageTools/lsp-server/lsp-server.dark
@@ -17,7 +17,7 @@ type Json = Stdlib.AltJson.Json
 /// to `rundir/logs/lsp-server.log`, for local debugging.
 let runServerCli (u: Unit) : Int =
   // clear `lsp-server.log`, and write a timestamp of the start-up
-  let _deleted = Builtin.fileDelete logFilePath
+  let _deleted = Stdlib.Cli.FileSystem.deleteFile logFilePath
 
   (Stdlib.DateTime.now ())
   |> Stdlib.DateTime.toString
@@ -194,7 +194,7 @@ let runServerCliLoop (state: LspState) : Int =
 let tryReadHeader
   (contentLength: Stdlib.Option.Option<Int>)
   : Stdlib.Result.Result<Int, String> =
-  let line = Builtin.stdinReadLine ()
+  let line = Stdlib.Cli.Stdin.readLine ()
 
   if line == "" then
     contentLength |> Stdlib.Option.toResult "No Content-Length header found"

--- a/packages/darklang/languageTools/nameResolver.dark
+++ b/packages/darklang/languageTools/nameResolver.dark
@@ -292,7 +292,7 @@ module FnName =
     | [] -> Stdlib.Result.Result.Error()
     | owner :: modules ->
       if owner == "Builtin" && modules == [] then
-        let allBuiltins = Builtin.getAllBuiltinFns ()
+        let allBuiltins = LanguageTools.allBuiltinFns ()
         if Stdlib.List.findFirst allBuiltins (fun f -> f.name.name == name.name) != Stdlib.Option.Option.None then
           let fqn =
             (ProgramTypes.FQFnName.Builtin

--- a/packages/darklang/languageTools/packageManager.dark
+++ b/packages/darklang/languageTools/packageManager.dark
@@ -70,14 +70,22 @@ module Type =
     : Stdlib.Option.Option<ProgramTypes.PackageType.PackageType> =
     Builtin.pmGetType hash
 
+  /// Every name this type is bound to on <param branchId>. More than one
+  /// when structurally identical types share a hash.
+  let locations
+    (branchId: Uuid)
+    (hash: ProgramTypes.FQTypeName.Package)
+    : List<ProgramTypes.PackageLocation> =
+    Builtin.pmGetLocationsByType branchId hash
+
   let getWithLocation
     (branchId: Uuid)
     (hash: ProgramTypes.FQTypeName.Package)
     : Stdlib.Option.Option<
       ProgramTypes.LocatedItem<ProgramTypes.PackageType.PackageType>> =
-    match Builtin.pmGetType hash with
+    match get hash with
     | Some entity ->
-      match PackageManager.pickLocation PackageManager.PickContext.empty (Builtin.pmGetLocationsByType branchId hash) with
+      match PackageManager.pickLocation PackageManager.PickContext.empty (locations branchId hash) with
       | Some location ->
         Stdlib.Option.Option.Some(
           ProgramTypes.LocatedItem { entity = entity; location = location }
@@ -98,14 +106,21 @@ module Value =
     : Stdlib.Option.Option<ProgramTypes.PackageValue.PackageValue> =
     Builtin.pmGetValue hash
 
+  /// Every name this value is bound to on <param branchId>.
+  let locations
+    (branchId: Uuid)
+    (hash: ProgramTypes.FQValueName.Package)
+    : List<ProgramTypes.PackageLocation> =
+    Builtin.pmGetLocationsByValue branchId hash
+
   let getWithLocation
     (branchId: Uuid)
     (hash: ProgramTypes.FQValueName.Package)
     : Stdlib.Option.Option<
       ProgramTypes.LocatedItem<ProgramTypes.PackageValue.PackageValue>> =
-    match Builtin.pmGetValue hash with
+    match get hash with
     | Some entity ->
-      match PackageManager.pickLocation PackageManager.PickContext.empty (Builtin.pmGetLocationsByValue branchId hash) with
+      match PackageManager.pickLocation PackageManager.PickContext.empty (locations branchId hash) with
       | Some location ->
         Stdlib.Option.Option.Some(
           ProgramTypes.LocatedItem { entity = entity; location = location }
@@ -126,14 +141,21 @@ module Function =
     : Stdlib.Option.Option<ProgramTypes.PackageFn.PackageFn> =
     Builtin.pmGetFn hash
 
+  /// Every name this fn is bound to on <param branchId>.
+  let locations
+    (branchId: Uuid)
+    (hash: ProgramTypes.FQFnName.Package)
+    : List<ProgramTypes.PackageLocation> =
+    Builtin.pmGetLocationsByFn branchId hash
+
   let getWithLocation
     (branchId: Uuid)
     (hash: ProgramTypes.FQFnName.Package)
     : Stdlib.Option.Option<
       ProgramTypes.LocatedItem<ProgramTypes.PackageFn.PackageFn>> =
-    match Builtin.pmGetFn hash with
+    match get hash with
     | Some entity ->
-      match PackageManager.pickLocation PackageManager.PickContext.empty (Builtin.pmGetLocationsByFn branchId hash) with
+      match PackageManager.pickLocation PackageManager.PickContext.empty (locations branchId hash) with
       | Some location ->
         Stdlib.Option.Option.Some(
           ProgramTypes.LocatedItem { entity = entity; location = location }
@@ -148,15 +170,15 @@ let findAny
   (branchId: Uuid)
   (location: ProgramTypes.PackageLocation)
   : Stdlib.Option.Option<(ProgramTypes.Hash * ProgramTypes.ItemKind)> =
-  match Builtin.pmFindType branchId location with
+  match Type.find branchId location with
   | Some hash ->
     Stdlib.Option.Option.Some((hash, ProgramTypes.ItemKind.Type))
   | None ->
-    match Builtin.pmFindFn branchId location with
+    match Function.find branchId location with
     | Some hash ->
       Stdlib.Option.Option.Some((hash, ProgramTypes.ItemKind.Fn))
     | None ->
-      match Builtin.pmFindValue branchId location with
+      match Value.find branchId location with
       | Some hash ->
         Stdlib.Option.Option.Some((hash, ProgramTypes.ItemKind.Value))
       | None -> Stdlib.Option.Option.None

--- a/packages/darklang/languageTools/parser/cliScript.dark
+++ b/packages/darklang/languageTools/parser/cliScript.dark
@@ -340,7 +340,7 @@ let parse
   match source |> LanguageTools.Parser.Parse.initialParse with
   | Error e -> Stdlib.Result.Result.Error(ParseError.Message e)
   | Ok parsedFile ->
-    parseFromWT ctx scriptName (Builtin.parserParseDiagnostics source) parsedFile
+    parseFromWT ctx scriptName (Parse.diagnostics source) parsedFile
 
 
 /// Single-shot parse for CLI use: creates PM and NRContext internally
@@ -372,11 +372,11 @@ let pmWithExtras
   (source: String)
   : Stdlib.Result.Result<ProgramTypes.PackageManager.PackageManager, ParseError> =
   // The range-complete parser, matching the rest of the LSP.
-  match Builtin.parserParseToWrittenTypes source with
+  match Parse.toWrittenTypes source with
   | None -> Stdlib.Result.Result.Error(ParseError.Message "parse failed")
   | Some parsedFile ->
     match
-      parseDecls ctx.owner scriptName (Builtin.parserParseDiagnostics source) parsedFile
+      parseDecls ctx.owner scriptName (Parse.diagnostics source) parsedFile
     with
     | Error e -> Stdlib.Result.Result.Error e
     | Ok moduleWT ->

--- a/packages/darklang/languageTools/parser/parse.dark
+++ b/packages/darklang/languageTools/parser/parse.dark
@@ -1,12 +1,27 @@
 module Darklang.LanguageTools.Parser.Parse
 
 
+/// The written-types tree for <param code>, or {{None}} if the tokenizer
+/// failed outright. Syntax errors short of that come back as a tree plus
+/// `diagnostics`.
+let toWrittenTypes
+  (code: String)
+  : Stdlib.Option.Option<WrittenTypes.ParsedFile> =
+  Builtin.parserParseToWrittenTypes code
+
+
+/// The parser's syntax diagnostics for <param code>, as (range, message)
+/// pairs. Empty on a clean parse.
+let diagnostics (code: String) : List<(Parser.Range * String)> =
+  Builtin.parserParseDiagnostics code
+
+
 let initialParse
   (code: String)
   : Stdlib.Result.Result<WrittenTypes.ParsedFile, String> =
   // The range-complete parser. Every consumer of this fn — canvas modules,
   // CLI scripts, the package-test runner, parsePTExpr — parses through it.
-  match Builtin.parserParseToWrittenTypes code with
+  match toWrittenTypes code with
   | Some parsedFile -> Stdlib.Result.Result.Ok parsedFile
   | None -> Stdlib.Result.Result.Error "parse failed"
 
@@ -41,7 +56,7 @@ let parsePTExprInContext
       NameResolver.NRContext
         { onMissing = NameResolver.OnMissing.Allow
           pm = PackageManager.pm ()
-          branchId = Builtin.scmMainBranchId
+          branchId = Darklang.SCM.Branch.mainBranchId
           owner = owner
           currentModule = currentModule }
 

--- a/packages/darklang/languageTools/writtenTypesToProgramTypes.dark
+++ b/packages/darklang/languageTools/writtenTypesToProgramTypes.dark
@@ -1669,7 +1669,7 @@ let parsedFileAsSourceFile
   )
   =
   let pm = LanguageTools.PackageManager.pm ()
-  let branchId = Builtin.scmMainBranchId
+  let branchId = Darklang.SCM.Branch.mainBranchId
   let ctx =
     NameResolver.NRContext
       { onMissing = NameResolver.OnMissing.Allow

--- a/packages/darklang/llm/tools/file-system.dark
+++ b/packages/darklang/llm/tools/file-system.dark
@@ -27,7 +27,7 @@ let resolveSafePath (path: String) : Stdlib.Result.Result<String, String> =
   else if isUnsafePath path then
     Stdlib.Result.Result.Error unsafePathError
   else
-    let currentDir = Builtin.directoryCurrent ()
+    let currentDir = Stdlib.Cli.FileSystem.currentDirectory ()
     let normalized =
       if path == "." then
         ""
@@ -57,7 +57,7 @@ let formatDirectoryEntries (entries: List<String>) : String =
         | Some n -> n
         | None -> entryPath
 
-      if Builtin.fileIsDirectory entryPath then
+      if Stdlib.Cli.FileSystem.isDirectory entryPath then
         name ++ "/"
       else
         name)
@@ -81,7 +81,7 @@ val maxSearchResults = 50
 val maxSearchFiles = 200
 
 let filePathToDisplayPath (fullPath: String) : String =
-  let cwd = Builtin.directoryCurrent ()
+  let cwd = Stdlib.Cli.FileSystem.currentDirectory ()
   let cwdPrefix = cwd ++ "/"
   if Stdlib.String.startsWith fullPath cwdPrefix then
     Stdlib.String.dropFirst fullPath (Stdlib.String.length cwdPrefix)
@@ -102,7 +102,7 @@ let searchFileForPattern
     if nextState.filesScanned > maxSearchFiles then
       { nextState with hitFileLimit = true }
     else
-      match Builtin.fileRead fullPath with
+      match Stdlib.Cli.FileSystem.readFile fullPath with
       | Error _ -> nextState
       | Ok bytes ->
         let content = Stdlib.String.fromBlobWithReplacement bytes
@@ -139,8 +139,8 @@ let searchPathsForPattern
     match pendingPaths with
     | [] -> state
     | path :: remaining ->
-      if Builtin.fileIsDirectory path then
-        let children = Builtin.directoryList path
+      if Stdlib.Cli.FileSystem.isDirectory path then
+        let children = Stdlib.Cli.FileSystem.listDirectory path
         let nextPending = Stdlib.List.append children remaining
         searchPathsForPattern nextPending pattern state
       else
@@ -171,7 +171,7 @@ let handleRead (input: Json) : Stdlib.Result.Result<ToolOutput, String> =
       match resolveSafePath path with
       | Error e -> Stdlib.Result.Result.Error e
       | Ok fullPath ->
-        match Builtin.fileRead fullPath with
+        match Stdlib.Cli.FileSystem.readFile fullPath with
         | Ok bytes ->
           let content = Stdlib.String.fromBlobWithReplacement bytes
           Stdlib.Result.Result.Ok(ToolOutput.Text content)
@@ -208,10 +208,10 @@ let handleList (input: Json) : Stdlib.Result.Result<ToolOutput, String> =
   match resolveSafePath path with
   | Error e -> Stdlib.Result.Result.Error e
   | Ok fullPath ->
-    if Stdlib.Bool.not (Builtin.fileIsDirectory fullPath) then
+    if Stdlib.Bool.not (Stdlib.Cli.FileSystem.isDirectory fullPath) then
       Stdlib.Result.Result.Error $"Not a directory: {path}"
     else
-      let entries = Builtin.directoryList fullPath
+      let entries = Stdlib.Cli.FileSystem.listDirectory fullPath
       Stdlib.Result.Result.Ok(ToolOutput.Text (formatDirectoryEntries entries))
 
 
@@ -239,7 +239,7 @@ let handleSearch (input: Json) : Stdlib.Result.Result<ToolOutput, String> =
                 hitFileLimit = false }
 
           let finalState =
-            if Builtin.fileIsDirectory fullPath then
+            if Stdlib.Cli.FileSystem.isDirectory fullPath then
               searchPathsForPattern [ fullPath ] pattern initialState
             else
               searchFileForPattern fullPath pattern initialState

--- a/packages/darklang/modelContextProtocol/serverBuilder/io.dark
+++ b/packages/darklang/modelContextProtocol/serverBuilder/io.dark
@@ -3,7 +3,7 @@ module Darklang.ModelContextProtocol.ServerBuilder
 
 /// Read a message from the client using line-based stdio
 let readMessageFromClientWithPath (logFilePath: String) : String =
-  let message = Builtin.stdinReadLine ()
+  let message = Stdlib.Cli.Stdin.readLine ()
   logWithPath logFilePath $"Got message from stdin, length: {(Stdlib.String.length message) |> Stdlib.Int.toString}"
 
   if message == "" then

--- a/packages/darklang/modelContextProtocol/serverBuilder/logging.dark
+++ b/packages/darklang/modelContextProtocol/serverBuilder/logging.dark
@@ -6,7 +6,7 @@ let getLogFilePath (serverName: String) : String =
 let logWithPath (logFilePath: String) (message: String) : Unit =
   let timestamp = (Stdlib.DateTime.now ()) |> Stdlib.DateTime.toString
   let logMessage = $"[{timestamp}] {message}\n"
-  let _ = Builtin.fileAppendText logFilePath logMessage
+  let _ = Stdlib.Cli.FileSystem.appendToFile logFilePath logMessage
   ()
 
 let logIncomingRequestWithPath (logFilePath: String) (message: String) : Unit =
@@ -14,4 +14,4 @@ let logIncomingRequestWithPath (logFilePath: String) (message: String) : Unit =
 
 let logAndSendToClientWithPath (logFilePath: String) (message: String) : Unit =
   logWithPath logFilePath $"Sending to client: {message}"
-  Builtin.printLine message
+  Stdlib.printLine message

--- a/packages/darklang/modelContextProtocol/serverBuilder/main.dark
+++ b/packages/darklang/modelContextProtocol/serverBuilder/main.dark
@@ -218,7 +218,7 @@ let run (server: McpServerBuilder) : Int =
   let logFilePath = getLogFilePath server.name
 
   // clear log file and write a timestamp of the start-up
-  let _deleted = Builtin.fileDelete logFilePath
+  let _deleted = Stdlib.Cli.FileSystem.deleteFile logFilePath
 
   (Stdlib.DateTime.now ())
   |> Stdlib.DateTime.toString

--- a/packages/darklang/prettyPrinter/moduleDeclaration.dark
+++ b/packages/darklang/prettyPrinter/moduleDeclaration.dark
@@ -72,7 +72,7 @@ module ModuleDeclaration =
     (ms: List<Module>)
     (t: LanguageTools.ProgramTypes.PackageType.PackageType)
     : List<Module> =
-    match Darklang.LanguageTools.PackageManager.pickLocation Darklang.LanguageTools.PackageManager.PickContext.empty (Builtin.pmGetLocationsByType branchId t.hash) with
+    match Darklang.LanguageTools.PackageManager.pickLocation Darklang.LanguageTools.PackageManager.PickContext.empty (LanguageTools.PackageManager.Type.locations branchId t.hash) with
     | Some location ->
       let fullPath = Stdlib.List.push location.modules location.owner
       withTypeHelper ms t fullPath
@@ -149,7 +149,7 @@ module ModuleDeclaration =
     (ms: List<Module>)
     (f: LanguageTools.ProgramTypes.PackageFn.PackageFn)
     : List<Module> =
-    match Darklang.LanguageTools.PackageManager.pickLocation Darklang.LanguageTools.PackageManager.PickContext.empty (Builtin.pmGetLocationsByFn branchId f.hash) with
+    match Darklang.LanguageTools.PackageManager.pickLocation Darklang.LanguageTools.PackageManager.PickContext.empty (LanguageTools.PackageManager.Function.locations branchId f.hash) with
     | Some location ->
       let fullPath = Stdlib.List.push location.modules location.owner
       withFnHelper ms f fullPath
@@ -225,7 +225,7 @@ module ModuleDeclaration =
     (ms: List<Module>)
     (v: LanguageTools.ProgramTypes.PackageValue.PackageValue)
     : List<Module> =
-    match Darklang.LanguageTools.PackageManager.pickLocation Darklang.LanguageTools.PackageManager.PickContext.empty (Builtin.pmGetLocationsByValue branchId v.hash) with
+    match Darklang.LanguageTools.PackageManager.pickLocation Darklang.LanguageTools.PackageManager.PickContext.empty (LanguageTools.PackageManager.Value.locations branchId v.hash) with
     | Some location ->
       let fullPath = Stdlib.List.push location.modules location.owner
       withValueHelper ms v fullPath

--- a/packages/darklang/prettyPrinter/programTypes.dark
+++ b/packages/darklang/prettyPrinter/programTypes.dark
@@ -117,7 +117,7 @@ module FQTypeName =
       (ctx: Context)
       (hash: LanguageTools.ProgramTypes.FQTypeName.Package)
       : String =
-      match Darklang.LanguageTools.PackageManager.pickLocation (Context.toPickContext ctx) (Builtin.pmGetLocationsByType ctx.branchId hash) with
+      match Darklang.LanguageTools.PackageManager.pickLocation (Context.toPickContext ctx) (LanguageTools.PackageManager.Type.locations ctx.branchId hash) with
       | Some l -> l.name
       | None -> shortHash hash
 
@@ -125,7 +125,7 @@ module FQTypeName =
       (ctx: Context)
       (hash: LanguageTools.ProgramTypes.FQTypeName.Package)
       : String =
-      match Darklang.LanguageTools.PackageManager.pickLocation (Context.toPickContext ctx) (Builtin.pmGetLocationsByType ctx.branchId hash) with
+      match Darklang.LanguageTools.PackageManager.pickLocation (Context.toPickContext ctx) (LanguageTools.PackageManager.Type.locations ctx.branchId hash) with
       | Some l ->
         packageNameWithContext ctx l.owner l.modules l.name
       | None -> shortHash hash
@@ -168,7 +168,7 @@ module FQValueName =
       (ctx: Context)
       (hash: LanguageTools.ProgramTypes.FQValueName.Package)
       : String =
-      match Darklang.LanguageTools.PackageManager.pickLocation (Context.toPickContext ctx) (Builtin.pmGetLocationsByValue ctx.branchId hash) with
+      match Darklang.LanguageTools.PackageManager.pickLocation (Context.toPickContext ctx) (LanguageTools.PackageManager.Value.locations ctx.branchId hash) with
       | Some l -> l.name
       | None -> shortHash hash
 
@@ -176,7 +176,7 @@ module FQValueName =
       (ctx: Context)
       (hash: LanguageTools.ProgramTypes.FQValueName.Package)
       : String =
-      match Darklang.LanguageTools.PackageManager.pickLocation (Context.toPickContext ctx) (Builtin.pmGetLocationsByValue ctx.branchId hash) with
+      match Darklang.LanguageTools.PackageManager.pickLocation (Context.toPickContext ctx) (LanguageTools.PackageManager.Value.locations ctx.branchId hash) with
       | Some l ->
         packageNameWithContext ctx l.owner l.modules l.name
       | None -> shortHash hash
@@ -225,7 +225,7 @@ module FQFnName =
       (ctx: Context)
       (hash: LanguageTools.ProgramTypes.FQFnName.Package)
       : String =
-      match Darklang.LanguageTools.PackageManager.pickLocation (Context.toPickContext ctx) (Builtin.pmGetLocationsByFn ctx.branchId hash) with
+      match Darklang.LanguageTools.PackageManager.pickLocation (Context.toPickContext ctx) (LanguageTools.PackageManager.Function.locations ctx.branchId hash) with
       | Some l -> l.name
       | None -> shortHash hash
 
@@ -233,7 +233,7 @@ module FQFnName =
       (ctx: Context)
       (hash: LanguageTools.ProgramTypes.FQFnName.Package)
       : String =
-      match Darklang.LanguageTools.PackageManager.pickLocation (Context.toPickContext ctx) (Builtin.pmGetLocationsByFn ctx.branchId hash) with
+      match Darklang.LanguageTools.PackageManager.pickLocation (Context.toPickContext ctx) (LanguageTools.PackageManager.Function.locations ctx.branchId hash) with
       | Some l ->
         packageNameWithContext ctx l.owner l.modules l.name
       | None -> shortHash hash

--- a/packages/darklang/prettyPrinter/runtimeTypes.dark
+++ b/packages/darklang/prettyPrinter/runtimeTypes.dark
@@ -63,7 +63,7 @@ module FQTypeName =
         (branchId: Uuid)
         (hash: LanguageTools.RuntimeTypes.FQTypeName.Package)
     : String =
-    resolvePackageHash LanguageTools.PackageManager.PickContext.empty (Builtin.pmGetLocationsByType branchId hash) hash
+    resolvePackageHash LanguageTools.PackageManager.PickContext.empty (LanguageTools.PackageManager.Type.locations branchId hash) hash
 
 // TODO rename to fqtypeName?
 let typeName
@@ -90,7 +90,7 @@ module FQValueName =
         (branchId: Uuid)
         (hash: LanguageTools.RuntimeTypes.FQValueName.Package)
     : String =
-    resolvePackageHash LanguageTools.PackageManager.PickContext.empty (Builtin.pmGetLocationsByValue branchId hash) hash
+    resolvePackageHash LanguageTools.PackageManager.PickContext.empty (LanguageTools.PackageManager.Value.locations branchId hash) hash
 
 // TODO rename to fqvalueName?
 let valueName
@@ -118,7 +118,7 @@ module FQFnName =
         (branchId: Uuid)
         (hash: LanguageTools.RuntimeTypes.FQFnName.Package)
     : String =
-    resolvePackageHash LanguageTools.PackageManager.PickContext.empty (Builtin.pmGetLocationsByFn branchId hash) hash
+    resolvePackageHash LanguageTools.PackageManager.PickContext.empty (LanguageTools.PackageManager.Function.locations branchId hash) hash
 
 
 // TODO rename to fqfnName?
@@ -190,7 +190,7 @@ let typeReference
       | Ok name ->
         match name with
         | Package hash ->
-          let locations = Builtin.pmGetLocationsByType branchId hash
+          let locations = LanguageTools.PackageManager.Type.locations branchId hash
           resolvePackageHashWithOriginalName LanguageTools.PackageManager.PickContext.empty locations typ.originalName hash
       | Error e -> nameResolutionError e
 

--- a/packages/darklang/stdlib/cli/bash.dark
+++ b/packages/darklang/stdlib/cli/bash.dark
@@ -3,7 +3,7 @@ module Darklang.Stdlib.Cli.Bash
 
 /// Read the content of .bashrc file
 let readBashrc () : Result.Result<String, String> =
-  (Builtin.fileRead "$HOME/.bashrc")
+  (Stdlib.Cli.FileSystem.readFile "$HOME/.bashrc")
   |> Result.map Stdlib.String.fromBlobWithReplacement
   |> Result.mapError Stdlib.Cli.FileSystem.FileError.toString
 
@@ -14,7 +14,7 @@ let applyBashConfigChanges () : Result.Result<Unit, String> =
 
 /// Write content to .bashrc file
 let overwriteBashrc (content: String) : Result.Result<Unit, String> =
-  (Builtin.fileWrite (Stdlib.String.toBlob content) "$HOME/.bashrc")
+  (FileSystem.overwriteFile "$HOME/.bashrc" (Stdlib.String.toBlob content))
   |> Result.map (fun _ -> ())
 
 
@@ -47,7 +47,7 @@ let addAlias
     | Ok() ->
       // CLEANUP: in bash `source ~/.bashrc` doesn't work from a subprocess, This is why we need to print a message to the user to run the command manually
       // one workaround is adding `[[ -f ~/.bashrc ]] && . ~/.bashrc` which makes sure .bashrc exists and sources it, applying it configuration to the current shell session.
-      Builtin.printLine
+      Stdlib.printLine
         "Changes have been made to your .bashrc file. \nTo apply these changes to your current terminal session, please run the following command:\nsource ~/.bashrc\n\n "
 
       applyBashConfigChanges ()
@@ -69,7 +69,7 @@ let addToPath (dir: String) : Result.Result<Unit, String> =
 
       match overwriteBashrc updatedContent with
       | Ok() ->
-        Builtin.printLine
+        Stdlib.printLine
           "Changes have been made to your .bashrc file. \nTo apply these changes to your current terminal session, please run the following command:\nsource ~/.bashrc\n\n "
 
         applyBashConfigChanges ()

--- a/packages/darklang/stdlib/cli/daemon.dark
+++ b/packages/darklang/stdlib/cli/daemon.dark
@@ -106,7 +106,7 @@ let stop (name: String) : Stdlib.Result.Result<String, String> =
 // The executable to re-invoke for the detached child — the `dark` binary currently running. No env var:
 // `getCurrentExecutablePath` is what the installer already uses to find itself.
 let launcher () : String =
-  Builtin.getCurrentExecutablePath ()
+  Stdlib.Cli.Sys.currentExecutablePath ()
 
 
 // Spawn `expr` DETACHED so it survives this process exiting: `nohup … &` backgrounds it + shields it

--- a/packages/darklang/stdlib/cli/file.dark
+++ b/packages/darklang/stdlib/cli/file.dark
@@ -37,7 +37,7 @@ let copy (src: String) (dst: String) : Result.Result<Unit, Posix.Error> =
     match Posix.openFile src (Posix.OpenFlags.rdonly ()) 0 with
     | Ok srcFd ->
       let readResult = Posix.fdReadAll srcFd []
-      let _ = Builtin.posixFdClose srcFd
+      let _ = Posix.fdClose srcFd
 
       match readResult with
       | Ok bytes ->
@@ -50,8 +50,8 @@ let copy (src: String) (dst: String) : Result.Result<Unit, Posix.Error> =
 
         match Posix.openFile dst flags srcMode with
         | Ok dstFd ->
-          let writeResult = Builtin.posixFdWrite dstFd bytes
-          let _ = Builtin.posixFdClose dstFd
+          let writeResult = Posix.fdWrite dstFd bytes
+          let _ = Posix.fdClose dstFd
 
           match writeResult with
           | Ok _ -> Stdlib.Result.Result.Ok()
@@ -72,7 +72,7 @@ let readBytes (path: String) : Result.Result<Blob, Posix.Error> =
   | Ok fd ->
     let result = Posix.fdReadAll fd []
 
-    let _ = Builtin.posixFdClose fd
+    let _ = Posix.fdClose fd
     result
   | Error e -> Stdlib.Result.Result.Error e
 
@@ -83,7 +83,7 @@ let readText (path: String) : Result.Result<String, Posix.Error> =
   | Ok fd ->
     let result = Posix.fdReadAll fd []
 
-    let _ = Builtin.posixFdClose fd
+    let _ = Posix.fdClose fd
 
     match result with
     | Ok blob ->
@@ -185,7 +185,7 @@ let readLastLines
       | Ok fd ->
         let tailResult =
           readTailChunks fd fileSize count 0 []
-        let _closed = Builtin.posixFdClose fd
+        let _closed = Posix.fdClose fd
 
         tailResult
         |> Stdlib.Result.andThen (fun (blob, startedAtBeginning) ->
@@ -230,9 +230,9 @@ let writeText (path: String) (content: String) : Result.Result<Unit, Posix.Error
   match Posix.openFile path flags Posix.Modes.defaultFile with
   | Ok fd ->
     let blob = Stdlib.String.toBlob content
-    let result = Builtin.posixFdWrite fd blob
+    let result = Posix.fdWrite fd blob
 
-    let _ = Builtin.posixFdClose fd
+    let _ = Posix.fdClose fd
 
     match result with
     | Ok _ -> Stdlib.Result.Result.Ok()
@@ -252,9 +252,9 @@ let appendText (path: String) (content: String) : Result.Result<Unit, Posix.Erro
   match Posix.openFile path flags Posix.Modes.defaultFile with
   | Ok fd ->
     let blob = Stdlib.String.toBlob content
-    let result = Builtin.posixFdWrite fd blob
+    let result = Posix.fdWrite fd blob
 
-    let _ = Builtin.posixFdClose fd
+    let _ = Posix.fdClose fd
 
     match result with
     | Ok _ -> Stdlib.Result.Result.Ok()
@@ -274,7 +274,7 @@ let touch (path: String) : Result.Result<Unit, Posix.Error> =
 
     match Posix.openFile path flags Posix.Modes.defaultFile with
     | Ok fd ->
-      let _ = Builtin.posixFdClose fd
+      let _ = Posix.fdClose fd
       Stdlib.Result.Result.Ok()
     | Error e -> Stdlib.Result.Result.Error e
 
@@ -293,7 +293,7 @@ let createTemp () : Result.Result<String, Posix.Error> =
 
   (Posix.mkstemp prefix)
   |> Stdlib.Result.map (fun result ->
-    let _ = Builtin.posixFdClose (Stdlib.Tuple2.first result)
+    let _ = Posix.fdClose (Stdlib.Tuple2.first result)
     Stdlib.Tuple2.second result)
 
 
@@ -355,8 +355,8 @@ let writeAtomic (path: String) (content: String) : Result.Result<Unit, Posix.Err
     let fd = Stdlib.Tuple2.first result
     let tmpPath = Stdlib.Tuple2.second result
     let blob = Stdlib.String.toBlob content
-    let writeResult = Builtin.posixFdWrite fd blob
-    let _ = Builtin.posixFdClose fd
+    let writeResult = Posix.fdWrite fd blob
+    let _ = Posix.fdClose fd
 
     match writeResult with
     | Ok _ -> Posix.rename tmpPath path
@@ -378,10 +378,10 @@ let withLock (path: String) (fn: Unit -> 'a) : Result.Result<'a, Posix.Error> =
     | Ok _ ->
       let result = fn ()
       let _ = Posix.flock fd false
-      let _ = Builtin.posixFdClose fd
+      let _ = Posix.fdClose fd
       Stdlib.Result.Result.Ok result
     | Error e ->
-      let _ = Builtin.posixFdClose fd
+      let _ = Posix.fdClose fd
       Stdlib.Result.Result.Error e
   | Error e -> Stdlib.Result.Result.Error e
 

--- a/packages/darklang/stdlib/cli/fileSystem.dark
+++ b/packages/darklang/stdlib/cli/fileSystem.dark
@@ -1,3 +1,9 @@
+/// File and directory operations, over the runtime's `file*` and `directory*`
+/// builtins.
+///
+/// `Stdlib.Cli.File` and `Stdlib.Cli.Dir` cover much of the same ground through
+/// posix syscalls, and carry an errno on failure. The two families haven't been
+/// merged; this is the one the CLI, LSP and agent tools call.
 module Darklang.Stdlib.Cli.FileSystem
 
 
@@ -21,9 +27,40 @@ module FileError =
     | Other msg -> msg
 
 
+/// The process's current working directory.
+let currentDirectory () : String =
+  Builtin.directoryCurrent ()
+
+
+/// Full paths of the entries in the directory at <param path>.
+let listDirectory (path: String) : List<String> =
+  Builtin.directoryList path
+
+
+/// Is there a file or directory at <param path>?
+let pathExists (path: String) : Bool =
+  Builtin.fileExists path
+
+
+/// Is <param path> a directory?
+let isDirectory (path: String) : Bool =
+  Builtin.fileIsDirectory path
+
+
+/// Delete the file at <param path>.
+let deleteFile (path: String) : Result.Result<Unit, String> =
+  Builtin.fileDelete path
+
+
+/// Append <param content> to the file at <param path>, creating the file if
+/// it isn't there.
+let appendToFile (path: String) (content: String) : Result.Result<Unit, String> =
+  Builtin.fileAppendText path content
+
+
 // Get files in a directory - returns just filenames
 let getDirectoryContents (path: String) : List<String> =
-  let currentDir = Builtin.directoryCurrent ()
+  let currentDir = currentDirectory ()
 
   let fullPath =
     if Stdlib.String.startsWith path "/" then
@@ -37,7 +74,7 @@ let getDirectoryContents (path: String) : List<String> =
           path
       $"{currentDir}/{normalizedPath}"
 
-  let files = Builtin.directoryList fullPath
+  let files = listDirectory fullPath
 
   files
   |> Stdlib.List.map (fun fullFilePath ->
@@ -51,7 +88,7 @@ let getDirectoryContents (path: String) : List<String> =
 
 // Check if a path is a directory - expects full path
 let isDirectoryAtPath (dirPath: String) (fileName: String) : Bool =
-  let currentDir = Builtin.directoryCurrent ()
+  let currentDir = currentDirectory ()
   let normalizedDirPath =
     if Stdlib.String.startsWith dirPath "/" then
       dirPath
@@ -67,6 +104,13 @@ let isDirectoryAtPath (dirPath: String) (fileName: String) : Bool =
 /// Read an entire file as a Blob.
 let readFile (path: String) : Result.Result<Blob, FileError> =
   Builtin.fileRead path
+
+
+/// Write <param content> to <param path>, replacing whatever's there. The
+/// parent directory has to exist already; <fn writeFile> is this plus the
+/// mkdir.
+let overwriteFile (path: String) (content: Blob) : Result.Result<Unit, String> =
+  Builtin.fileWrite content path
 
 
 /// Read an entire file and decode it as UTF-8. Convenience over
@@ -96,4 +140,4 @@ let writeFile (path: String) (content: Blob) : Result.Result<Unit, String> =
 
   match mkdirResult with
   | Error e -> Stdlib.Result.Result.Error e
-  | Ok _ -> Builtin.fileWrite content path
+  | Ok _ -> overwriteFile path content

--- a/packages/darklang/stdlib/cli/fish.dark
+++ b/packages/darklang/stdlib/cli/fish.dark
@@ -3,13 +3,15 @@ module Darklang.Stdlib.Cli.Fish
 
 /// Read the content of config.fish file
 let readFishConfig () : Result.Result<String, String> =
-  (Builtin.fileRead "$HOME/.config/fish/config.fish")
+  (Stdlib.Cli.FileSystem.readFile "$HOME/.config/fish/config.fish")
   |> Result.map Stdlib.String.fromBlobWithReplacement
   |> Result.mapError Stdlib.Cli.FileSystem.FileError.toString
 
 /// Overwrite what's in the config.fish file
 let overwriteFishConfig (content: String) : Result.Result<Unit, String> =
-  (Builtin.fileWrite (Stdlib.String.toBlob content) "$HOME/.config/fish/config.fish")
+  (FileSystem.overwriteFile
+    "$HOME/.config/fish/config.fish"
+    (Stdlib.String.toBlob content))
   |> Result.map (fun _ -> ())
 
 

--- a/packages/darklang/stdlib/cli/log.dark
+++ b/packages/darklang/stdlib/cli/log.dark
@@ -5,20 +5,20 @@ module Darklang.Stdlib.Cli.Log
 
 /// Log an info message (green prefix)
 let info (msg: String) : Unit =
-  Builtin.printLine ($"{UI.Color.green "[INFO]"} {msg}")
+  Stdlib.printLine ($"{UI.Color.green "[INFO]"} {msg}")
 
 /// Log a warning message (yellow prefix)
 let warn (msg: String) : Unit =
-  Builtin.printLine ($"{UI.Color.yellow "[WARN]"} {msg}")
+  Stdlib.printLine ($"{UI.Color.yellow "[WARN]"} {msg}")
 
 /// Log an error message (red prefix)
 let error (msg: String) : Unit =
-  Builtin.printLine ($"{UI.Color.red "[ERROR]"} {msg}")
+  Stdlib.printLine ($"{UI.Color.red "[ERROR]"} {msg}")
 
 /// Log a debug message (gray prefix)
 let debug (msg: String) : Unit =
-  Builtin.printLine ($"{UI.Color.gray "[DEBUG]"} {msg}")
+  Stdlib.printLine ($"{UI.Color.gray "[DEBUG]"} {msg}")
 
 /// Log a success message (green prefix with checkmark)
 let success (msg: String) : Unit =
-  Builtin.printLine ($"{UI.Color.green "[OK]"} {msg}")
+  Stdlib.printLine ($"{UI.Color.green "[OK]"} {msg}")

--- a/packages/darklang/stdlib/cli/posix.dark
+++ b/packages/darklang/stdlib/cli/posix.dark
@@ -43,6 +43,17 @@ let fdRead (fd: Int) (count: Int) : Result.Result<Blob, Error> =
   Builtin.posixFdRead fd count
 
 
+/// Write <param bytes> to an open file descriptor. Returns the number
+/// of bytes written.
+let fdWrite (fd: Int) (bytes: Blob) : Result.Result<Int, Error> =
+  Builtin.posixFdWrite fd bytes
+
+
+/// Close an open file descriptor.
+let fdClose (fd: Int) : Result.Result<Unit, Error> =
+  Builtin.posixFdClose fd
+
+
 /// Read all bytes from a file descriptor until EOF.
 /// Accumulates chunks (as Blobs) and concats once at EOF.
 let fdReadAll
@@ -123,7 +134,7 @@ let readlink (path: String) : Result.Result<String, Error> =
 /// Uses readlink — returns Ok true/false, or Error on permission/other failures.
 /// readlink returns EINVAL when the target is not a symlink.
 let isSymlink (path: String) : Result.Result<Bool, Error> =
-  match Builtin.posixReadlink path with
+  match readlink path with
   | Ok _ -> Stdlib.Result.Result.Ok true
   | Error e ->
     if e.errno == Errno.einval then
@@ -161,6 +172,11 @@ let listDir (path: String) : Result.Result<List<String>, Error> =
 /// Get an environment variable
 let getenv (name: String) : Stdlib.Option.Option<String> =
   Builtin.posixGetenv name
+
+
+/// System name info: (sysname, nodename, machine).
+let uname () : Result.Result<(String * String * String), Error> =
+  Builtin.posixUname ()
 
 
 /// Send a signal to a process

--- a/packages/darklang/stdlib/cli/stdin.dark
+++ b/packages/darklang/stdlib/cli/stdin.dark
@@ -1,6 +1,17 @@
 module Darklang.Stdlib.Cli.Stdin
 
 
+/// Read one line from stdin, without its trailing newline. Blocks until a
+/// line (or EOF) arrives.
+let readLine () : String =
+  Builtin.stdinReadLine ()
+
+
+/// Read all of stdin, until EOF.
+let readAll () : String =
+  Builtin.stdinReadAll ()
+
+
 module Key =
   type Key =
     | None
@@ -461,7 +472,7 @@ module Key =
   /// Display name of the key, e.g. `Enter` or `A`
   let toString (k: Key): String =
     // toRepr prints the fully-qualified case name; keep just the last segment
-    (Builtin.toRepr k)
+    (Stdlib.toRepr k)
     |> Stdlib.String.split "."
     |> Stdlib.List.last
     |> Stdlib.Option.withDefault ""

--- a/packages/darklang/stdlib/cli/sys.dark
+++ b/packages/darklang/stdlib/cli/sys.dark
@@ -14,20 +14,25 @@ let currentUser () : Stdlib.Option.Option<String> =
 
 /// Get the system hostname.
 let hostname () : Result.Result<String, Posix.Error> =
-  (Builtin.posixUname ())
+  (Posix.uname ())
   |> Stdlib.Result.map (fun result -> Stdlib.Tuple3.second result)
 
 
 /// Get the operating system name (e.g. "Linux", "Darwin").
 let os () : Result.Result<String, Posix.Error> =
-  (Builtin.posixUname ())
+  (Posix.uname ())
   |> Stdlib.Result.map (fun result -> Stdlib.Tuple3.first result)
 
 
 /// Get the CPU architecture (e.g. "x86_64", "aarch64").
 let arch () : Result.Result<String, Posix.Error> =
-  (Builtin.posixUname ())
+  (Posix.uname ())
   |> Stdlib.Result.map (fun result -> Stdlib.Tuple3.third result)
+
+
+/// The path of the running executable.
+let currentExecutablePath () : String =
+  Builtin.getCurrentExecutablePath ()
 
 
 /// Get the number of available CPUs.

--- a/packages/darklang/stdlib/cli/ui/progress.dark
+++ b/packages/darklang/stdlib/cli/ui/progress.dark
@@ -21,8 +21,8 @@ let bar (current: Int) (total: Int) (label: String) : Unit =
     if total == 0 then 0
     else Stdlib.Int.divide (current * 100) total
 
-  Builtin.print
+  Stdlib.print
     $"\r[{filledStr}{emptyStr}] {Stdlib.Int.toString pct}% {label}"
 
-  if current >= total then Builtin.printLine ""
+  if current >= total then Stdlib.printLine ""
   else ()

--- a/packages/darklang/stdlib/cli/ui/prompt.dark
+++ b/packages/darklang/stdlib/cli/ui/prompt.dark
@@ -3,36 +3,36 @@ module Darklang.Stdlib.Cli.UI.Prompt
 
 /// Ask the user for text input.
 let ask (question: String) : String =
-  Builtin.print ($"{question} ")
-  Builtin.stdinReadLine ()
+  Stdlib.print ($"{question} ")
+  Stdlib.Cli.Stdin.readLine ()
 
 
 /// Ask the user a yes/no question. Returns true for yes.
 let confirm (question: String) : Bool =
-  Builtin.print ($"{question} [y/N] ")
-  let answer = Stdlib.String.toLowercase (Builtin.stdinReadLine ())
+  Stdlib.print ($"{question} [y/N] ")
+  let answer = Stdlib.String.toLowercase (Stdlib.Cli.Stdin.readLine ())
   answer == "y" || answer == "yes"
 
 
 /// Ask the user to select from a list of choices. Returns the chosen item.
 let select (question: String) (choices: List<String>) : String =
-  Builtin.printLine question
+  Stdlib.printLine question
 
   let _ =
     choices
     |> Stdlib.List.indexedMap (fun i choice ->
-      Builtin.printLine ($"  {Color.bold (Stdlib.Int.toString (i + 1))}. {choice}"))
+      Stdlib.printLine ($"  {Color.bold (Stdlib.Int.toString (i + 1))}. {choice}"))
 
-  Builtin.print "Enter number: "
-  let input = Builtin.stdinReadLine ()
+  Stdlib.print "Enter number: "
+  let input = Stdlib.Cli.Stdin.readLine ()
 
   match Stdlib.Int.parse input with
   | Ok n ->
     match Stdlib.List.getAt choices (n - 1) with
     | Some choice -> choice
     | None ->
-      Builtin.printLine (Color.red "Invalid selection")
+      Stdlib.printLine (Color.red "Invalid selection")
       select question choices
   | Error _e ->
-    Builtin.printLine (Color.red "Please enter a number")
+    Stdlib.printLine (Color.red "Please enter a number")
     select question choices

--- a/packages/darklang/stdlib/cli/ui/spinner.dark
+++ b/packages/darklang/stdlib/cli/ui/spinner.dark
@@ -6,7 +6,7 @@ module Darklang.Stdlib.Cli.UI.Spinner
 /// Note: not a real spinner — prints a static message. A real spinner
 /// would need background threads, which Dark doesn't support yet.
 let run (message: String) (fn: Unit -> 'a) : 'a =
-  Builtin.print ($"{message}... ")
+  Stdlib.print ($"{message}... ")
   let result = fn ()
-  Builtin.printLine (Color.green "done")
+  Stdlib.printLine (Color.green "done")
   result

--- a/packages/darklang/stdlib/cli/ui/table.dark
+++ b/packages/darklang/stdlib/cli/ui/table.dark
@@ -36,7 +36,7 @@ let print (columns: List<String>) (rows: List<List<String>>) : Unit =
       | None -> header)
     |> Stdlib.String.join "  "
 
-  Builtin.printLine (Color.bold headerLine)
+  Stdlib.printLine (Color.bold headerLine)
 
   // Print separator
   let sepLine =
@@ -44,7 +44,7 @@ let print (columns: List<String>) (rows: List<List<String>>) : Unit =
     |> Stdlib.List.map (fun w -> Stdlib.String.repeat "-" w)
     |> Stdlib.String.join "  "
 
-  Builtin.printLine sepLine
+  Stdlib.printLine sepLine
 
   // Print data rows
   let _ =
@@ -63,6 +63,6 @@ let print (columns: List<String>) (rows: List<List<String>>) : Unit =
           | None -> cell)
         |> Stdlib.String.join "  "
 
-      Builtin.printLine line)
+      Stdlib.printLine line)
 
   ()

--- a/packages/darklang/stdlib/cli/zsh.dark
+++ b/packages/darklang/stdlib/cli/zsh.dark
@@ -3,13 +3,13 @@ module Darklang.Stdlib.Cli.Zsh
 
 /// Read the content of .zshrc file
 let readZshrc () : Result.Result<String, String> =
-  (Builtin.fileRead "$HOME/.zshrc")
+  (Stdlib.Cli.FileSystem.readFile "$HOME/.zshrc")
   |> Result.map Stdlib.String.fromBlobWithReplacement
   |> Result.mapError Stdlib.Cli.FileSystem.FileError.toString
 
 /// Overwrite what's in the .zshrc file
 let overwriteZshrc (content: String) : Result.Result<Unit, String> =
-  (Builtin.fileWrite (Stdlib.String.toBlob content) "$HOME/.zshrc")
+  (FileSystem.overwriteFile "$HOME/.zshrc" (Stdlib.String.toBlob content))
   |> Result.map (fun _ -> ())
 
 

--- a/packages/darklang/stdlib/httpclient.dark
+++ b/packages/darklang/stdlib/httpclient.dark
@@ -270,7 +270,7 @@ module Sse =
     (bytes: Stream<UInt8>)
     (state: ParseState)
     : Stdlib.Option.Option<(Event * ParseState)> =
-    match Builtin.streamNext<UInt8> bytes with
+    match Stdlib.Stream.next<UInt8> bytes with
     | None ->
       // End of stream. Flush any buffered lines as a final event
       // (SSE spec: a trailing blank line is optional).
@@ -351,5 +351,5 @@ module Sse =
   /// so a slow LLM response surfaces tokens as they're produced.
   let parse (bytes: Stream<UInt8>) : Stream<Event> =
     let initial = ParseState { lastId = ""; currentLines = []; currentLine = [] }
-    Builtin.streamUnfold<ParseState, Event> initial (fun state ->
+    Stdlib.Stream.unfold<ParseState, Event> initial (fun state ->
       pullNextEvent bytes state)

--- a/packages/darklang/stdlib/noModule.dark
+++ b/packages/darklang/stdlib/noModule.dark
@@ -7,3 +7,7 @@ let equals (a: 'a) (b: 'a) : Bool = Builtin.equals a b
 
 /// Returns true if the two value are not equal
 let notEquals (a: 'a) (b: 'a) : Bool = Builtin.notEquals a b
+
+/// A developer-facing string for <param value>: the shape you'd want in a
+/// debug print, not something to parse or show a user.
+let toRepr (value: 'a) : String = Builtin.toRepr value

--- a/packages/darklang/stdlib/valueSearch.dark
+++ b/packages/darklang/stdlib/valueSearch.dark
@@ -64,7 +64,7 @@ let findByType
   valueHashes
   |> Stdlib.List.filterMap (fun valueHash ->
     // Get location for this value
-    match Darklang.LanguageTools.PackageManager.pickLocation Darklang.LanguageTools.PackageManager.PickContext.empty (Builtin.pmGetLocationsByValue branchId valueHash) with
+    match Darklang.LanguageTools.PackageManager.pickLocation Darklang.LanguageTools.PackageManager.PickContext.empty (LanguageTools.PackageManager.Value.locations branchId valueHash) with
     | Some location ->
       // Check if it's in the target namespace
       let valuePath = Stdlib.List.append [ location.owner ] location.modules

--- a/packages/darklang/tracing/store.dark
+++ b/packages/darklang/tracing/store.dark
@@ -1,0 +1,78 @@
+/// Reads and maintenance over the recorded trace store.
+///
+/// These are thin wrappers over the `traces*` builtins, typed to the shapes
+/// in `Darklang.Tracing`: the builtins return bare `List<'a>`, so without a
+/// wrapper every caller re-states the type it expects. Consumers (the CLI
+/// `traces` command, the workbench, dashboards) go through here.
+module Darklang.Tracing.Store
+
+
+/// Is trace recording on for this process? Worth asking before reporting an
+/// empty result: with recording off, every query returns empty whatever ran.
+let enabled () : Bool =
+  Builtin.tracesEnabled ()
+
+
+/// The most recent <param limit> traces, newest first.
+let list (limit: Int) : List<TraceSummary> =
+  Builtin.tracesList limit
+
+
+/// The most recent <param limit> traces that called <param fnName>.
+let listByFn (fnName: String) (limit: Int) : List<TraceSummary> =
+  Builtin.tracesListByFn fnName limit
+
+
+/// The most recent <param limit> traces whose inputs, args or results
+/// contain <param pattern>.
+let find (pattern: String) (limit: Int) : List<TraceSummary> =
+  Builtin.tracesFind pattern limit
+
+
+/// Full payload for one trace: summary, inputs and fn calls.
+let view (traceID: String) : Stdlib.Option.Option<TraceData> =
+  Builtin.tracesView traceID
+
+
+/// The trace's input as source text, for replay. {{None}} when the trace
+/// is missing or its input isn't a string (e.g. an HTTP Request record).
+let getInput (traceID: String) : Stdlib.Option.Option<String> =
+  Builtin.tracesGetInput traceID
+
+
+/// Expand a trace-ID prefix to the full ID, or say why it can't be.
+let resolveID (input: String) : Stdlib.Result.Result<String, String> =
+  Builtin.tracesResolveID input
+
+
+/// Per-fn totals over the last <param traceLimit> traces:
+/// (fnName, totalMs, maxMs, callCount).
+let hotspots (traceLimit: Int) : List<(String * Int * Int * Int)> =
+  Builtin.tracesHotspots traceLimit
+
+
+/// Per-handler totals over the last <param traceLimit> traces:
+/// (handler, totalMs, maxMs, traceCount).
+let statsByHandler (traceLimit: Int) : List<(String * Int * Int * Int)> =
+  Builtin.tracesStatsByHandler traceLimit
+
+
+/// Delete one trace by full ID. Returns the number of rows deleted.
+let delete (traceID: String) : Int =
+  Builtin.tracesDelete traceID
+
+
+/// Delete every trace. Returns the number deleted.
+let clear () : Int =
+  Builtin.tracesClear ()
+
+
+/// Delete traces recorded before <param cutoff>. Returns the number deleted.
+let clearBefore (cutoff: String) : Int =
+  Builtin.tracesClearBefore cutoff
+
+
+/// Keep the <param keepN> most recent traces, delete the rest. Returns the
+/// number deleted.
+let pruneKeep (keepN: Int) : Int =
+  Builtin.tracesPruneKeep keepN

--- a/packages/darklang/wasm-repl-server.dark
+++ b/packages/darklang/wasm-repl-server.dark
@@ -40,7 +40,7 @@ let router (req: Stdlib.Http.Request) : Stdlib.Http.Response =
   else
     let file = if path == "/" then "/index.html" else path
 
-    match Builtin.fileRead (root () ++ file) with
+    match Stdlib.Cli.FileSystem.readFile (root () ++ file) with
     | Ok blob ->
       // HEAD gets the same headers/status as GET, minus the body
       let body = if method == "HEAD" then Stdlib.String.toBlob "" else blob

--- a/packages/darklang/wip/ai/anthropic/integration-tests.dark
+++ b/packages/darklang/wip/ai/anthropic/integration-tests.dark
@@ -944,7 +944,7 @@ module BatchTests =
               Stdlib.Result.Result.Ok currentBatch
             else
               // Wait 2 seconds before next poll
-              let _ = Builtin.timeSleep 2000.0
+              let _ = Stdlib.Cli.Posix.sleep 2000.0
               Stdlib.Result.Result.Error "Still processing"
           | Error e ->
             Stdlib.Result.Result.Error (Response.ApiError.toString e))

--- a/packages/feriel/modelContextProtocol/push-notification/tools/pushover.dark
+++ b/packages/feriel/modelContextProtocol/push-notification/tools/pushover.dark
@@ -1,9 +1,9 @@
 module Feriel.ModelContextProtocol.PushNotification.Tools.Pushover
 
 let sendNotification (message: String) (title: String) : String =
-  match Builtin.environmentGet "PUSHOVER_USER_KEY" with
+  match Stdlib.Env.get "PUSHOVER_USER_KEY" with
   | Some userKey ->
-    (match Builtin.environmentGet "PUSHOVER_APP_TOKEN" with
+    (match Stdlib.Env.get "PUSHOVER_APP_TOKEN" with
     | Some appToken ->
       let url = "https://api.pushover.net/1/messages.json"
       let headers = [ ("Content-Type", "application/x-www-form-urlencoded") ]

--- a/packages/internal/tests.dark
+++ b/packages/internal/tests.dark
@@ -52,7 +52,7 @@ let parseSingleTestFromFile
         LanguageTools.NameResolver.NRContext
           { onMissing = LanguageTools.NameResolver.OnMissing.ThrowError
             pm = pm
-            branchId = Builtin.scmMainBranchId
+            branchId = Darklang.SCM.Branch.mainBranchId
             owner = ""
             currentModule = [] }
 


### PR DESCRIPTION
This takes `tests/builtin`'s multi-use allowlist from 55 entries to 1, and adds the mirror check on the other side: every registered builtin needs at least one Dark caller somewhere in the repo. Branch: `shrink-builtin-multiuse-allowlist`.

## Why

The allowlist was doing two jobs at once. Some entries were genuinely intentional; most were just "we haven't gotten to it yet", and the TODO above it said so. Once you start pulling on them, nearly all of them come out: the builtin gets one wrapper that names it, types it and documents it, and the callers go through the wrapper. The interesting cases are the ones where the wrapper is an actual improvement rather than a formality: `tracesList` returns a bare `List<'a>`, so every one of its seven call sites had to re-state the type it expected. `Darklang.Tracing.Store.list` says `List<TraceSummary>` once.

The key decision is what stays. `unwrap` does, and it's the only one. I checked that a generic wrapper is possible - `let unwrap (value: 'optOrRes) : 'a = Builtin.unwrap value` typechecks and runs for both Option and Result - so the reason isn't that it can't be done. It's that it would cost a package call at every one of the 62 unwraps, and put itself at the bottom of every unwrap failure's call stack, one frame below the code that actually had the `None`. That reasoning is written next to the entry, so the next person can disagree with it on the merits. If you'd rather have the empty list, say so and I'll route the 62 sites.

## Changes made

**The tests** (`backend/tests/Tests/Builtin.Tests.fs`):

- `multiUseAllowlist` is down to `unwrap`.
- New test, `every builtin is referenced from Dark`: a builtin nothing calls is dead F# we keep compiling, serializing and documenting. It scans every `.dark` in the repo, not just `packages/`, so a builtin that only a test file or a perf workload calls still counts as used. It found four. `testInspect` and `testDeleteUser` were dead (the latter deletes from `accounts_v0`, a table from the LibCloud world) and are gone; `interpreterStatsEnableDetailedTiming` now has a wrapper, which is how it left the list; `testSetExpectedExceptionCount` is allowlisted with its reason.
- Both checks, and the existing `old functions are deprecated`, were only looking at `localBuiltIns`, which leaves out the whole CliHost library - `dark eval`, script running, the CLI's own entry points - and at fns but not values. They now run over every builtin a running `darklang` can reach. That widening is what surfaced `cliEvaluateExpression` (9 refs), `cliParseAndExecuteScript` and `scmMainBranchId`.

**New wrappers:**

- `Darklang.Tracing.Store` (`packages/darklang/tracing/store.dark`) - the whole `traces*` surface, typed to the shapes already in `tracing/types.dark`.
- `Darklang.LanguageTools.InterpreterStats` - reset, get, and the detailed-timing switch that was previously reachable only by typing the builtin name into `dark eval`.
- `Cli.Eval.evaluateRaw` and `Cli.Run.parseAndExecute` - the two host entry points, each now called from one place.
- `Cli.Scripts.{list,get,add,update,delete}`, `Cli.Deps.getDependents`, `Cli.Packages.DB.listAll`, `LanguageTools.allBuiltinFns`, `Parser.Parse.{toWrittenTypes, diagnostics}`, `Stdlib.toRepr`, `Stdlib.Cli.Stdin.{readLine,readAll}`, `Stdlib.Cli.Sys.{uname,currentExecutablePath}`, `Stdlib.Cli.Posix.{fdWrite,fdClose}`, and six additions to `Stdlib.Cli.FileSystem`.

**Existing wrappers that callers were simply bypassing:** `Stdlib.Env.get`, `Stdlib.print`/`printLine`, `Stdlib.Cli.FileSystem.readFile`, `Stdlib.Cli.Posix.readlink`, `SCM.Branch.mainBranchId`, and the `LanguageTools.PackageManager.{Type,Value,Function}` modules, which also gained a `locations` fn each so the pm-locations builtins had somewhere to go.

`AGENTS.md` states the rule next to "Adding a builtin", since the tests enforce it now.

---

## Worth special review

- **`Stdlib.Cli.FileSystem.overwriteFile` vs `writeFile`.** `writeFile` does `mkdir -p` on the parent first. Routing the old direct `Builtin.fileWrite` callers through it would have changed behaviour, and in the shell-config helpers (`bash.dark` and friends, which write to a literal unexpanded `"$HOME/.bashrc"`) it would have created a directory literally named `$HOME`. So the raw one is its own fn and `writeFile` is now "that plus the mkdir". Those shell helpers look broken to me for unrelated reasons; I left that alone.
- **The LSP calling `Cli.Scripts.get`/`update`.** The `Script` type lives in `Darklang.Cli.Scripts` and is pinned there by a `PackageRefs` entry on the F# side, so moving the type is its own change. The wrappers went next to the type, which means the LSP's script filesystem provider now calls into a `Cli.*` module. It was calling the same builtins before, so nothing got worse, but it is a layering smell with an obvious fix later.
- **Two file-IO families.** `Stdlib.Cli.FileSystem` (the `file*` builtins) and `Stdlib.Cli.File`/`Dir` (posix syscalls, errno-carrying) overlap. I didn't merge them, but the module header now says which is which, since concentrating the builtin wrappers in one of them makes a reader land there first.