### PR TITLE
Misc improvements to pretty-printing

### DIFF
--- a/backend/src/Builtins/Builtins.Cli/Libs/Terminal.fs
+++ b/backend/src/Builtins/Builtins.Cli/Libs/Terminal.fs
@@ -340,6 +340,26 @@ let fns () : List<BuiltInFn> =
       deprecated = NotDeprecated }
 
 
+    { name = fn "cliTerminalColorEnabled" 0
+      typeParams = []
+      parameters = [ Param.make "unit" TUnit "" ]
+      returnType = TBool
+      description =
+        "Whether output should carry color: false when NO_COLOR is set, or when "
+        + "stdout is redirected"
+      fn =
+        (function
+        | _, _, _, [| DUnit |] ->
+          let noColor =
+            System.Environment.GetEnvironmentVariable "NO_COLOR" |> isNull |> not
+          DBool(not noColor && TerminalCapabilities.isOutputTerminal ()) |> Ply
+        | _ -> incorrectArgs ())
+      sqlSpec = NotQueryable
+      previewable = Impure
+      capabilities = LibExecution.Capabilities.noCaps
+      deprecated = NotDeprecated }
+
+
     { name = fn "cliGetLogDir" 0
       typeParams = []
       parameters = [ Param.make "unit" TUnit "" ]

--- a/backend/src/Builtins/Builtins.CliHost/Libs/Cli.fs
+++ b/backend/src/Builtins/Builtins.CliHost/Libs/Cli.fs
@@ -568,6 +568,12 @@ let fns () : List<BuiltInFn> =
           Param.make "branchId" TUuid ""
           Param.make "expression" TString ""
           Param.make
+            "currentModule"
+            (TList TString)
+            "Where the caller is standing, owner-first; names in the result are spelled relative to it"
+          Param.make "width" TInt "Columns the result should be laid out for"
+          Param.make "color" TBool "Whether the result may carry terminal color"
+          Param.make
             "allowHarmful"
             TBool
             "Opt out of Harmful-deprecation halting (see docs/deprecation)" ]
@@ -587,9 +593,15 @@ let fns () : List<BuiltInFn> =
         let okNone () = resultOk (Dval.optionNone KTString)
         (function
         | exeState,
-          _,
+          vm,
           [],
-          [| accountIDDval; DUuid branchId; DString expression; DBool allowHarmful |] ->
+          [| accountIDDval
+             DUuid branchId
+             DString expression
+             DList(_, currentModule)
+             DInt width
+             DBool color
+             DBool allowHarmful |] ->
           uply {
             // Attribute the run to the calling account so the trace
             // insert can stamp `traces.account_id`.
@@ -630,7 +642,22 @@ let fns () : List<BuiltInFn> =
                   | DUnit -> return okNone ()
                   | DString s -> return okSome s
                   | _ ->
-                    let! asString = Exe.dvalToRepr exeState result
+                    // Width and color are the caller's to decide: they are facts about the process
+                    // this output is headed for, and asking here would mean reaching into another
+                    // builtin's terminal code. `Cli.Terminal` owns both and answers them in Dark.
+                    let currentModule =
+                      currentModule
+                      |> List.choose (fun d ->
+                        match d with
+                        | DString s -> Some s
+                        | _ -> None)
+                    let! asString =
+                      Exe.dvalToReprForTerminal
+                        exeState
+                        (intToInt32 vm width)
+                        color
+                        currentModule
+                        result
                     return okSome asString
                 | Error(e, callStack) ->
                   let! csString = Exe.callStackString exeState callStack

--- a/backend/src/LibExecution/Execution.fs
+++ b/backend/src/LibExecution/Execution.fs
@@ -258,6 +258,38 @@ let dvalToRepr (state : RT.ExecutionState) (dval : RT.Dval) : Task<string> =
     | _ -> return prettyPrintFallback "dval" dval
   }
 
+
+/// Like `dvalToRepr`, but laid out for a line `width` columns wide and painted for a terminal.
+///
+/// The width is passed in rather than looked up, because the printers are deliberately unable to read
+/// the terminal: that is what keeps rendering reproducible in tests and lets a pane pass its own width
+/// rather than the screen's.
+///
+/// Goes through the CLI's own `Terminal.renderValue`, which supplies the palette, so nothing here has
+/// to know what a color is or build a `Palette` to ask for one.
+let dvalToReprForTerminal
+  (state : RT.ExecutionState)
+  (width : int)
+  (color : bool)
+  (currentModule : List<string>)
+  (dval : RT.Dval)
+  : Task<string> =
+  task {
+    let fnName = RT.FQFnName.fqPackage (PackageRefs.Fn.Cli.renderValue ())
+    let currentModule = currentModule |> List.map RT.DString |> Dval.list RT.KTString
+    let args =
+      NEList.ofList
+        (RT.DUuid state.branchId)
+        [ Dval.int (bigint width)
+          RT.DBool color
+          currentModule
+          RT2DT.Dval.toDT dval ]
+    match! executeFunction state fnName [] args with
+    | Ok(RT.DString s) -> return s
+    | _ -> return prettyPrintFallback "dval" dval
+  }
+
+
 let typeRefToString
   (state : RT.ExecutionState)
   (typeRef : RT.TypeReference)

--- a/backend/src/LibExecution/PackageRefs.fs
+++ b/backend/src/LibExecution/PackageRefs.fs
@@ -501,6 +501,7 @@ module Fn =
 
   module Cli =
     let executeCliCommand = p [ "Cli" ] "executeCliCommand"
+    let renderValue = p [ "Cli"; "Terminal" ] "renderValue"
 
   module Internal =
     let private p addl = p ("Internal" :: addl)

--- a/backend/testfiles/execution/stdlib/json.dark
+++ b/backend/testfiles/execution/stdlib/json.dark
@@ -1396,7 +1396,7 @@ module UserDefinedAliases =
   Stdlib.Json.serialize<StringResult<Int64>> (Result.Error "err") = "{\"Error\":[\"err\"]}"
 
   // This test currently slips by the typechecker, and so we get an internal exception
-  Stdlib.Json.serialize<StringResult<Int64>> (Result.Error 1L) = error="Darklang.Stdlib.Json.serialize's 1st parameter `value` expects Darklang.Stdlib.Result.Result<Int64, String>, but got Darklang.Stdlib.Result.Result<_, Int64> (Darklang.Stdlib.Result.Result<_, Int64>.Error(1))"
+  Stdlib.Json.serialize<StringResult<Int64>> (Result.Error 1L) = error="Darklang.Stdlib.Json.serialize's 1st parameter `value` expects Darklang.Stdlib.Result.Result<Int64, String>, but got Darklang.Stdlib.Result.Result<_, Int64> (Error(1))"
 module Package =
   Stdlib.Json.serialize<Option<Int64>> Option.None = "{\"None\":[]}"
 

--- a/backend/testfiles/execution/stdlib/list.dark
+++ b/backend/testfiles/execution/stdlib/list.dark
@@ -88,7 +88,7 @@ Stdlib.List.filter [ 1L; 2L; 3L ] (fun item ->
   match item with
   | 1L -> Stdlib.Option.Option.None
   | 2L -> false
-  | 3L -> true) = error="Encountered a condition that must be a Bool, but got a Darklang.Stdlib.Option.Option<_> (Darklang.Stdlib.Option.Option<_>.None)"
+  | 3L -> true) = error="Encountered a condition that must be a Bool, but got a Darklang.Stdlib.Option.Option<_> (None)"
 Stdlib.List.filter [ true; false; true ] (fun item -> "a") = error="Encountered a condition that must be a Bool, but got a String (\"a\")"
 Stdlib.List.filter [ 1L; 2L; 3L ] (fun item ->
   match item with
@@ -225,7 +225,7 @@ module Partition =
     match item with
     | 1L -> Stdlib.Option.Option.None
     | 2L -> false
-    | 3L -> true) = error="Encountered a condition that must be a Bool, but got a Darklang.Stdlib.Option.Option<_> (Darklang.Stdlib.Option.Option<_>.None)"
+    | 3L -> true) = error="Encountered a condition that must be a Bool, but got a Darklang.Stdlib.Option.Option<_> (None)"
 Stdlib.List.pushBack [ 2L; 3L ] 1L = [ 2L; 3L; 1L ]
 Stdlib.List.pushBack [] 1L = [ 1L ]
 

--- a/backend/testfiles/execution/stdlib/pretty.dark
+++ b/backend/testfiles/execution/stdlib/pretty.dark
@@ -1,0 +1,208 @@
+// Tests for Stdlib.Pretty, the width-aware layout combinators.
+//
+// The cases follow the behaviour table in the library's own spec: the same document rendered at a wide
+// and a narrow width, plus the properties that separate a real Wadler/Leijen renderer from string
+// concatenation -- text never wraps, groups decide independently, and a hard line forces its enclosing
+// groups to break.
+
+// --- helpers ---
+let t (s: String) : Darklang.Stdlib.Pretty.Doc = Darklang.Stdlib.Pretty.text s
+
+let r (width: Int) (d: Darklang.Stdlib.Pretty.Doc) : String =
+  Darklang.Stdlib.Pretty.render width d
+
+let g (d: Darklang.Stdlib.Pretty.Doc) : Darklang.Stdlib.Pretty.Doc =
+  Darklang.Stdlib.Pretty.group d
+
+let abc () : Darklang.Stdlib.Pretty.Doc =
+  Darklang.Stdlib.Pretty.vsep [ t "a"; t "b"; t "c" ]
+
+/// `[a, b, c, d, e]`: a bracketed list that breaks one element per line when it must.
+let bracketed (items: List<String>) : Darklang.Stdlib.Pretty.Doc =
+  let docs = Stdlib.List.map items (fun i -> t i)
+  let inner =
+    Darklang.Stdlib.Pretty.join
+      docs
+      (Darklang.Stdlib.Pretty.concat (t ",") Darklang.Stdlib.Pretty.line)
+  g (Darklang.Stdlib.Pretty.concat
+      (t "[")
+      (Darklang.Stdlib.Pretty.concat
+        (Darklang.Stdlib.Pretty.nest 2 inner)
+        (t "]")))
+
+
+// ========================================
+// Text never wraps
+// ========================================
+module Simple =
+  r 80 (t "hello world") = "hello world"
+
+  // Still, at a width it cannot possibly fit: only `line` produces breaks, never `text`.
+  r 5 (t "hello world") = "hello world"
+
+  r 80 Darklang.Stdlib.Pretty.empty = ""
+
+
+// ========================================
+// A group is flat if it fits, broken if it doesn't
+// ========================================
+module Inline =
+  r 80 (g (abc ())) = "a b c"
+  r 4 (g (abc ())) = "a\nb\nc"
+
+  // Exactly wide enough.
+  r 5 (g (abc ())) = "a b c"
+
+
+// ========================================
+// nest indents the inside of a break, not the front of the document
+// ========================================
+module Nested =
+  let doc () : Darklang.Stdlib.Pretty.Doc =
+    Darklang.Stdlib.Pretty.concat
+      (t "outer")
+      (Darklang.Stdlib.Pretty.nest 2
+        (Darklang.Stdlib.Pretty.concat
+          Darklang.Stdlib.Pretty.line
+          (Darklang.Stdlib.Pretty.vsep [ t "inner1"; t "inner2" ])))
+
+  r 80 (g (doc ())) = "outer inner1 inner2"
+  r 10 (g (doc ())) = "outer\n  inner1\n  inner2"
+
+
+// ========================================
+// Lists and records: the shapes the value printer actually needs
+// ========================================
+module Structures =
+  r 80 (bracketed [ "a"; "b"; "c"; "d"; "e" ]) = "[a, b, c, d, e]"
+  r 10 (bracketed [ "aaa"; "bbb"; "ccc"; "ddd" ]) = "[aaa,\n  bbb,\n  ccc,\n  ddd]"
+
+  let rec_ () : Darklang.Stdlib.Pretty.Doc =
+    bracketed [ "name: alice"; "age: 30"; "role: admin" ]
+
+  r 80 (rec_ ()) = "[name: alice, age: 30, role: admin]"
+  r 20 (rec_ ()) = "[name: alice,\n  age: 30,\n  role: admin]"
+
+
+// ========================================
+// Groups decide independently
+//
+// The property that makes this a layout engine rather than a width check: an outer group breaking does
+// not force an inner one to, so a long structure of short parts stays readable.
+// ========================================
+module Independence =
+  let doc () : Darklang.Stdlib.Pretty.Doc =
+    Darklang.Stdlib.Pretty.vsep
+      [ g (Darklang.Stdlib.Pretty.vsep [ t "aa"; t "bb" ])
+        g (Darklang.Stdlib.Pretty.vsep [ t "cc"; t "dd" ]) ]
+
+  // Everything fits: one line.
+  r 80 (g (doc ())) = "aa bb cc dd"
+
+  // The outer group can't fit, so it breaks -- but each inner pair still can, so they stay flat.
+  r 6 (g (doc ())) = "aa bb\ncc dd"
+
+
+// ========================================
+// hardLine always breaks, and forces its enclosing groups to break with it
+// ========================================
+module Hard =
+  let doc () : Darklang.Stdlib.Pretty.Doc =
+    Darklang.Stdlib.Pretty.concat
+      (t "a")
+      (Darklang.Stdlib.Pretty.concat Darklang.Stdlib.Pretty.hardLine (t "b"))
+
+  r 80 (doc ()) = "a\nb"
+
+  // Wide enough for `a b`, but a hard line is not a soft one: the group breaks anyway.
+  r 80 (g (doc ())) = "a\nb"
+
+
+// ========================================
+// Joining
+// ========================================
+module Joining =
+  r 80 (Darklang.Stdlib.Pretty.hsep [ t "a"; t "b"; t "c" ]) = "a b c"
+  r 80 (Darklang.Stdlib.Pretty.hsep []) = ""
+  r 80 (Darklang.Stdlib.Pretty.vsep []) = ""
+  r 80 (Darklang.Stdlib.Pretty.join [ t "a"; t "b" ] (t ", ")) = "a, b"
+  r 80 (Darklang.Stdlib.Pretty.join [ t "only" ] (t ", ")) = "only"
+
+
+// ========================================
+// softLine: a break that costs nothing when flat
+//
+// The difference between `[1, 2]` and `[ 1, 2 ]`, which is why delimiters use it and separators don't.
+// ========================================
+module Soft =
+  let doc () : Darklang.Stdlib.Pretty.Doc =
+    Darklang.Stdlib.Pretty.concat
+      (t "[")
+      (Darklang.Stdlib.Pretty.concat
+        (Darklang.Stdlib.Pretty.nest 2
+          (Darklang.Stdlib.Pretty.concat
+            Darklang.Stdlib.Pretty.softLine
+            (Darklang.Stdlib.Pretty.join
+              [ t "1"; t "2" ]
+              (Darklang.Stdlib.Pretty.concat (t ",") Darklang.Stdlib.Pretty.line))))
+        (Darklang.Stdlib.Pretty.concat Darklang.Stdlib.Pretty.softLine (t "]")))
+
+  r 80 (g (doc ())) = "[1, 2]"
+  r 4 (g (doc ())) = "[\n  1,\n  2\n]"
+
+
+// ========================================
+// Measured in columns, not characters
+//
+// `Stdlib.String.length` counts grapheme clusters; a CJK character is one grapheme two columns wide. A
+// layout engine measuring the former lets lines overflow by up to half their width.
+// ========================================
+module Width =
+  Stdlib.String.length "日本語" = 3
+  Stdlib.String.displayWidth "日本語" = 6
+
+  Stdlib.String.length "👍" = 1
+  Stdlib.String.displayWidth "👍" = 2
+
+  // Four graphemes, eight columns: fits in 10 by the wrong measure, breaks by the right one.
+  r 10 (g (Darklang.Stdlib.Pretty.vsep [ t "日本"; t "語text" ])) = "日本\n語text"
+
+
+// ========================================
+// A hard line after a group doesn't stop the group fitting
+//
+// Inside the group it means "cannot be one line"; after it, it just ends the line. Conflating the two
+// made every group followed by a hard line break, which is every arm of a match.
+// ========================================
+module HardAfter =
+  let doc () : Darklang.Stdlib.Pretty.Doc =
+    Darklang.Stdlib.Pretty.concat
+      (g (Darklang.Stdlib.Pretty.vsep [ t "a"; t "b" ]))
+      (Darklang.Stdlib.Pretty.concat Darklang.Stdlib.Pretty.hardLine (t "next"))
+
+  r 80 (doc ()) = "a b\nnext"
+
+  // And a hard line *inside* the group still forces it open.
+  r 80 (g (Darklang.Stdlib.Pretty.concat
+            (t "a")
+            (Darklang.Stdlib.Pretty.concat Darklang.Stdlib.Pretty.hardLine (t "b")))) = "a\nb"
+
+
+// ========================================
+// Styled text is measured by its text
+//
+// Decoration must not move where a document breaks. If the escapes counted, a colored value would wrap
+// earlier than the same value plain, which is the sort of bug you chase for an hour.
+// ========================================
+module Styled =
+  let red (x: String) : Darklang.Stdlib.Pretty.Doc =
+    Darklang.Stdlib.Pretty.styled "<<" x ">>"
+
+  // Two columns of text, whatever the decoration weighs.
+  r 80 (red "ab") = "<<ab>>"
+
+  // The same break decision as the undecorated form, at both widths.
+  r 5 (g (Darklang.Stdlib.Pretty.vsep [ red "ab"; red "cd" ])) = "<<ab>> <<cd>>"
+  r 5 (g (Darklang.Stdlib.Pretty.vsep [ t "ab"; t "cd" ])) = "ab cd"
+  r 3 (g (Darklang.Stdlib.Pretty.vsep [ red "ab"; red "cd" ])) = "<<ab>>\n<<cd>>"
+  r 3 (g (Darklang.Stdlib.Pretty.vsep [ t "ab"; t "cd" ])) = "ab\ncd"

--- a/backend/testfiles/execution/stdlib/prettyPrinter.dark
+++ b/backend/testfiles/execution/stdlib/prettyPrinter.dark
@@ -1,0 +1,207 @@
+// Tests for the value pretty-printer, `PrettyPrinter.RuntimeTypes.dval`.
+//
+// This is what `eval` shows you, what a trace records, and what a runtime error quotes a value with, so
+// it is worth pinning precisely. `Builtin.reflect` turns an ordinary value into the RuntimeTypes.Dval
+// the printer takes, which is how these cases stay readable.
+//
+// Note when reading the expectations: they are Dark source, so `"\"a\\nb\""` is the eleven characters
+// `"a\nb"` with a real backslash in the middle. That is the point of most of the escaping cases.
+
+// --- helpers ---
+let pp (v: 'a) : String =
+  Darklang.PrettyPrinter.RuntimeTypes.dval
+    Darklang.SCM.Branch.mainBranchId
+    (Builtin.reflect v)
+
+let emptyInts () : List<Int> = []
+
+let emptyStrings () : List<String> = []
+
+let loc
+  (owner: String)
+  (modules: List<String>)
+  (name: String)
+  : Darklang.LanguageTools.ProgramTypes.PackageLocation =
+  Darklang.LanguageTools.ProgramTypes.PackageLocation
+    { owner = owner; modules = modules; name = name }
+
+
+// ========================================
+// Scalars
+// ========================================
+module Scalars =
+  pp () = "()"
+  pp true = "true"
+  pp false = "false"
+  pp 42 = "42"
+  pp (-7) = "-7"
+  pp "" = "\"\""
+  pp "plain" = "\"plain\""
+  pp 'a' = "'a'"
+
+
+// ========================================
+// Escaping
+//
+// Strings and chars used to be wrapped in their quotes unescaped, so a value holding a newline printed
+// as a real line break inside its own literal and one holding a quote closed it early.
+// ========================================
+module Escaping =
+  pp "a\nb" = "\"a\\nb\""
+  pp "say \"hi\"" = "\"say \\\"hi\\\"\""
+  pp "tab\there" = "\"tab\\there\""
+  pp "back\\slash" = "\"back\\\\slash\""
+  pp "car\rriage" = "\"car\\rriage\""
+
+  pp '\n' = "'\\n'"
+  pp '\'' = "'\\''"
+  pp '\\' = "'\\\\'"
+
+  // Non-ASCII is not a control character and passes through as itself.
+  pp "héllo" = "\"héllo\""
+  pp "日本" = "\"日本\""
+
+  // Escaping happens at every depth, not just the top level.
+  pp [ "a\nb" ] = "[\"a\\nb\"]"
+
+
+// ========================================
+// Collections
+// ========================================
+module Collections =
+  // `List<_>`, not `List<Int>`, even though `emptyInts` is annotated: an empty list carries no element
+  // type at runtime, so there is nothing for the printer to report. See the note in Records below.
+  pp (emptyInts ()) = "List<_> []"
+  pp [ 1; 2; 3 ] = "[1, 2, 3]"
+  pp [ [ 1; 2 ]; [ 3 ] ] = "[[1, 2], [3]]"
+
+  pp (1, 2) = "(1, 2)"
+  pp (1, "two", true) = "(1, \"two\", true)"
+
+  pp (Stdlib.Dict.empty) = "{}"
+  pp (Stdlib.Dict.fromListOverwritingDuplicates [ ("a", 1); ("b", 2) ]) = "{ a: 1, b: 2 }"
+
+  // A key that isn't a bare identifier is backticked, the way the source printer quotes field names.
+  pp (Stdlib.Dict.fromListOverwritingDuplicates [ ("has-hyphen", 1) ]) = "{ ``has-hyphen``: 1 }"
+  pp (Stdlib.Dict.fromListOverwritingDuplicates [ ("type", 1) ]) = "{ ``type``: 1 }"
+
+
+// ========================================
+// Records
+//
+// Fields print in the order the type declares them. They live in a Dict, which iterates
+// alphabetically, so without the reordering `PackageLocation` came out modules/name/owner.
+// ========================================
+module Records =
+  // Breaks, because the whole line is measured: the type name in front counts toward the fit. The
+  // string version measured the joined fields alone, so a 51-character name didn't count and this
+  // printed as one 118-column line while reporting that it fitted in 80.
+  pp (loc "Darklang" [ "Stdlib"; "List" ] "map") =
+    "LanguageTools.ProgramTypes.PackageLocation {\n  owner: \"Darklang\",\n  modules: [\"Stdlib\", \"List\"],\n  name: \"map\"\n}"
+
+  // `List<_>`, not `List<String>`: an empty list carries no element type at runtime, and the printer
+  // doesn't consult the field's declared type to recover one. Recorded as-is because it is what happens;
+  // the `_` is the same gap that shows up as `Option<_>.None`, and belongs with the type-args work.
+  pp (loc "Darklang" [] "x") =
+    "LanguageTools.ProgramTypes.PackageLocation {\n  owner: \"Darklang\",\n  modules: List<_> [],\n  name: \"x\"\n}"
+
+
+// ========================================
+// Enums
+// ========================================
+module Enums =
+  // Option and Result print their case alone: `Some`, `None`, `Ok`, `Error` are unambiguous everywhere
+  // and resolve unqualified, so naming their type in front of them is noise. Any other enum keeps its
+  // type name, because a bare `Red` doesn't tell you it came from `Color`.
+  pp (Stdlib.Option.Option.Some 1) = "Some(1)"
+  pp (Stdlib.Result.Result.Ok 1) = "Ok(1)"
+
+
+// ========================================
+// Name shortening
+//
+// The rule mirrors `LibDB.NameLookup.namesToTry`, which tries a given name with progressively shorter
+// prefixes of the current module glued on. So the shortest spelling that still resolves is the target's
+// path minus its longest common prefix with the current module. These cases are the shapes that matter.
+// ========================================
+module Shortening =
+  let short
+    (currentModule: List<String>)
+    (owner: String)
+    (modules: List<String>)
+    (name: String)
+    : String =
+    Darklang.PrettyPrinter.shortenName currentModule owner modules name
+
+  // Same module: the leaf name alone.
+  short [ "Darklang"; "LanguageTools"; "ProgramTypes"; "PackageFn" ]
+        "Darklang" [ "LanguageTools"; "ProgramTypes"; "PackageFn" ] "Parameter" = "Parameter"
+
+  // Parent module: still just the leaf, because the resolver walks up.
+  short [ "Darklang"; "LanguageTools"; "ProgramTypes"; "PackageFn" ]
+        "Darklang" [ "LanguageTools"; "ProgramTypes" ] "TypeReference" = "TypeReference"
+
+  // Sibling module: keep the part that differs.
+  short [ "Darklang"; "Stdlib"; "Option" ] "Darklang" [ "Stdlib"; "List" ] "map" = "List.map"
+
+  // No context at all: `Stdlib.` resolves with `Darklang` implied, so the owner comes off.
+  short [] "Darklang" [ "Stdlib"; "List" ] "map" = "Stdlib.List.map"
+
+  // Someone else's package stays fully qualified.
+  short [ "Darklang"; "Stdlib" ] "Stachu" [ "Parser" ] "map" = "Stachu.Parser.map"
+
+  // Option and Result resolve unqualified from anywhere.
+  short [ "Darklang"; "Stdlib"; "List" ] "Darklang" [ "Stdlib"; "Option" ] "Option" = "Option"
+  short [ "Stachu"; "Whatever" ] "Darklang" [ "Stdlib"; "Result" ] "Result" = "Result"
+
+  // Prefixes are compared segment-wise. The old rule compared strings, so from `...List` a reference to
+  // `...ListView.render` was shortened to `iew.render`.
+  short [ "Darklang"; "Stdlib"; "List" ] "Darklang" [ "Stdlib"; "ListView" ] "render" = "ListView.render"
+
+  // A partial segment match is not a match.
+  short [ "Darklang"; "Stdlib"; "Li" ] "Darklang" [ "Stdlib"; "List" ] "map" = "List.map"
+
+
+// ========================================
+// Options
+//
+// The same value, rendered against different constraints. This is the property the printers are
+// supposed to have: nothing is read from the environment, so the caller decides and the output follows.
+// ========================================
+module Options =
+  let at (width: Int) (v: 'a) : String =
+    Darklang.PrettyPrinter.RuntimeTypes.dvalWith
+      Darklang.SCM.Branch.mainBranchId
+      (Darklang.PrettyPrinter.DisplayOptions.atWidth width)
+      (Builtin.reflect v)
+
+  // Wide enough: one line.
+  at 200 [ 1; 2; 3 ] = "[1, 2, 3]"
+
+  // Narrow enough that the same list has to break.
+  at 8 [ 100; 200; 300 ] = "[\n  100,\n  200,\n  300\n]"
+
+  // The default is 80 columns, and `dval` is the default-options wrapper, so the two agree.
+  (at 80 [ 1; 2; 3 ]) == (pp [ 1; 2; 3 ]) = true
+
+  // Nested wrappers, which is where the old output was worst: this used to be three lines of
+  // `Darklang.Stdlib.Option.Option<Darklang.Stdlib.Option.Option<List<Int>>>.Some(...)`.
+  pp (Stdlib.Option.Option.Some(Stdlib.Option.Option.Some [ 1; 2; 3 ])) = "Some(Some([1, 2, 3]))"
+
+  // A non-wrapper enum keeps its type name.
+  pp (Stdlib.List.chunkBySize [ 1; 2; 3 ] 0) =
+    "Error(Stdlib.List.ChunkBySizeError.SizeMustBeGreaterThanZero)"
+
+  // Unless the type has several names and nothing says which. `Stdlib.Int.ParseError`,
+  // `Stdlib.Float.ParseError` and `Stdlib.Uuid.ParseError` are all `| BadFormat`, so content-addressing
+  // makes them one type with three names; naming one is guessing, and it used to guess wrong often
+  // enough that `Stdlib.Int.parse` would report a `Stdlib.Uuid.ParseError`. The case alone is honest.
+  pp (Stdlib.Int.parse "abc") = "Error(BadFormat)"
+
+  // The same record at a width that fits it: one line, so the break above is the width deciding, not a
+  // record always breaking.
+  Darklang.PrettyPrinter.RuntimeTypes.dvalWith
+    Darklang.SCM.Branch.mainBranchId
+    (Darklang.PrettyPrinter.DisplayOptions.atWidth 200)
+    (Builtin.reflect (loc "Darklang" [ "Stdlib" ] "map")) =
+    "LanguageTools.ProgramTypes.PackageLocation { owner: \"Darklang\", modules: [\"Stdlib\"], name: \"map\" }"

--- a/backend/tests/Tests/LibParser.RoundTrip.Tests.fs
+++ b/backend/tests/Tests/LibParser.RoundTrip.Tests.fs
@@ -18,6 +18,22 @@ module RT = LibExecution.RuntimeTypes
 module Dval = LibExecution.Dval
 module PackageRefs = LibExecution.PackageRefs
 
+/// Cases where printing the printer's own output changes it, with the reason.
+///
+/// These are pre-existing bugs the idempotency check found, not licence to add more. Two causes:
+///
+///  - **Module declarations re-nest.** The printer emits the owner as a `module` wrapper, and these
+///    files are parsed with owner "Tests", so printing `module Tests = …` and feeding it back yields
+///    `module Tests = module Tests = …`, one level deeper each pass. That is a real hazard for anything
+///    that prefills a buffer from the printer and saves it back through the parser.
+///
+///  - **Parenthesisation is unstable.** `EApply` parenthesises its arguments and `EInfix` wraps both
+///    sides, so `factorial (n) - (1L)` re-prints as `(factorial n) - (1L)`. Same tree, different text;
+///    the printer just doesn't agree with itself about which parens are needed.
+///
+/// Both are fixed by the source-printer work, at which point this list should be empty.
+let knownNonIdempotent : Set<string> = Set.empty
+
 let t
   (name : string)
   (input : string)
@@ -88,11 +104,28 @@ let t
       }
 
     let! firstPrint = roundOnce input
-    return
-      Expect.RT.equalDval
-        (RT.DString firstPrint)
-        (RT.DString expected)
-        "Didn't round-trip as expected"
+    Expect.RT.equalDval
+      (RT.DString firstPrint)
+      (RT.DString expected)
+      "Didn't round-trip as expected"
+
+    // Print, parse, print: the second print must equal the first.
+    //
+    // The assertion above only says the printer turns *this* input into the expected text. It says
+    // nothing about whether the printer's own output is a fixed point, and those come apart: a printer
+    // that re-qualifies a name, or lays a construct out differently from how it accepts it, passes the
+    // first check and still churns the text every time a file goes through it. That matters here
+    // because the expected strings are hand-written, so a layout change means regenerating them -- and
+    // a regenerated expectation is only trustworthy if the printer agrees with itself.
+    if Set.contains name knownNonIdempotent then
+      return ()
+    else
+      let! secondPrint = roundOnce firstPrint
+      return
+        Expect.RT.equalDval
+          (RT.DString secondPrint)
+          (RT.DString firstPrint)
+          "Printing is not idempotent: printing the printer's own output changed it"
   }
 
 
@@ -605,7 +638,7 @@ let typeReferences =
     t
       "option alias, shortcut name"
       "type MyOption = Stdlib.Option.Option"
-      "type MyOption =\n  Stdlib.Option.Option"
+      "type MyOption =\n  Option"
       []
       []
       []
@@ -613,7 +646,7 @@ let typeReferences =
     t
       "option alias, unapplied"
       "type MyOption = Stdlib.Option.Option"
-      "type MyOption =\n  Stdlib.Option.Option"
+      "type MyOption =\n  Option"
       []
       []
       []
@@ -621,7 +654,7 @@ let typeReferences =
     t
       "option alias, applied"
       "type MyOption = Stdlib.Option.Option<Int64>"
-      "type MyOption =\n  Stdlib.Option.Option<Int64>"
+      "type MyOption =\n  Option<Int64>"
       []
       []
       []
@@ -638,13 +671,14 @@ let typeReferences =
 
     // Unqualified Result/Option type names resolve via the stdlib fallback from any
     // module, mirroring how their constructors (Ok/Error, Some/None) already
-    // resolve unqualified everywhere. Once resolved, the name pretty-prints in
-    // the canonical `Stdlib.X.Y` form, so the unqualified input round-trips to the
-    // qualified output.
+    // resolve unqualified everywhere. The printer knows about that fallback too, so
+    // these print back unqualified: input and output are the same text, which is
+    // what you want from a round-trip and wasn't true while the printer re-qualified
+    // them to `Stdlib.X.Y`.
     t
       "unqualified Result resolves through stdlib fallback"
       "type MyResult = Result<Int64, String>"
-      "type MyResult =\n  Stdlib.Result.Result<Int64, String>"
+      "type MyResult =\n  Result<Int64, String>"
       []
       []
       []
@@ -652,7 +686,7 @@ let typeReferences =
     t
       "unqualified Option resolves through stdlib fallback"
       "type MyOpt = Option<Int64>"
-      "type MyOpt =\n  Stdlib.Option.Option<Int64>"
+      "type MyOpt =\n  Option<Int64>"
       []
       []
       []
@@ -660,7 +694,7 @@ let typeReferences =
     t
       "unqualified Result unapplied resolves through stdlib fallback"
       "type MyResult = Result"
-      "type MyResult =\n  Stdlib.Result.Result"
+      "type MyResult =\n  Result"
       []
       []
       []
@@ -978,7 +1012,7 @@ let exprs =
     t
       "string match pattern with escape"
       "match s with\n| \"a\\nb\" -> 1L\n| _ -> 0L"
-      "match s with\n| \"a\\nb\" ->\n  1L\n| _ ->\n  0L"
+      "match s with\n| \"a\\nb\" -> 1L\n| _ -> 0L"
       []
       []
       []
@@ -1060,7 +1094,7 @@ let exprs =
     t
       "multiline string - interpolated"
       "$\"\"\"test {\"1\"}\"\"\" == \"test 1\""
-      "($\"test {\"1\"}\") == (\"test 1\")"
+      "$\"test {\"1\"}\" == \"test 1\""
       []
       []
       []
@@ -1101,7 +1135,7 @@ let exprs =
   Stdlib.Int64.add 1L 2L
   Stdlib.List.head [1L; 2L]
 ]"""
-      "[Stdlib.Tuple2.second (4L, 5L); Stdlib.Int64.add 1L 2L; Stdlib.List.head [1L; 2L]]"
+      "[\n  Stdlib.Tuple2.second (4L, 5L);\n  Stdlib.Int64.add 1L 2L;\n  Stdlib.List.head [1L; 2L]\n]"
       []
       []
       []
@@ -1116,14 +1150,14 @@ let exprs =
     2L)
   Stdlib.List.head [1L; 2L]
 ]"""
-      "[Stdlib.Tuple2.second (4L, 5L); Stdlib.Int64.add 1L 2L; Stdlib.List.head [1L; 2L]]"
+      "[\n  Stdlib.Tuple2.second (4L, 5L);\n  Stdlib.Int64.add 1L 2L;\n  Stdlib.List.head [1L; 2L]\n]"
       []
       []
       []
       false
 
     // dict literal
-    t "empty dict" "Dict { }" "Dict {  }" [] [] [] false
+    t "empty dict" "Dict { }" "Dict {}" [] [] [] false
     t "simple int dict" "Dict { a = 1L }" "Dict { a = 1L }" [] [] [] false
     t
       "string dict"
@@ -1204,7 +1238,7 @@ let exprs =
       []
       []
       false
-    t "tuple with expr" "(1L, 2L + 3L, 4L)" "(1L, (2L) + (3L), 4L)" [] [] [] false
+    t "tuple with expr" "(1L, 2L + 3L, 4L)" "(1L, 2L + 3L, 4L)" [] [] [] false
 
     // record literals
     t
@@ -1309,8 +1343,7 @@ let exprs =
       name = "Jane"
       age = 31L
       hasPet = false })"""
-      """let myRec =
-  Tests.Person { name = "John"; age = 30L; hasPet = true }
+      """let myRec = Tests.Person { name = "John"; age = 30L; hasPet = true }
 { myRec with name = "Jane"; age = 31L; hasPet = false }"""
       [ person ]
       []
@@ -1327,30 +1360,9 @@ let exprs =
       []
       []
       false
-    t
-      "option none, short"
-      "Stdlib.Option.Option.None"
-      "Stdlib.Option.Option.None"
-      []
-      []
-      []
-      false
-    t
-      "option none, long"
-      "Stdlib.Option.Option.None"
-      "Stdlib.Option.Option.None"
-      []
-      []
-      []
-      false
-    t
-      "option some"
-      "Stdlib.Option.Option.Some 1L"
-      "Stdlib.Option.Option.Some(1L)"
-      []
-      []
-      []
-      false
+    t "option none, short" "Stdlib.Option.Option.None" "Option.None" [] [] [] false
+    t "option none, long" "Stdlib.Option.Option.None" "Option.None" [] [] [] false
+    t "option some" "Stdlib.Option.Option.Some 1L" "Option.Some(1L)" [] [] [] false
     t
       "custom enum tupled params"
       "Tests.MyEnum.C((1L, 2L))"
@@ -1384,7 +1396,7 @@ let exprs =
       "enum with indented field"
       """Stdlib.Result.Result.Error
   Stdlib.List.ChunkBySizeError.SizeMustBeGreaterThanZero"""
-      """Stdlib.Result.Result.Error(Stdlib.List.ChunkBySizeError.SizeMustBeGreaterThanZero)"""
+      """Result.Error(Stdlib.List.ChunkBySizeError.SizeMustBeGreaterThanZero)"""
       []
       []
       []
@@ -1404,7 +1416,7 @@ let exprs =
       []
       false
     // Pretty-printing normalizes the let body indentation.
-    t "simple let expr" "let x = 1L\n  x" "let x =\n  1L\nx" [] [] [] false
+    t "simple let expr" "let x = 1L\n  x" "let x = 1L\nx" [] [] [] false
     // A nested function definition desugars to a lambda bound by a let, so the
     // roundtrip is intentionally lossy: the param/return types are dropped and the
     // `let f (x) = ...` sugar prints as `let f = (fun x -> ...)`. (Top-level
@@ -1413,17 +1425,17 @@ let exprs =
     t
       "nested function definition (desugars to lambda)"
       "let result =\n  let double (x: Int64): Int64 = x * 2L\n  double 5L\nresult"
-      "let result =\n  let double =\n    (fun x ->\n      (x) * (2L))\n  double 5L\nresult"
+      "let result =\n  let double = (fun x -> x * 2L)\n  double 5L\nresult"
       []
       []
       []
       false
-    t "let expr with indent" "let x =\n  1L\nx" "let x =\n  1L\nx" [] [] [] false
+    t "let expr with indent" "let x =\n  1L\nx" "let x = 1L\nx" [] [] [] false
 
     t
       "tuple destructuring"
-      "let (var1, var2) =\n  var3\n(var1, var2)"
-      "let (var1, var2) =\n  var3\n(var1, var2)"
+      "let (var1, var2) = var3\n(var1, var2)"
+      "let (var1, var2) = var3\n(var1, var2)"
       []
       []
       []
@@ -1431,8 +1443,8 @@ let exprs =
 
     t
       "tuple destructuring 2"
-      "let (var1, var2) =\n  (var3, var4)\n(var1, var2)"
-      "let (var1, var2) =\n  (var3, var4)\n(var1, var2)"
+      "let (var1, var2) = (var3, var4)\n(var1, var2)"
+      "let (var1, var2) = (var3, var4)\n(var1, var2)"
       []
       []
       []
@@ -1472,31 +1484,24 @@ let exprs =
       []
       []
       false
-    t
-      "field access in context"
-      "person.age + 1L"
-      "(person.age) + (1L)"
-      []
-      []
-      []
-      false
+    t "field access in context" "person.age + 1L" "person.age + 1L" [] [] [] false
 
     // lambda
-    t "simple lambda" "fun x -> x + 1L" "(fun x ->\n  (x) + (1L))" [] [] [] false
+    t "simple lambda" "fun x -> x + 1L" "(fun x -> x + 1L)" [] [] [] false
     t
       "lambda wrapped with parens"
       "(fun x -> x + 1L)"
-      "(fun x ->\n  (x) + (1L))"
+      "(fun x -> x + 1L)"
       []
       []
       []
       false
-    t "lambda, 2 args" "fun x y -> x * y" "(fun x y ->\n  (x) * (y))" [] [] [] false
-    t "lambda, unit arg" "fun () -> 1L" "(fun () ->\n  1L)" [] [] [] false
+    t "lambda, 2 args" "fun x y -> x * y" "(fun x y -> x * y)" [] [] [] false
+    t "lambda, unit arg" "fun () -> 1L" "(fun () -> 1L)" [] [] [] false
     t
       "lambda with notable body"
       "fun var -> (Stdlib.String.toUppercase (Stdlib.String.fromChar var))"
-      "(fun var ->\n  Stdlib.String.toUppercase (Stdlib.String.fromChar var))"
+      "(fun var -> Stdlib.String.toUppercase (Stdlib.String.fromChar var))"
       []
       []
       []
@@ -1504,7 +1509,7 @@ let exprs =
     t
       "lambda with notable body 2"
       "fun (str1, str2) -> str1 ++ str2"
-      "(fun (str1, str2) ->\n  (str1) ++ (str2))"
+      "(fun (str1, str2) -> str1 ++ str2)"
       []
       []
       []
@@ -1512,19 +1517,12 @@ let exprs =
 
 
     // if expressions
-    t "if, 1" "if true then 1L" "if true then\n  1L" [] [] [] false
-    t
-      "if, 2"
-      "if true then 1L else 2L"
-      "if true then\n  1L\nelse\n  2L"
-      []
-      []
-      []
-      false
+    t "if, 1" "if true then 1L" "if true then 1L" [] [] [] false
+    t "if, 2" "if true then 1L else 2L" "if true then 1L else 2L" [] [] [] false
     t
       "if, 3"
       "if a < b then 1L else if c > d then 2L"
-      "if (a) < (b) then\n  1L\nelse if (c) > (d) then\n  2L"
+      "if a < b then 1L else if c > d then 2L"
       []
       []
       []
@@ -1532,25 +1530,18 @@ let exprs =
     t
       "if, 4"
       "if a < b then 1L else if c > d then 2L else 3L"
-      "if (a) < (b) then\n  1L\nelse if (c) > (d) then\n  2L\nelse\n  3L"
+      "if a < b then 1L else if c > d then 2L else 3L"
       []
       []
       []
       false
 
-    t "if, 5" "if true then\n 1L" "if true then\n  1L" [] [] [] false
-    t
-      "if, 6"
-      "if true then\n 1L\nelse\n 2L"
-      "if true then\n  1L\nelse\n  2L"
-      []
-      []
-      []
-      false
+    t "if, 5" "if true then\n 1L" "if true then 1L" [] [] [] false
+    t "if, 6" "if true then\n 1L\nelse\n 2L" "if true then 1L else 2L" [] [] [] false
     t
       "if, 7"
       "if true then\n a\nelse if false then\n c"
-      "if true then\n  a\nelse if false then\n  c"
+      "if true then a else if false then c"
       []
       []
       []
@@ -1559,20 +1550,13 @@ let exprs =
     t
       "if, 8"
       "if a > b then\n a\nelse if c > d then\n c\nelse d"
-      "if (a) > (b) then\n  a\nelse if (c) > (d) then\n  c\nelse\n  d"
+      "if a > b then a else if c > d then c else d"
       []
       []
       []
       false
 
-    t
-      "if, 9"
-      "if true then\n\ta\nelse\n\tb"
-      "if true then\n  a\nelse\n  b"
-      []
-      []
-      []
-      false
+    t "if, 9" "if true then\n\ta\nelse\n\tb" "if true then a else b" [] [] [] false
 
     t
       "if, many branches"
@@ -1582,12 +1566,7 @@ else if false then
   c
 else if true then
   d"""
-      """if true then
-  a
-else if false then
-  c
-else if true then
-  d"""
+      "if true then a else if false then c else if true then d"
       []
       []
       []
@@ -1601,11 +1580,7 @@ if a > b then
     c
   else
     b"""
-      """if (a) > (b) then
-  if (c) > (d) then
-    c
-  else
-    b"""
+      """if a > b then if c > d then c else b"""
       []
       []
       []
@@ -1619,11 +1594,7 @@ if a > b then
     c
 else
   b"""
-      """if (a) > (b) then
-  if (c) > (d) then
-    c
-else
-  b"""
+      """if a > b then if c > d then c else b"""
       []
       []
       []
@@ -1644,16 +1615,9 @@ else
         g
       else
         h"""
-      """if (a) > (b) then
+      """if a > b then
   a
-else if (c) > (d) then
-  c
-else if (e) > (f) then
-  e
-else if (g) > (h) then
-  g
-else
-  h"""
+else if c > d then c else if e > f then e else if g > h then g else h"""
       []
       []
       []
@@ -1664,7 +1628,7 @@ else
     t
       "match, unit"
       "match () with\n| () -> true"
-      "match () with\n| () ->\n  true"
+      "match () with\n| () -> true"
       []
       []
       []
@@ -1672,7 +1636,7 @@ else
     t
       "match, bool"
       "match true with\n| true -> true"
-      "match true with\n| true ->\n  true"
+      "match true with\n| true -> true"
       []
       []
       []
@@ -1681,7 +1645,7 @@ else
     t
       "match, int 1y"
       "match 1y with\n| 1y -> true"
-      "match 1y with\n| 1y ->\n  true"
+      "match 1y with\n| 1y -> true"
       []
       []
       []
@@ -1689,7 +1653,7 @@ else
     t
       "match, int -1y"
       "match -1y with\n| -1y -> true"
-      "match -1y with\n| -1y ->\n  true"
+      "match -1y with\n| -1y -> true"
       []
       []
       []
@@ -1697,7 +1661,7 @@ else
     t
       "match, int 0uy"
       "match 0uy with\n| 0uy -> true"
-      "match 0uy with\n| 0uy ->\n  true"
+      "match 0uy with\n| 0uy -> true"
       []
       []
       []
@@ -1705,7 +1669,7 @@ else
     t
       "match, int 1s"
       "match 1s with\n| 1s -> true"
-      "match 1s with\n| 1s ->\n  true"
+      "match 1s with\n| 1s -> true"
       []
       []
       []
@@ -1713,7 +1677,7 @@ else
     t
       "match, int 2us"
       "match 2us with\n| 2us -> true"
-      "match 2us with\n| 2us ->\n  true"
+      "match 2us with\n| 2us -> true"
       []
       []
       []
@@ -1721,7 +1685,7 @@ else
     t
       "match, int 3l"
       "match 3l with\n| 3l -> true"
-      "match 3l with\n| 3l ->\n  true"
+      "match 3l with\n| 3l -> true"
       []
       []
       []
@@ -1729,7 +1693,7 @@ else
     t
       "match, int 5ul"
       "match 5ul with\n| 5ul -> true"
-      "match 5ul with\n| 5ul ->\n  true"
+      "match 5ul with\n| 5ul -> true"
       []
       []
       []
@@ -1737,7 +1701,7 @@ else
     t
       "match, int 7L"
       "match 7L with\n| 7L -> true"
-      "match 7L with\n| 7L ->\n  true"
+      "match 7L with\n| 7L -> true"
       []
       []
       []
@@ -1745,7 +1709,7 @@ else
     t
       "match, int 8UL"
       "match 8UL with\n| 8UL -> true"
-      "match 8UL with\n| 8UL ->\n  true"
+      "match 8UL with\n| 8UL -> true"
       []
       []
       []
@@ -1753,7 +1717,7 @@ else
     t
       "match, int 9Q"
       "match 9Q with\n| 9Q -> true"
-      "match 9Q with\n| 9Q ->\n  true"
+      "match 9Q with\n| 9Q -> true"
       []
       []
       []
@@ -1761,7 +1725,7 @@ else
     t
       "match, int 10Z"
       "match 10Z with\n| 10Z -> true"
-      "match 10Z with\n| 10Z ->\n  true"
+      "match 10Z with\n| 10Z -> true"
       []
       []
       []
@@ -1769,7 +1733,7 @@ else
     t
       "match, float 0.9"
       "match 0.9 with\n| 0.9 -> true"
-      "match 0.9 with\n| 0.9 ->\n  true"
+      "match 0.9 with\n| 0.9 -> true"
       []
       []
       []
@@ -1777,7 +1741,7 @@ else
     t
       "match, string"
       "match \"str\" with\n| \"str\" -> true"
-      "match \"str\" with\n| \"str\" ->\n  true"
+      "match \"str\" with\n| \"str\" -> true"
       []
       []
       []
@@ -1785,7 +1749,7 @@ else
     t
       "match, char"
       "match 'c' with\n| 'c' -> true"
-      "match 'c' with\n| 'c' ->\n  true"
+      "match 'c' with\n| 'c' -> true"
       []
       []
       []
@@ -1793,7 +1757,7 @@ else
     t
       "match, var"
       "match var with\n| var -> true"
-      "match var with\n| var ->\n  true"
+      "match var with\n| var -> true"
       []
       []
       []
@@ -1801,7 +1765,7 @@ else
     t
       "match, str 2"
       "match \"str\" with\n| \"str\" -> true\n| \"other\" -> false"
-      "match \"str\" with\n| \"str\" ->\n  true\n| \"other\" ->\n  false"
+      "match \"str\" with\n| \"str\" -> true\n| \"other\" -> false"
       []
       []
       []
@@ -1809,7 +1773,7 @@ else
     t
       "match, int list 1"
       "match [1L; 2L] with\n| [1L; 2L] -> true"
-      "match [1L; 2L] with\n| [1L; 2L] ->\n  true"
+      "match [1L; 2L] with\n| [1L; 2L] -> true"
       []
       []
       []
@@ -1817,7 +1781,7 @@ else
     t
       "match, int list 2"
       "match [1L; 2L; 3L] with\n| head :: tail ->\n \"pass\""
-      "match [1L; 2L; 3L] with\n| head :: tail ->\n  \"pass\""
+      "match [1L; 2L; 3L] with\n| head :: tail -> \"pass\""
       []
       []
       []
@@ -1825,7 +1789,7 @@ else
     t
       "match, int tuple"
       "match (1L, 2L) with\n| (1L, 2L) -> true"
-      "match (1L, 2L) with\n| (1L, 2L) ->\n  true"
+      "match (1L, 2L) with\n| (1L, 2L) -> true"
       []
       []
       []
@@ -1833,7 +1797,7 @@ else
     t
       "match, enum"
       "match Stdlib.Result.Result.Ok 5L with\n| Ok(5L) -> true\n| Error(e) -> false"
-      "match Stdlib.Result.Result.Ok(5L) with\n| Ok(5L) ->\n  true\n| Error(e) ->\n  false"
+      "match Result.Ok(5L) with\n| Ok(5L) -> true\n| Error(e) -> false"
       []
       []
       []
@@ -1841,7 +1805,7 @@ else
     t
       "match, enum no parens with one arg"
       "match Stdlib.Result.Result.Ok 5L with\n| Ok 5L -> true\n| Error e  -> false"
-      "match Stdlib.Result.Result.Ok(5L) with\n| Ok(5L) ->\n  true\n| Error(e) ->\n  false"
+      "match Result.Ok(5L) with\n| Ok(5L) -> true\n| Error(e) -> false"
       []
       []
       []
@@ -1849,7 +1813,7 @@ else
     t
       "match, enum with 2 args"
       "match MyEnum.D(5L, 3L) with\n| D(5L, 3L) -> true\n| _  -> false"
-      "match MyEnum.D(5L, 3L) with\n| D(5L, 3L) ->\n  true\n| _ ->\n  false"
+      "match MyEnum.D(5L, 3L) with\n| D(5L, 3L) -> true\n| _ -> false"
       []
       []
       []
@@ -1857,7 +1821,7 @@ else
     t
       "match, enum no parens with 1 tuple arg"
       "match Stdlib.Result.Result.Ok((5L, 3L)) with\n| Ok((5L, 3L)) -> true\n| Error e  -> false"
-      "match Stdlib.Result.Result.Ok((5L, 3L)) with\n| Ok((5L, 3L)) ->\n  true\n| Error(e) ->\n  false"
+      "match Result.Ok((5L, 3L)) with\n| Ok((5L, 3L)) -> true\n| Error(e) -> false"
       []
       []
       []
@@ -1865,7 +1829,7 @@ else
     t
       "match, string 3"
       "match \"str\" with\n| \"str\" when true -> true"
-      "match \"str\" with\n| \"str\" when true ->\n  true"
+      "match \"str\" with\n| \"str\" when true -> true"
       []
       []
       []
@@ -1873,7 +1837,7 @@ else
     t
       "match, when simple"
       "match x with\n| y when y > 1L -> true\n| z when z < 1L -> false\n| w -> w"
-      "match x with\n| y when (y) > (1L) ->\n  true\n| z when (z) < (1L) ->\n  false\n| w ->\n  w"
+      "match x with\n| y when y > 1L -> true\n| z when z < 1L -> false\n| w -> w"
       []
       []
       []
@@ -1881,7 +1845,7 @@ else
     t
       "match, ignored 1"
       "match true with\n| _ -> true"
-      "match true with\n| _ ->\n  true"
+      "match true with\n| _ -> true"
       []
       []
       []
@@ -1889,7 +1853,7 @@ else
     t
       "match, ignored 2"
       "match true with\n| _var -> true"
-      "match true with\n| _var ->\n  true"
+      "match true with\n| _var -> true"
       []
       []
       []
@@ -1898,7 +1862,7 @@ else
     t
       "match, multiple patterns"
       "match (1L, 2L) with\n| (1L, 2L) | (2L, 1L) -> true\n| _ -> false"
-      "match (1L, 2L) with\n| (1L, 2L) | (2L, 1L) ->\n  true\n| _ ->\n  false"
+      "match (1L, 2L) with\n| (1L, 2L) | (2L, 1L) -> true\n| _ -> false"
       []
       []
       []
@@ -1906,12 +1870,12 @@ else
 
 
     // pipe expression
-    t "pipe, infix" "1L |> (+) 2L" "1L\n|> (+) 2L" [] [] [] false
-    t "pipe, into var" "1L |> x" "1L\n|> x" [] [] [] false
+    t "pipe, infix" "1L |> (+) 2L" "1L |> (+) 2L" [] [] [] false
+    t "pipe, into var" "1L |> x" "1L |> x" [] [] [] false
     t
       "pipe, into lambda"
       "1L |> (fun x -> x + 1L)"
-      "1L\n|> fun x -> (x) + (1L)"
+      "1L |> fun x -> x + 1L"
       []
       []
       []
@@ -1919,7 +1883,7 @@ else
     t
       "pipe, into lambda, 2"
       "1L |> fun x -> x + 1L"
-      "1L\n|> fun x -> (x) + (1L)"
+      "1L |> fun x -> x + 1L"
       []
       []
       []
@@ -1927,7 +1891,7 @@ else
     t
       "pipe, into enum"
       "3L |> Stdlib.Result.Result.Ok"
-      "3L\n|> Stdlib.Result.Result.Ok"
+      "3L |> Result.Ok"
       []
       []
       []
@@ -1935,7 +1899,7 @@ else
     t
       "pipe, into enum 2"
       "33L |> Tests.MyEnum.D(21L)"
-      "33L\n|> Tests.MyEnum.D(21L)"
+      "33L |> Tests.MyEnum.D(21L)"
       [ myEnum ]
       []
       []
@@ -1943,7 +1907,7 @@ else
     t
       "pipe, into fn call"
       "1L |> Stdlib.Int64.add 2L"
-      "1L\n|> Stdlib.Int64.add 2L"
+      "1L |> Stdlib.Int64.add 2L"
       []
       []
       []
@@ -1951,7 +1915,7 @@ else
     t
       "pipe, into fn call 2"
       "1L |> Stdlib.Int64.toString"
-      "1L\n|> Stdlib.Int64.toString"
+      "1L |> Stdlib.Int64.toString"
       []
       []
       []
@@ -1959,7 +1923,7 @@ else
     t
       "pipe, into fn call 3"
       "\"true\" |> Builtin.jsonParse<Bool>"
-      "\"true\"\n|> Builtin.jsonParse<Bool>"
+      "\"true\" |> Builtin.jsonParse<Bool>"
       []
       []
       []
@@ -1967,7 +1931,7 @@ else
     t
       "pipe, into fn call 4"
       "Stdlib.Int64.add 1L 2L |> Stdlib.Int64.add 1L"
-      "Stdlib.Int64.add 1L 2L\n|> Stdlib.Int64.add 1L"
+      "Stdlib.Int64.add 1L 2L |> Stdlib.Int64.add 1L"
       []
       []
       []
@@ -1975,33 +1939,26 @@ else
     t
       "pipe, into fn call 5"
       "[1L; 2L] |> Stdlib.List.last |> Builtin.unwrap"
-      "[1L; 2L]\n|> Stdlib.List.last\n|> Builtin.unwrap"
+      "[1L; 2L] |> Stdlib.List.last |> Builtin.unwrap"
       []
       []
       []
       false
 
     // Infix calls pretty-print with explicit operand parentheses.
-    t "fn call, add once" "1L + 2L" "(1L) + (2L)" [] [] [] false
-    t "fn call, add twice" "1L + b + 3L" "((1L) + (b)) + (3L)" [] [] [] false
-    t
-      "fn call, add thrice"
-      "1L + 2L * 3L - 4L"
-      "((1L) + ((2L) * (3L))) - (4L)"
-      []
-      []
-      []
-      false
-    t "fn call, >" "1L > 2L" "(1L) > (2L)" [] [] [] false
-    t "fn call, >=" "1L >= 2L" "(1L) >= (2L)" [] [] [] false
-    t "fn call, <" "1L < 2L" "(1L) < (2L)" [] [] [] false
-    t "fn call, <=" "1L <= 2L" "(1L) <= (2L)" [] [] [] false
-    t "fn call, ==" "1L == 2L" "(1L) == (2L)" [] [] [] false
-    t "fn call, !=" "1L != 2L" "(1L) != (2L)" [] [] [] false
-    t "fn call, ^" "1L ^ 2L" "(1L) ^ (2L)" [] [] [] false
-    t "fn call, ++" "strVar ++ \"str\"" "(strVar) ++ (\"str\")" [] [] [] false
-    t "fn call, &&" "true && false" "(true) && (false)" [] [] [] false
-    t "fn call, ||" "true || false" "(true) || (false)" [] [] [] false
+    t "fn call, add once" "1L + 2L" "1L + 2L" [] [] [] false
+    t "fn call, add twice" "1L + b + 3L" "1L + b + 3L" [] [] [] false
+    t "fn call, add thrice" "1L + 2L * 3L - 4L" "1L + 2L * 3L - 4L" [] [] [] false
+    t "fn call, >" "1L > 2L" "1L > 2L" [] [] [] false
+    t "fn call, >=" "1L >= 2L" "1L >= 2L" [] [] [] false
+    t "fn call, <" "1L < 2L" "1L < 2L" [] [] [] false
+    t "fn call, <=" "1L <= 2L" "1L <= 2L" [] [] [] false
+    t "fn call, ==" "1L == 2L" "1L == 2L" [] [] [] false
+    t "fn call, !=" "1L != 2L" "1L != 2L" [] [] [] false
+    t "fn call, ^" "1L ^ 2L" "1L ^ 2L" [] [] [] false
+    t "fn call, ++" "strVar ++ \"str\"" "strVar ++ \"str\"" [] [] [] false
+    t "fn call, &&" "true && false" "true && false" [] [] [] false
+    t "fn call, ||" "true || false" "true || false" [] [] [] false
     t "fn call, and short" "and true false" "and true false" [] [] [] true
     t
       "fn call, and longer"
@@ -2051,10 +2008,11 @@ else
   (fun x -> Stdlib.String.toUppercase x)
   ("one", 2L, "pi")
 """
-      """Stdlib.Tuple3.mapAllThree (fun x ->
-  Stdlib.String.toUppercase x) (fun x ->
-  (x) - (2L)) (fun x ->
-  Stdlib.String.toUppercase x) ("one", 2L, "pi")"""
+      """Stdlib.Tuple3.mapAllThree
+  (fun x -> Stdlib.String.toUppercase x)
+  (fun x -> x - 2L)
+  (fun x -> Stdlib.String.toUppercase x)
+  ("one", 2L, "pi")"""
       []
       []
       []
@@ -2062,7 +2020,10 @@ else
     t
       "fn call with db reference"
       """Stdlib.DB.set Tests.Person { name = "John"; age = 30L; hasPet = true } "key" TestDB"""
-      """Stdlib.DB.set Tests.Person { name = "John"; age = 30L; hasPet = true } "key" TestDB"""
+      """Stdlib.DB.set
+  Tests.Person { name = "John"; age = 30L; hasPet = true }
+  "key"
+  TestDB"""
       [ person ]
       []
       []
@@ -2158,7 +2119,7 @@ let valueDeclarations =
     t
       "dict, empty"
       "val emptyDict = Dict {}"
-      "val emptyDict = Dict {  }"
+      "val emptyDict = Dict {}"
       []
       []
       []
@@ -2224,7 +2185,7 @@ let valueDeclarations =
     t
       "option, none"
       "val none = Stdlib.Option.Option.None"
-      "val none = Stdlib.Option.Option.None"
+      "val none = Option.None"
       []
       []
       []
@@ -2232,7 +2193,7 @@ let valueDeclarations =
     t
       "option, some 1"
       "val some = Stdlib.Option.Option.Some(1L)"
-      "val some = Stdlib.Option.Option.Some(1L)"
+      "val some = Option.Some(1L)"
       []
       []
       []
@@ -2259,7 +2220,7 @@ let functionDeclarations =
   [ t
       "function doc comment"
       "/// Greets a user\nlet greet (name: String): String = \"Hello \" ++ name"
-      "/// Greets a user\nlet greet (name: String): String =\n  (\"Hello \") ++ (name)"
+      "/// Greets a user\nlet greet (name: String): String =\n  \"Hello \" ++ name"
       []
       []
       []
@@ -2277,7 +2238,7 @@ let functionDeclarations =
     t
       "single package param"
       "let double2 (i: LanguageTools.ID) : Int64 = (i + i)"
-      "let double2 (i: LanguageTools.ID): Int64 =\n  (i) + (i)"
+      "let double2 (i: LanguageTools.ID): Int64 =\n  i + i"
       []
       []
       []
@@ -2354,7 +2315,7 @@ let functionDeclarations =
     t
       "fn declaration with indented body"
       "let helloPerson (name: String): String =\n  let greeting = \"Hello \"\n  greeting ++ name"
-      "let helloPerson (name: String): String =\n  let greeting =\n    \"Hello \"\n  (greeting) ++ (name)"
+      "let helloPerson (name: String): String =\n  let greeting = \"Hello \"\n  greeting ++ name"
       []
       []
       []
@@ -2367,7 +2328,7 @@ let functionDeclarations =
     1L
   else
     n * (factorial (n - 1L))"""
-      "let factorial (n: Int64): Int64 =\n  if (n) <= (1L) then\n    1L\n  else\n    (n) * (factorial (n) - (1L))"
+      "let factorial (n: Int64): Int64 =\n  if n <= 1L then 1L else n * factorial (n - 1L)"
       []
       []
       []
@@ -2386,13 +2347,9 @@ let functionDeclarations =
   if Stdlib.Int64.lessThanOrEqualTo z 0L then
     y
   else
-    let result =
-      incr y (Stdlib.Int64.subtract z 1L)
-    let incr =
-      (fun x ->
-        Stdlib.Int64.add x 2L)
-    let lambdaResult =
-      incr z
+    let result = incr y (Stdlib.Int64.subtract z 1L)
+    let incr = (fun x -> Stdlib.Int64.add x 2L)
+    let lambdaResult = incr z
     Stdlib.Int64.add result lambdaResult"""
       []
       []
@@ -2404,7 +2361,7 @@ let moduleDeclarations =
   [ t
       "simple module"
       "module MyModule =\n  type ID = Int64"
-      "module Tests =\n  module MyModule =\n    type ID =\n      Int64"
+      "module MyModule =\n  type ID =\n    Int64"
       []
       []
       []
@@ -2416,7 +2373,7 @@ let moduleDeclarations =
     t
       "unqualified Result resolves inside a non-Stdlib module"
       "module MyModule =\n  type MyResult = Result<Int64, String>"
-      "module Tests =\n  module MyModule =\n    type MyResult =\n      Stdlib.Result.Result<Int64, String>"
+      "module MyModule =\n  type MyResult =\n    Result<Int64, String>"
       []
       []
       []
@@ -2430,7 +2387,7 @@ let moduleDeclarations =
   type MyString = String
   let myFn (i: Int64): Int64 = 1L
   val x = 100L"""
-      "module Tests =\n  module MyModule =\n    type ID =\n      Int64\n\n    type MyString =\n      String\n\n    let myFn (i: Int64): Int64 =\n      1L\n\n    val x = 100L"
+      "module MyModule =\n  type ID =\n    Int64\n\n  type MyString =\n    String\n\n  let myFn (i: Int64): Int64 =\n    1L\n\n  val x = 100L"
       []
       []
       []
@@ -2446,7 +2403,7 @@ let moduleDeclarations =
   let myFn (i: Int64): Int64 = 1L
 
   val x = 100L"""
-      "module Tests =\n  module MyModule =\n    type ID =\n      Int64\n\n    type MyString =\n      String\n\n    let myFn (i: Int64): Int64 =\n      1L\n\n    val x = 100L"
+      "module MyModule =\n  type ID =\n    Int64\n\n  type MyString =\n    String\n\n  let myFn (i: Int64): Int64 =\n    1L\n\n  val x = 100L"
       []
       []
       []
@@ -2462,7 +2419,7 @@ let moduleDeclarations =
       type ID = Int64
       val x = 100L
       1L"""
-      "module Tests =\n  module MyModule1 =\n    type ID =\n      Int64\n\n    module MyModule2 =\n      type ID =\n        Int64\n\n      module MyModule3 =\n        type ID =\n          Int64\n\n        val x = 100L\n\n        1L"
+      "module MyModule1 =\n  type ID =\n    Int64\n\n  module MyModule2 =\n    type ID =\n      Int64\n\n    module MyModule3 =\n      type ID =\n        Int64\n\n      val x = 100L\n\n      1L"
       []
       []
       []
@@ -2490,10 +2447,10 @@ let sourceFiles =
       "type BookID =\n  Int64
 
 let getTitle (bookId: BookID): String =
-  let book =\n    Library.getBook bookId
+  let book = Library.getBook bookId
   getNameFromBook book
 
-let curiousGeorgeBookId =\n  101L
+let curiousGeorgeBookId = 101L
 Builtin.printLine (getTitle curiousGeorgeBookId)
 0L"
       []
@@ -2511,7 +2468,7 @@ Builtin.printLine (getTitle curiousGeorgeBookId)
 val two = 2L
 
 two"""
-      "module Tests =\n  module Helpers =\n    /// One from Helpers\n    val one = 1L\n\n/// Top-level value\nval two = 2L\n\ntwo"
+      "module Helpers =\n  /// One from Helpers\n  val one = 1L\n\n/// Top-level value\nval two = 2L\n\ntwo"
       []
       []
       []

--- a/packages/darklang/cli/conflicts.dark
+++ b/packages/darklang/cli/conflicts.dark
@@ -73,8 +73,9 @@ let renderContent
   let ctx =
     PrettyPrinter.ProgramTypes.Context
       { branchId = branchId
-        currentModule = Stdlib.Option.Option.None
-        currentFunction = Stdlib.Option.Option.None }
+        currentModule = []
+        currentFunction = Stdlib.Option.Option.None
+        width = 80 }
   // Resolve the hash across kinds rather than by the conflict's stored `itemKind`. A hash is
   // content-addressed and kind-agnostic, and a CROSS-KIND conflict (one side bound the name to a value, the
   // other to a fn — reachable since a name holds ONE item regardless of kind, post one-name-one-item) stores

--- a/packages/darklang/cli/deps.dark
+++ b/packages/darklang/cli/deps.dark
@@ -21,10 +21,24 @@ let resolveNames
   (branchId: Uuid)
   (itemHashes: List<LanguageTools.ProgramTypes.Hash>)
   : Dict<String> =
+  Deps.resolveNamesIn branchId [] itemHashes
+
+
+/// Like `resolveNames`, but spelling each name from `currentModule`.
+///
+/// `[]` gives the fully-qualified form, which is what a standalone list wants. A caller that knows
+/// where the reader is standing should say so: reading one item's references inside a module, the path
+/// back up to the root is the noise it looks like.
+let resolveNamesIn
+  (branchId: Uuid)
+  (currentModule: List<String>)
+  (itemHashes: List<LanguageTools.ProgramTypes.Hash>)
+  : Dict<String> =
   (Builtin.depsResolveLocations branchId itemHashes)
   |> Stdlib.List.fold Stdlib.Dict.empty (fun acc (itemHash, location) ->
     let h = Darklang.LanguageTools.ProgramTypes.hashToString itemHash
-    let displayName = PrettyPrinter.ProgramTypes.PackageLocation.packageLocation location
+    let displayName =
+      PrettyPrinter.ProgramTypes.PackageLocation.packageLocationIn currentModule location
     Stdlib.Dict.set acc h displayName)
 
 
@@ -58,10 +72,13 @@ let showDependents
     Stdlib.printLine ""
 
     deps
-    |> Stdlib.List.iter (fun (_sourceHash, sourceLoc, refType) ->
-      let name = PrettyPrinter.ProgramTypes.PackageLocation.packageLocation sourceLoc
-      let kind = Darklang.Cli.Packages.Propagate.itemKindToString refType
-      Stdlib.printLine $"  [{kind}] {name}")
+    // Grouped by module and capped, like every other long listing. Four hundred flat rows whose only
+    // difference is the last segment is a list you scroll past rather than read.
+    |> Stdlib.List.map (fun (_sourceHash, sourceLoc, _refType) ->
+      PrettyPrinter.ProgramTypes.PackageLocation.packageLocation sourceLoc)
+    |> Listing.groupedByModule
+    |> fun rows -> Listing.capped rows Listing.defaultLimit "narrow with a module path"
+    |> Stdlib.printLines
 
 
 /// Helper for transitive traversal — collects dependents via batched
@@ -140,11 +157,14 @@ let showTransitiveDependents
     Stdlib.printLine $"Found {Stdlib.Int.toString count} items that could break if {entityName} changes:"
     Stdlib.printLine ""
 
+    // Grouped by module and capped. Four hundred flat rows whose only difference is the last segment
+    // is a list you scroll past, not one you read.
     deps
-    |> Stdlib.List.iter (fun (sourceLoc, refType) ->
-      let name = PrettyPrinter.ProgramTypes.PackageLocation.packageLocation sourceLoc
-      let kind = Darklang.Cli.Packages.Propagate.itemKindToString refType
-      Stdlib.printLine $"  [{kind}] {name}")
+    |> Stdlib.List.map (fun (sourceLoc, _refType) ->
+      PrettyPrinter.ProgramTypes.PackageLocation.packageLocation sourceLoc)
+    |> Listing.groupedByModule
+    |> fun rows -> Listing.capped rows Listing.defaultLimit "narrow with a module path"
+    |> Stdlib.printLines
 
 
 /// Display dependencies (what this entity uses)
@@ -167,9 +187,10 @@ let showDependencies
     let namesDict = resolveNames branchId hashes
 
     deps
-    |> Stdlib.List.iter (fun (targetHash, refType) ->
-      let name = getName namesDict targetHash
-      Stdlib.printLine $"  [{refType}] {name}")
+    |> Stdlib.List.map (fun (targetHash, refType) ->
+      $"{Glyphs.forKind refType} {getName namesDict targetHash}")
+    |> fun rows -> Listing.capped rows Listing.defaultLimit "narrow with a module path"
+    |> Stdlib.printLines
 
 
 /// Resolve a path to (hash, location, kind, displayName).

--- a/packages/darklang/cli/execution/eval.dark
+++ b/packages/darklang/cli/execution/eval.dark
@@ -9,11 +9,26 @@ let evaluateRaw
   (accountID: Stdlib.Option.Option<Uuid>)
   (branchId: Uuid)
   (expr: String)
+  (currentModule: List<String>)
   (allowHarmful: Bool)
   : Stdlib.Result.Result<
       Stdlib.Option.Option<String>,
       ExecutionError.ExecutionError> =
-  Builtin.cliEvaluateExpression accountID branchId expr allowHarmful
+  // Width and color are decided here rather than inside the builtin. They are facts about the process
+  // the output is headed for, and `Cli.Terminal` is what owns them; having the host reach across into
+  // another builtin's terminal code to ask would be the wrong way round. Both fall back sanely when
+  // there is no terminal (80 columns, no color), so the callers that never print are unaffected.
+  let (width, _rows) = Terminal.getSize ()
+  let color = Terminal.colorEnabled ()
+
+  Builtin.cliEvaluateExpression
+    accountID
+    branchId
+    expr
+    currentModule
+    width
+    color
+    allowHarmful
 
 
 /// Evaluate `expr` and hand back what it produced: `Ok (Some printed)` for a value, `Ok None` for something
@@ -25,7 +40,13 @@ let evaluate
   (expr: String)
   (allowHarmful: Bool)
   : Stdlib.Result.Result<Stdlib.Option.Option<String>, String> =
-  match evaluateRaw state.accountID state.currentBranchId expr allowHarmful with
+  // Where the user is standing, so the printed value spells names the way they would.
+  let currentModule =
+    Packages.Traversal.getCurrentModulePath state.packageData.currentLocation
+
+  match
+    evaluateRaw state.accountID state.currentBranchId expr currentModule allowHarmful
+  with
   | Ok result -> Stdlib.Result.Result.Ok result
   | Error err ->
     Stdlib.Result.Result.Error(ExecutionError.toString state.currentBranchId err)

--- a/packages/darklang/cli/packages/db.dark
+++ b/packages/darklang/cli/packages/db.dark
@@ -155,7 +155,7 @@ let viewDB (state: Cli.AppState) (dbName: String) : Cli.AppState =
       ++ nl ++ "  " ++ rowExpr ++ ")"
       ++ nl ++ "|> Stdlib.String.join \"<<<ROW>>>\""
 
-    match Eval.evaluateRaw state.accountID state.currentBranchId expr false with
+    match Eval.evaluateRaw state.accountID state.currentBranchId expr [] false with
     | Ok resultOpt ->
       let result = resultOpt |> Stdlib.Option.withDefault ""
       Stdlib.printLine ""
@@ -218,7 +218,7 @@ let getDBValue
   : Cli.AppState =
   let expr = $"Stdlib.DB.get \"{key}\" {dbName}"
 
-  match Eval.evaluateRaw state.accountID state.currentBranchId expr false with
+  match Eval.evaluateRaw state.accountID state.currentBranchId expr [] false with
   | Ok (Some result) ->
     Stdlib.printLine result
     state
@@ -242,7 +242,7 @@ let setDBValue
     let expr =
       $"Stdlib.DB.set ({typeName} {valueExpr}) \"{key}\" {dbName}"
 
-    match Eval.evaluateRaw state.accountID state.currentBranchId expr false with
+    match Eval.evaluateRaw state.accountID state.currentBranchId expr [] false with
     | Ok _ ->
       Stdlib.printLine (Stdlib.Cli.UI.Colors.success $"Set {key} in {dbName}")
       state
@@ -258,7 +258,7 @@ let deleteDBValue
   : Cli.AppState =
   let expr = $"Stdlib.DB.delete \"{key}\" {dbName}"
 
-  match Eval.evaluateRaw state.accountID state.currentBranchId expr false with
+  match Eval.evaluateRaw state.accountID state.currentBranchId expr [] false with
   | Ok _ ->
     Stdlib.printLine (Stdlib.Cli.UI.Colors.success $"Deleted {key} from {dbName}")
     state
@@ -274,7 +274,7 @@ let queryDB
   : Cli.AppState =
   let expr = $"Stdlib.DB.query {dbName} ({filterExpr})"
 
-  match Eval.evaluateRaw state.accountID state.currentBranchId expr false with
+  match Eval.evaluateRaw state.accountID state.currentBranchId expr [] false with
   | Ok (Some result) ->
     Stdlib.printLine result
     state

--- a/packages/darklang/cli/packages/display.dark
+++ b/packages/darklang/cli/packages/display.dark
@@ -1,20 +1,14 @@
 module Darklang.Cli.Packages.Display
 
-/// Icon mappings for different entity types
+/// Icon for an entity type. The glyphs themselves live in `Cli.Glyphs`, which is the single vocabulary
+/// shared with the workbench; this is just the `EntityType` spelling of the same question.
 let getIcon (entityType: EntityType) : String =
   match entityType with
-  | Module -> "🗂️"
-  | Function -> "⚡️"
-  | Type -> "🔖"
-  | Value -> "💎"
+  | Module -> Glyphs.module_
+  | Function -> Glyphs.fn
+  | Type -> Glyphs.type_
+  | Value -> Glyphs.value
 
 
-/// Get section header with icon for entity type
-let getSectionHeader (entityType: String) : String =
-  match entityType with
-  | "module" -> "🗂️ Modules:"
-  | "function" -> "⚡️ Functions:"
-  | "type" -> "🔖 Types:"
-  | "value" -> "💎 Values:"
-  | "submodule" -> "🗂️ Submodules:"
-  | _ -> entityType ++ ":"
+/// Section header with icon for an entity type.
+let getSectionHeader (entityType: String) : String = Glyphs.sectionHeader entityType

--- a/packages/darklang/cli/packages/signatures.dark
+++ b/packages/darklang/cli/packages/signatures.dark
@@ -11,19 +11,14 @@ module Darklang.Cli.Packages.Signatures
 // would cover the same surface without the separate dispatch entry.
 
 
-// Pretty-printer context: prefer collapsing to `Darklang.Stdlib` so that types
-// like `Stdlib.Option.Option` render as `Option.Option` everywhere,
-// regardless of which sub-module we scoped the listing to. For non-Stdlib
-// roots, fall back to the root itself.
+// Pretty-printer context for a listing rooted at `modulePath`.
+//
+// This used to special-case `Darklang.Stdlib` by name so that `Stdlib.Option.Option` would print as
+// `Option.Option` regardless of which submodule the listing was scoped to. `shortenName` makes that
+// unnecessary: it drops the longest common prefix with the current module and knows Option and Result
+// resolve bare, so the same listing shortens correctly without anyone naming a namespace.
 let rootContext (branchId: Uuid) (modulePath: List<String>) : PrettyPrinter.ProgramTypes.Context =
-  let cur =
-    match modulePath with
-    | "Darklang" :: "Stdlib" :: _ -> "Darklang.Stdlib"
-    | _ -> Stdlib.String.join modulePath "."
-  PrettyPrinter.ProgramTypes.Context
-    { branchId = branchId
-      currentModule = Stdlib.Option.Option.Some cur
-      currentFunction = Stdlib.Option.Option.None }
+  PrettyPrinter.ProgramTypes.Context.forModule branchId modulePath
 
 
 // Renders the signature body only (no name) — e.g.

--- a/packages/darklang/cli/packages/view.dark
+++ b/packages/darklang/cli/packages/view.dark
@@ -147,10 +147,9 @@ let entityRows (branchId: Uuid) (location: PackageLocation) : List<String> =
       [ $"Type '{locationStr}' not found." ]
     | item :: _ ->
       let ctx =
-        PrettyPrinter.ProgramTypes.Context
-          { branchId = branchId
-            currentModule = Stdlib.Option.Option.None
-            currentFunction = Stdlib.Option.Option.None }
+        PrettyPrinter.ProgramTypes.Context.forModule
+          branchId
+          (Stdlib.List.push name.modules name.owner)
       let prettyPrinted = PrettyPrinter.ProgramTypes.packageType ctx item.entity
       let highlighted = SyntaxHighlighting.highlightCode prettyPrinted
 
@@ -172,10 +171,9 @@ let entityRows (branchId: Uuid) (location: PackageLocation) : List<String> =
       [ $"Function '{locationStr}' not found." ]
     | item :: _ ->
       let ctx =
-        PrettyPrinter.ProgramTypes.Context
-          { branchId = branchId
-            currentModule = Stdlib.Option.Option.None
-            currentFunction = Stdlib.Option.Option.None }
+        PrettyPrinter.ProgramTypes.Context.forModule
+          branchId
+          (Stdlib.List.push name.modules name.owner)
       let prettyPrinted = PrettyPrinter.ProgramTypes.packageFn ctx item.entity
       let highlighted = SyntaxHighlighting.highlightCode prettyPrinted
       let capsBadge =
@@ -201,10 +199,9 @@ let entityRows (branchId: Uuid) (location: PackageLocation) : List<String> =
       [ $"Value '{locationStr}' not found." ]
     | item :: _ ->
       let ctx =
-        PrettyPrinter.ProgramTypes.Context
-          { branchId = branchId
-            currentModule = Stdlib.Option.Option.None
-            currentFunction = Stdlib.Option.Option.None }
+        PrettyPrinter.ProgramTypes.Context.forModule
+          branchId
+          (Stdlib.List.push name.modules name.owner)
       let prettyPrinted = PrettyPrinter.ProgramTypes.packageValue ctx item.entity
       let highlighted = SyntaxHighlighting.highlightCode prettyPrinted
 
@@ -290,7 +287,7 @@ let fnAt
     Stdlib.Result.Result.Error "that's a value; this view is for functions"
 
 
-/// The ProgramTypes tree, indented by depth. Node kinds are coloured and payloads dimmed, so the shape
+/// The ProgramTypes tree, indented by depth. Node kinds are colored and payloads dimmed, so the shape
 /// reads at a glance and the detail is there when you look for it.
 let astRows
   (branchId: Uuid)

--- a/packages/darklang/cli/scm/log.dark
+++ b/packages/darklang/cli/scm/log.dark
@@ -10,9 +10,10 @@ module Darklang.Cli.SCM.Log
 let renderOneLine
   (c: SCM.PackageOps.Commit)
   (isAncestor: Bool)
+  (long: Bool)
   : String =
   let id = LanguageTools.ProgramTypes.hashToShort c.hash
-  let createdAt = Stdlib.DateTime.toString c.createdAt
+  let createdAt = RelativeTime.stamp long c.createdAt
   let opCount = Stdlib.Int.toString c.opCount
   let suffix = if isAncestor then $"  [{c.branchName}]" else ""
 
@@ -21,9 +22,9 @@ let renderOneLine
   else
     $"  {Cli.Colors.cyan}{id}{Cli.Colors.reset}  {createdAt}  {Cli.Colors.dim}{c.committerName}{Cli.Colors.reset}  {opCount} ops  {c.message}"
 
-let renderDetailed (c: SCM.PackageOps.Commit) (isAncestor: Bool) : Unit =
+let renderDetailed (c: SCM.PackageOps.Commit) (isAncestor: Bool) (long: Bool) : Unit =
   let id = LanguageTools.ProgramTypes.hashToShort c.hash
-  let createdAt = Stdlib.DateTime.toString c.createdAt
+  let createdAt = RelativeTime.stamp long c.createdAt
   let opCount = Stdlib.Int.toString c.opCount
 
   if isAncestor then
@@ -43,6 +44,9 @@ let execute (state: AppState) (args: List<String>) : AppState =
   let branchId = state.currentBranchId
   let detailed =
     (Stdlib.List.member args "--detailed") || (Stdlib.List.member args "--full")
+
+  // Relative by default; the exact stamp when you ask for it.
+  let long = Stdlib.List.member args "--long"
 
   let limit =
     match Stdlib.List.filter args (fun a -> Stdlib.String.startsWith a "--" |> Stdlib.Bool.not) with
@@ -75,9 +79,9 @@ let execute (state: AppState) (args: List<String>) : AppState =
       let isAncestor = commitBranchId != currentBranchIdStr && commitBranchId != ""
 
       if detailed then
-        renderDetailed c isAncestor
+        renderDetailed c isAncestor long
       else
-        Stdlib.printLine (renderOneLine c isAncestor))
+        Stdlib.printLine (renderOneLine c isAncestor long))
 
   state
 
@@ -87,7 +91,7 @@ let complete (_state: AppState) (_args: List<String>) : List<Completion.Completi
 
 
 let help (_state: AppState) : String =
-  [ "Usage: commits [limit] [--detailed]"
+  [ "Usage: commits [limit] [--detailed] [--long]"
     "Show commit history for the current branch and its ancestors."
     "Commits from parent branches are shown dimmed with the branch name."
     ""
@@ -95,6 +99,7 @@ let help (_state: AppState) : String =
     "  limit        Maximum number of commits to show (default: 20)"
     "  --detailed   Three lines per commit (id/date/author, message, blank) instead of one."
     "               --full does the same."
+    "  --long       Exact timestamps instead of `3 days ago`."
     ""
     "Aliases: log, history"
     ""

--- a/packages/darklang/cli/scm/review/app.dark
+++ b/packages/darklang/cli/scm/review/app.dark
@@ -104,8 +104,9 @@ let prettyPrintFromPM (branchId: Uuid) (itemName: String) (kind: String) : Strin
   let ctx =
     PrettyPrinter.ProgramTypes.Context
       { branchId = branchId
-        currentModule = Stdlib.Option.Option.None
-        currentFunction = Stdlib.Option.Option.None }
+        currentModule = []
+        currentFunction = Stdlib.Option.Option.None
+        width = 80 }
   match kind with
   | "Fn" ->
     match results.fns with
@@ -131,8 +132,9 @@ let prettyPrintFromOps
   let ctx =
     PrettyPrinter.ProgramTypes.Context
       { branchId = branchId
-        currentModule = Stdlib.Option.Option.None
-        currentFunction = Stdlib.Option.Option.None }
+        currentModule = []
+        currentFunction = Stdlib.Option.Option.None
+        width = 80 }
   let targetHash =
     (extractSetOps ops)
     |> Stdlib.List.filterMap (fun entry ->

--- a/packages/darklang/cli/scm/showCommit.dark
+++ b/packages/darklang/cli/scm/showCommit.dark
@@ -50,17 +50,21 @@ let execute (state: AppState) (args: List<String>) : AppState =
       match meta with
       | Some c ->
         Stdlib.printLine
-          $"Commit {Cli.Colors.cyan}{shortId}{Cli.Colors.reset} — {c.committerName}, {Stdlib.DateTime.toString c.createdAt} — {Stdlib.Int.toString (Stdlib.List.length ops)} ops"
+          $"Commit {Cli.Colors.cyan}{shortId}{Cli.Colors.reset} — {c.committerName}, {RelativeTime.ago c.createdAt} — {Stdlib.Int.toString (Stdlib.List.length ops)} ops"
 
         Stdlib.printLine $"  {c.message}"
       | None ->
         Stdlib.printLine
           $"Commit {Cli.Colors.cyan}{shortId}{Cli.Colors.reset} — {Stdlib.Int.toString (Stdlib.List.length ops)} ops:"
 
+      // Capped: the init commit holds eleven thousand ops, and printing all of them buries the header
+      // that says so. The count is already in the line above, so the footer only has to say what's left.
       ops
-      |> Stdlib.List.iter (fun op ->
+      |> Stdlib.List.map (fun op ->
         let opStr = PrettyPrinter.ProgramTypes.PackageOp.packageOp branchId op
-        Stdlib.printLine $"  {opStr}")
+        $"  {opStr}")
+      |> fun rows -> Listing.capped rows Listing.defaultLimit "use `ops` to page through them"
+      |> Stdlib.printLines
 
     state
   | _ ->

--- a/packages/darklang/cli/tracing.dark
+++ b/packages/darklang/cli/tracing.dark
@@ -1132,7 +1132,7 @@ let executeReplay (state: Cli.AppState) (traceID: String) : Cli.AppState =
     Stdlib.printLine ""
     match
       Eval.evaluateRaw
-        state.accountID state.currentBranchId code false
+        state.accountID state.currentBranchId code [] false
     with
     | Ok outputOpt ->
       match outputOpt with

--- a/packages/darklang/cli/utils/glyphs.dark
+++ b/packages/darklang/cli/utils/glyphs.dark
@@ -1,0 +1,57 @@
+/// The one set of glyphs for package item kinds.
+///
+/// Every glyph here occupies exactly ONE terminal column under `Tui.Text.displayWidth`, and `forKind`
+/// pads to two. That property is the whole point, and it is easy to lose: `⚡` (the old function icon)
+/// measures two by the Unicode tables while terminals draw it as one, so a column of mixed rows came
+/// out ragged and no amount of padding fixed it for both. The emoji that were used elsewhere -- 🗂️ ⚡️ 🔖
+/// 💎 -- carry variation selectors and have the same problem.
+///
+/// Check `Tui.Text.displayWidth` before swapping any of these.
+module Darklang.Cli.Glyphs
+
+/// A module.
+val module_ = "🗂"
+
+/// A function.
+val fn = "ƒ"
+
+/// A type.
+val type_ = "#"
+
+/// A value, and the fallback for anything unrecognised.
+val value = "•"
+
+
+/// The glyph for a kind name, padded to two terminal columns so names line up.
+///
+/// Accepts the spellings the various callers use: the tree loaders say "fn"/"type"/"val", the backend's
+/// display kinds are "Fn"/"Type"/"Value", and the package listings say "function"/"value"/"submodule".
+let forKind (kind: String) : String =
+  let glyph =
+    match Stdlib.String.toLowercase kind with
+    | "module" -> Glyphs.module_
+    | "submodule" -> Glyphs.module_
+    | "fn" -> Glyphs.fn
+    | "function" -> Glyphs.fn
+    | "type" -> Glyphs.type_
+    | "val" -> Glyphs.value
+    | "value" -> Glyphs.value
+    | _ -> Glyphs.value
+
+  Tui.Text.fitToWidth glyph 2
+
+
+/// A section header for a listing: glyph plus the plural noun.
+let sectionHeader (kind: String) : String =
+  let label =
+    match Stdlib.String.toLowercase kind with
+    | "module" -> "Modules"
+    | "submodule" -> "Submodules"
+    | "fn" -> "Functions"
+    | "function" -> "Functions"
+    | "type" -> "Types"
+    | "val" -> "Values"
+    | "value" -> "Values"
+    | other -> other
+
+  $"{Glyphs.forKind kind} {label}:"

--- a/packages/darklang/cli/utils/listing.dark
+++ b/packages/darklang/cli/utils/listing.dark
@@ -1,0 +1,63 @@
+/// One rule for what a long listing does when it is too long to read.
+///
+/// `search` already capped its results and said how many it dropped; `deps` printed all 431 dependents
+/// and `show` all 11,578 ops. A listing that scrolls a thousand lines past you has told you less than
+/// one that shows twenty and says how many there were, and silently truncating is worse than either --
+/// a cap you can't see reads as "that's all of them".
+module Darklang.Cli.Listing
+
+/// How many rows a long listing shows before it stops and says how many are left.
+val defaultLimit = 20
+
+
+/// The first `limit` rows, plus a footer saying how many were left out and how to see them.
+///
+/// `more` is the hint: what the reader should do to get the rest.
+let capped (rows: List<String>) (limit: Int) (more: String) : List<String> =
+  let n = Stdlib.List.length rows
+
+  if n <= limit then
+    rows
+  else
+    let extra = Stdlib.Int.toString (n - limit)
+
+    Stdlib.List.append
+      (Stdlib.List.take rows limit)
+      [ Colors.hint $"  ... and {extra} more ({more})" ]
+
+
+/// Split a fully-qualified name into its module path and its leaf.
+let splitLeaf (name: String) : (String * String) =
+  let parts = Stdlib.String.split name "."
+
+  match Stdlib.List.last parts with
+  | None -> ("", name)
+  | Some leaf ->
+    let modulePath =
+      parts
+      |> Stdlib.List.take ((Stdlib.List.length parts) - 1)
+      |> Stdlib.String.join "."
+
+    (modulePath, leaf)
+
+
+/// Group qualified names under their module, so a long list reads as a few modules rather than as
+/// hundreds of near-identical paths whose only difference is the last segment.
+let groupedByModule (names: List<String>) : List<String> =
+  let modules =
+    names
+    |> Stdlib.List.map (fun n -> Stdlib.Tuple2.first (Listing.splitLeaf n))
+    |> Stdlib.List.unique
+
+  modules
+  |> Stdlib.List.map (fun m ->
+    let leaves =
+      names
+      |> Stdlib.List.filter (fun n -> (Stdlib.Tuple2.first (Listing.splitLeaf n)) == m)
+      |> Stdlib.List.map (fun n -> Stdlib.Tuple2.second (Listing.splitLeaf n))
+
+    let count = Stdlib.Int.toString (Stdlib.List.length leaves)
+    let header = Colors.dimText $"  {m}  ({count})"
+
+    [ header; $"    {Stdlib.String.join leaves ", "}" ])
+  |> Stdlib.List.flatten

--- a/packages/darklang/cli/utils/relativeTime.dark
+++ b/packages/darklang/cli/utils/relativeTime.dark
@@ -1,0 +1,39 @@
+/// Timestamps as a reader thinks about them.
+///
+/// `2026-08-17T18:43:04Z` is precise and nearly useless for scanning a log: working out that it was
+/// yesterday takes longer than reading the rest of the row. "22 hours ago" answers the question the
+/// column is actually there for. The exact stamp is still one flag away, for when it's the thing you
+/// need.
+module Darklang.Cli.RelativeTime
+
+/// "3 days ago", "22 hours ago", "just now".
+///
+/// Coarse on purpose: one unit, no "1 day 4 hours". A log column wants a glance, not a duration.
+let ago (then_: DateTime) : String =
+  // On one line deliberately: a `-` starting a continuation line at the same column reads as a new
+  // statement (it could be a negative literal), so the split form silently became two expressions.
+  let now = Stdlib.DateTime.toSeconds (Stdlib.DateTime.now ())
+  let seconds = now - (Stdlib.DateTime.toSeconds then_)
+
+  let plural (n: Int) (unit: String) : String =
+    let s = if n == 1 then "" else "s"
+    $"{Stdlib.Int.toString n} {unit}{s} ago"
+
+  // A clock that is a little ahead, or a commit made during this second.
+  if seconds < 60 then
+    "just now"
+  else if seconds < 3600 then
+    plural (Stdlib.Int.divide seconds 60) "minute"
+  else if seconds < 86400 then
+    plural (Stdlib.Int.divide seconds 3600) "hour"
+  else if seconds < 2592000 then
+    plural (Stdlib.Int.divide seconds 86400) "day"
+  else if seconds < 31536000 then
+    plural (Stdlib.Int.divide seconds 2592000) "month"
+  else
+    plural (Stdlib.Int.divide seconds 31536000) "year"
+
+
+/// The relative form, or the exact stamp when `long` is set.
+let stamp (long: Bool) (t: DateTime) : String =
+  if long then Stdlib.DateTime.toString t else RelativeTime.ago t

--- a/packages/darklang/cli/utils/terminal.dark
+++ b/packages/darklang/cli/utils/terminal.dark
@@ -3,3 +3,61 @@ module Darklang.Cli.Terminal
 /// Samples terminal width and height in one native call.
 let getSize () : (Int * Int) =
   Builtin.cliTerminalSize ()
+
+
+/// Whether printed output should carry color.
+///
+/// `NO_COLOR` is the informal standard and people expect it to work; a redirected stdout is what makes
+/// `dark eval ... > file` produce text rather than escape sequences. Both are facts about the process,
+/// which is why the host answers rather than the printer.
+let colorEnabled () : Bool =
+  Builtin.cliTerminalColorEnabled ()
+
+
+/// Display options sized to the terminal we are actually printing to.
+///
+/// Lives here rather than next to `DisplayOptions` on purpose: reading the terminal is something the
+/// edge does, and a printer that could reach for this would stop being reproducible in a test or
+/// sizeable to a pane. `getSize` is the one place the builtin is reached.
+let displayOptions () : PrettyPrinter.DisplayOptions =
+  let (cols, _rows) = Terminal.getSize ()
+  PrettyPrinter.DisplayOptions.atWidth cols
+
+
+/// The CLI's palette for printed values.
+///
+/// Lives here rather than beside `DisplayOptions` because these are `Cli.Colors` constants, and
+/// `PrettyPrinter` has no business knowing about them. It knows a string is a string; this says what a
+/// string looks like.
+let palette () : PrettyPrinter.Palette =
+  PrettyPrinter.Palette
+    { string_ = Colors.stringColor
+      number = Colors.numberColor
+      typeName = Colors.brightBlue
+      caseName = Colors.magenta
+      keyword = Colors.keywordColor
+      reset = Colors.reset }
+
+
+/// A value rendered for this terminal: laid out for `width`, painted with the CLI's palette.
+///
+/// The CLI host calls this rather than the printer directly, because the palette is a `Cli.Colors`
+/// thing and the printer must not know about it.
+let renderValue
+  (branchId: Uuid)
+  (width: Int)
+  (color: Bool)
+  (currentModule: List<String>)
+  (dv: LanguageTools.RuntimeTypes.Dval)
+  : String =
+  // Whether to color is decided by the host, not here: it is a fact about stdout and the environment,
+  // and asking for it from Dark needs an `env` capability the instance may not grant.
+  let palette = if color then Terminal.palette () else PrettyPrinter.Palette.plain
+
+  let opts =
+    { PrettyPrinter.DisplayOptions.default with
+        width = width
+        palette = palette
+        currentModule = currentModule }
+
+  PrettyPrinter.RuntimeTypes.dvalWith branchId opts dv

--- a/packages/darklang/cli/workbench/authoring.dark
+++ b/packages/darklang/cli/workbench/authoring.dark
@@ -171,8 +171,9 @@ let openEditExisting (state: State) (item: BodyItem) : Step =
   let ctx =
     PrettyPrinter.ProgramTypes.Context
       { branchId = state.branchId
-        currentModule = Stdlib.Option.Option.None
-        currentFunction = Stdlib.Option.Option.None }
+        currentModule = []
+        currentFunction = Stdlib.Option.Option.None
+        width = 80 }
   // Prefill from the item's current source, per kind. `val` items save under the "value" kind (see saveEditing).
   let kindAndSrc =
     if item.kind == "type" then

--- a/packages/darklang/cli/workbench/chrome.dark
+++ b/packages/darklang/cli/workbench/chrome.dark
@@ -19,7 +19,7 @@ let renderViewBody (state: State) (region: Stdlib.Cli.UI.Layout.Region) : List<S
     Stdlib.Cli.UI.SplitPane.render
       region
       Stdlib.Cli.UI.SplitPane.Orientation.Horizontal
-      45
+      (matterSplitFor state)
       state.focus
       treeTitle
       (fun r -> renderTreeList state r)
@@ -141,7 +141,7 @@ let hintsForView (state: State) : String =
     [ ("/", "search"); (":", "cmd"); ("p", "prompt"); ("`", "views"); ("?", "help"); ("esc/q", "quit") ]
   let ctx =
     if view == vMatter then
-      [ ("↑↓", "move"); ("→", "in"); ("d", "deps"); ("n/t/v", "new"); ("e", "edit"); ("r", "rename"); ("L", "values"); ("f", "filter") ]
+      [ ("↑↓", "move"); ("→", "in"); ("n/t/v", "new"); ("e", "edit"); ("r", "rename"); ("L", "values"); ("f", "filter") ]
     else if view == vHome then
       // Home is a dashboard, not a list - nothing here moves, so don't advertise a cursor. The tabs panel
       // names its own keys.
@@ -181,7 +181,7 @@ val helpGroups =
     ("Views", "ctrl+←/→ switch   [ ] cycle   ` picker   1-9 jump")
     ("Move", "↑↓ or j/k   g/G top/bottom   tab focus/section")
     ("Matter", "→/l in   ←/h up   ⏎ open   n/t/v new   e edit   r rename   L values-lens   f filter")
-    ("Inspect", "⏎ walk callers   d deps")
+    ("Inspect", "⏎ walk callers")
     ("REPL", "⏎ run (or keep typing)   f clear log   x clear session")
     ("SCM", "tab section   c commit   x discard   b branch   s switch   m merge   r rebase   o/t/a resolve")
     ("AI", "tab Agents/Prompts   a ask")

--- a/packages/darklang/cli/workbench/detail.dark
+++ b/packages/darklang/cli/workbench/detail.dark
@@ -7,26 +7,12 @@ module Darklang.Cli.Workbench
 
 /// The glyph for a row's kind, padded to two terminal columns.
 ///
-/// Lowercased first because two vocabularies meet here: the tree's loaders use "fn"/"type"/"val", while WIP
-/// rows carry the backend's display kinds ("Fn"/"Type"/"Value", see `getWipItems`). Matching only the
-/// lowercase spelling meant every row in SCM Changes fell through to the bullet.
-///
-/// Padded to a fixed two columns, because the glyphs aren't all one column and concatenating them raw left
-/// names in a mixed list starting a column apart - a ragged left edge down the tree.
-///
-/// Every glyph here measures ONE column under `displayWidth`, which is what makes that padding correct. `⚡`
-/// used to be the fn icon and measured two, while terminals draw it as one, so fn rows came out a column short
-/// of everything else and no padding could be right for both. Any replacement needs the same property: check
-/// `Stdlib.Cli.Tui.Text.displayWidth` before swapping a glyph in here.
+/// `Cli.Glyphs` owns the vocabulary, including the rule that every glyph measures one column and gets
+/// padded to two; this only has to decide that a module row is a module, since `BodyItem` carries that
+/// separately from its kind string.
 let iconFor (item: BodyItem) : String =
-  let glyph =
-    if item.isModule then "🗂"
-    else
-      match Stdlib.String.toLowercase item.kind with
-      | "fn" -> "ƒ"
-      | "type" -> "#"
-      | _ -> "•"
-  Stdlib.Cli.Tui.Text.fitToWidth glyph 2
+  if item.isModule then Glyphs.forKind "module" else Glyphs.forKind item.kind
+
 
 let renderTreeList (state: State) (region: Stdlib.Cli.UI.Layout.Region) : List<Stdlib.Cli.UI.Layout.Span> =
   if Stdlib.List.isEmpty state.items then
@@ -83,11 +69,15 @@ let detailLines (state: State) : List<String> =
     else
       let modulePath = modulePathOf state.location
       let results = Packages.Query.searchExactMatch state.branchId modulePath item.name
+      // Anchored at the module being browsed, so the Inspect pane spells references the way someone
+      // standing in that module would. `modulePath` is owner-first, which is what `forModule` wants.
+      //
+      // And laid out for the pane it is going into, rather than for the printers' default 80. Reading
+      // the pane width is the caller's job -- the printer can't, by design -- so it happens here.
+      // Wrapping in `renderScrollableLines` stays as the floor under a line no layout could shorten.
       let ctx =
-        PrettyPrinter.ProgramTypes.Context
-          { branchId = state.branchId
-            currentModule = Stdlib.Option.Option.None
-            currentFunction = Stdlib.Option.Option.None }
+        { PrettyPrinter.ProgramTypes.Context.forModule state.branchId modulePath with
+            width = previewInnerWidth () }
       let src =
         match item.kind with
         | "fn" ->
@@ -202,11 +192,14 @@ let itemMeta (state: State) : String =
         | None -> "not deprecated"
       kindLabel ++ "  ·  hash " ++ short ++ "  ·  current  ·  " ++ deprecation
 
-/// Per-node actions offered on the item page. Only what's wired (`d` deps); try/traces are named in the
-/// hint line but land in later passes, so they read as affordances, not working keys yet.
-let itemActions (item: BodyItem) : String =
-  if item.kind == "fn" then Stdlib.Cli.UI.Colors.dimText "d deps  ·  t try, x traces (coming)"
-  else Stdlib.Cli.UI.Colors.dimText "d deps"
+/// Per-node actions offered on the item page, or nothing when there are none to offer.
+///
+/// `d deps` used to lead here. It opened the item's dependencies in the reader, which is the same text
+/// this page already prints under `── references ──`, so it was a keystroke to see what was on screen.
+/// try/traces are named as affordances and land in later passes; they are not wired yet.
+let itemActions (item: BodyItem) : List<String> =
+  if item.kind == "fn" then [ ""; Stdlib.Cli.UI.Colors.dimText "t try, x traces (coming)" ]
+  else []
 
 let inspectPageLines (state: State) : List<String> =
   match Stdlib.List.getAt state.items state.selected with
@@ -216,17 +209,28 @@ let inspectPageLines (state: State) : List<String> =
       [ (iconFor item) ++ " " ++ item.name; ""; Stdlib.Cli.UI.Colors.dimText "module - → to enter" ]
     else
       // Highlight the source portion here (the page mixes code + colored ref/meta lines, so renderPreview
-      // can't blanket-highlight it). Guard: only swap in the highlighted lines if the count still lines up.
+      // can't blanket-highlight it).
+      //
+      // The guard is a line-count check: highlighting re-lexes the rendered text, and if that comes back
+      // with a different number of lines the colors would land on the wrong rows. Falling back to the
+      // plain source is right, but it used to be silent, so a printer change that altered the line count
+      // just quietly turned syntax highlighting off and nothing said why. Say it.
       let srcPlain = detailLines state
       let src =
         let h =
           SyntaxHighlighting.highlightCode (Stdlib.String.join srcPlain "\n") |> Stdlib.String.split "\n"
-        if Stdlib.List.length h == Stdlib.List.length srcPlain then h else srcPlain
+        if Stdlib.List.length h == Stdlib.List.length srcPlain then
+          h
+        else
+          Stdlib.List.append
+            srcPlain
+            [ Colors.warning
+                $"(syntax highlighting off: re-lexing produced {Stdlib.Int.toString (Stdlib.List.length h)} lines, source has {Stdlib.Int.toString (Stdlib.List.length srcPlain)})" ]
       let refs = Stdlib.String.split (depsText state) "\n"
       Stdlib.List.flatten
         [ src
           [ ""; Stdlib.Cli.UI.Colors.dimText (itemMeta state) ]
-          [ ""; itemActions item ]
+          (itemActions item)
           [ ""; Stdlib.Cli.UI.Colors.colorize Stdlib.Cli.UI.Colors.cyan "── references ──"; "" ]
           refs ]
 

--- a/packages/darklang/cli/workbench/keys-view.dark
+++ b/packages/darklang/cli/workbench/keys-view.dark
@@ -134,10 +134,6 @@ let handleViewKey
                 (InputState { prompt = "search "; field = Stdlib.Cli.UI.TextField.fromText ""; action = "search" }) }
     | Some "]" -> cycleView state 1
     | Some "[" -> cycleView state (0 - 1)
-    | Some "d" ->
-      // Matter/Inspect: show the selected leaf's dependencies (what it uses) in the reader.
-      if state.activeView == vMatter then openReader state (depsText state) false
-      else Step.Continue state
     | Some "a" ->
       // SCM Conflicts: acknowledge. AI: ask the agent. Devices: add an instance (placeholder).
       if (state.activeView == vSCM) && (state.scm.section == ScmSection.Conflicts) then resolveConflict state "ok"

--- a/packages/darklang/cli/workbench/loaders-misc.dark
+++ b/packages/darklang/cli/workbench/loaders-misc.dark
@@ -79,11 +79,11 @@ let thingDetail (state: State) : String =
     let results = Packages.Query.searchExactMatch state.branchId mods leaf
     match results.values with
     | i :: _ ->
+      // `mods` is the value's own module, and the pane knows its width: the last two places in the
+      // workbench still printing against neither.
       let ctx =
-        PrettyPrinter.ProgramTypes.Context
-          { branchId = state.branchId
-            currentModule = Stdlib.Option.Option.None
-            currentFunction = Stdlib.Option.Option.None }
+        { PrettyPrinter.ProgramTypes.Context.forModule state.branchId mods with
+            width = previewInnerWidth () }
       PrettyPrinter.ProgramTypes.packageValue ctx i.entity
     | [] -> "(not found)"
 

--- a/packages/darklang/cli/workbench/loaders.dark
+++ b/packages/darklang/cli/workbench/loaders.dark
@@ -125,8 +125,9 @@ let changesSourceText (branchId: Uuid) (selected: Int) : String =
     let ctx =
       PrettyPrinter.ProgramTypes.Context
         { branchId = branchId
-          currentModule = Stdlib.Option.Option.None
-          currentFunction = Stdlib.Option.Option.None }
+          currentModule = []
+          currentFunction = Stdlib.Option.Option.None
+          width = 80 }
     let src =
       if kind == "Type" then
         match results.types with
@@ -198,20 +199,33 @@ let depsText (state: State) : String =
         let depLines =
           if Stdlib.List.isEmpty deps then [ Stdlib.Cli.UI.Colors.dimText "  (none)" ]
           else
-            let namesDict = Darklang.Cli.Deps.resolveNames state.branchId (deps |> Stdlib.List.map (fun p -> let (h, _) = p in h))
+            let namesDict =
+              Darklang.Cli.Deps.resolveNamesIn
+                state.branchId
+                (modulePathOf state.location)
+                (deps |> Stdlib.List.map (fun p -> let (h, _) = p in h))
             deps |> Stdlib.List.map (fun p -> let (th, _rt) = p in "  " ++ (Darklang.Cli.Deps.getName namesDict th))
         // Dependents - what uses this item.
         let dependents = Cli.Deps.getDependents state.branchId [ (loc, kind) ]
         let dependentLines =
           if Stdlib.List.isEmpty dependents then [ Stdlib.Cli.UI.Colors.dimText "  (none)" ]
-          else dependents |> Stdlib.List.map (fun t -> let (_h, sLoc, _rt) = t in "  " ++ (PrettyPrinter.ProgramTypes.PackageLocation.packageLocation sLoc))
-        (Stdlib.Cli.UI.Colors.boldText item.name)
-        ++ "\n\n"
-        ++ (Stdlib.Cli.UI.Colors.dimText ("Dependencies (uses) - " ++ (Stdlib.Int.toString (Stdlib.List.length deps))))
+          else
+            // Spelled from where the reader is standing, like everything else on this page.
+            let here = modulePathOf state.location
+            dependents
+            |> Stdlib.List.map (fun t ->
+              let (_h, sLoc, _rt) = t
+              "  " ++ (PrettyPrinter.ProgramTypes.PackageLocation.packageLocationIn here sLoc))
+        // No item name here: `inspectPageLines` composes this under a page already headed by that
+        // item's source, so including it printed the name twice on one screen.
+        //
+        // Counts use the same `label  ·  count` shape as the pane titles and the meta strip, rather
+        // than a third punctuation for the same idea on the same screen.
+        (Stdlib.Cli.UI.Colors.dimText ("Dependencies (uses)  ·  " ++ (Stdlib.Int.toString (Stdlib.List.length deps))))
         ++ "\n"
         ++ (Stdlib.String.join depLines "\n")
         ++ "\n\n"
-        ++ (Stdlib.Cli.UI.Colors.dimText ("Dependents (used by) - " ++ (Stdlib.Int.toString (Stdlib.List.length dependents))))
+        ++ (Stdlib.Cli.UI.Colors.dimText ("Dependents (used by)  ·  " ++ (Stdlib.Int.toString (Stdlib.List.length dependents))))
         ++ "\n"
         ++ (Stdlib.String.join dependentLines "\n")
 
@@ -289,7 +303,7 @@ let refreshPeek (next: State) : State =
           let fullpath =
             Stdlib.String.join (Stdlib.List.append (modulePathOf next.location) [ item.name ]) "."
           captureOutput (fun () ->
-            Eval.evaluateRaw next.accountId next.branchId (fullpath ++ " ()") false)
+            Eval.evaluateRaw next.accountId next.branchId (fullpath ++ " ()") [] false)
         else
           ""
       | None -> ""

--- a/packages/darklang/cli/workbench/nav.dark
+++ b/packages/darklang/cli/workbench/nav.dark
@@ -49,7 +49,9 @@ let navUp (state: State) : Step =
 let navDown (state: State) : Step =
   match state.focus with
   | Second ->
-    let maxScroll = Stdlib.Int.max 0 ((Stdlib.List.length (previewLines state)) - 1)
+    // Screen rows, not logical lines: a long line wraps to several, and bounding on the unwrapped count
+    // stops the scroll before its tail is reachable.
+    let maxScroll = Stdlib.Int.max 0 ((previewRowCount state) - 1)
     Step.Continue { state with detailScroll = Stdlib.Int.min maxScroll (state.detailScroll + 1) }
   | First ->
     let maxIdx = (Stdlib.List.length state.items) - 1

--- a/packages/darklang/cli/workbench/render.dark
+++ b/packages/darklang/cli/workbench/render.dark
@@ -5,10 +5,32 @@
 module Darklang.Cli.Workbench
 
 /// Render `lines` into `region` as a vertically-scrollable block: drop `scroll` rows, take what fits, each cut
-/// ANSI-aware so colour survives an overflow. `display` is the styled variant shown per row (pass `lines`
+/// ANSI-aware so color survives an overflow. `display` is the styled variant shown per row (pass `lines`
 /// itself when there's no highlighting); `lines` drives the count. `colOffset` insets the text from the
 /// region's left (the split-pane preview insets 1; the full-screen reader doesn't). Backs both
 /// `renderPreview` and `renderReading`.
+/// Break one logical line into the rows it occupies at `maxFit` columns.
+///
+/// Continuation rows are indented two columns, so a wrapped line reads as one thing rather than as two
+/// unrelated rows; the wrap width is reduced to match, which keeps every row inside the pane.
+let wrapRow (maxFit: Int) (line: String) : List<String> =
+  let room = Stdlib.Int.max 1 (maxFit - 2)
+
+  match Tui.Text.wrapStyled line room with
+  | [] -> [ "" ]
+  | first :: rest -> Stdlib.List.push (rest |> Stdlib.List.map (fun r -> "  " ++ r)) first
+
+
+/// Render `lines` into `region` as a vertically-scrollable block: wrap each logical line to the pane
+/// width, drop `scroll` rows, take what fits. `display` is the styled variant shown per row (pass
+/// `lines` itself when there's no highlighting); `lines` drives the fallback. `colOffset` insets the
+/// text from the region's left (the split-pane preview insets 1; the full-screen reader doesn't). Backs
+/// both `renderPreview` and `renderReading`.
+///
+/// Rows used to be cut with `clipToWidth`, which meant anything past the pane's right edge was gone:
+/// not wrapped, not reachable by scrolling, and with no mark that it had ever been there. A record
+/// literal printed on one line (the source printer doesn't break them) lost most of its fields that
+/// way. Wrapping is a floor under that, not a substitute for the printer laying out to the width.
 let renderScrollableLines
   (region: Stdlib.Cli.UI.Layout.Region)
   (colOffset: Int)
@@ -16,29 +38,84 @@ let renderScrollableLines
   (display: List<String>)
   (scroll: Int)
   : List<Stdlib.Cli.UI.Layout.Span> =
-  let len = Stdlib.List.length lines
+  let maxFit = Stdlib.Int.max 1 (region.cols - 1)
+
+  // Wrap first, then scroll: `scroll` counts screen rows, so it has to index the wrapped list or
+  // scrolling skips whole tails of long lines.
+  let rows =
+    lines
+    |> Stdlib.List.indexedMap (fun i l ->
+      let disp = Stdlib.List.getAt display i |> Stdlib.Option.withDefault l
+      wrapRow maxFit disp)
+    |> Stdlib.List.flatten
+
+  let len = Stdlib.List.length rows
   let off = Stdlib.Int.min scroll (Stdlib.Int.max 0 (len - 1))
-  let maxFit = Stdlib.Int.max 0 (region.cols - 1)
-  lines
+
+  rows
   |> Stdlib.List.indexedMap (fun i l -> (i, l))
   |> Stdlib.List.drop off
   |> Stdlib.List.take region.rows
   |> Stdlib.List.map (fun pair ->
-    let (i, p) = pair
+    let (i, l) = pair
     let row = i - off
-    let disp = Stdlib.List.getAt display i |> Stdlib.Option.withDefault p
-    Stdlib.Cli.UI.Layout.at region row colOffset (Stdlib.Cli.Tui.Text.clipToWidth disp maxFit))
+    // Belt and braces: a single grapheme wider than the pane can't be wrapped, only cut.
+    Stdlib.Cli.UI.Layout.at region row colOffset (Stdlib.Cli.Tui.Text.clipToWidth l maxFit))
   |> Stdlib.List.flatten
+
+
+/// How wide the tree pane should be, as a percent of the body, for the items currently in it.
+///
+/// Sized to the longest name plus its cursor, glyph, badges and borders, then held between a floor and
+/// a ceiling. The tree is a column of short names; the Inspect pane is where the text that needs room
+/// actually goes, so any column the tree doesn't need belongs to it.
+let matterSplitFor (state: State) : Int =
+  let (w, _h) = Terminal.getSize ()
+  let w = if w < 24 then 80 else w
+
+  let longest =
+    state.items
+    |> Stdlib.List.map (fun i -> Stdlib.String.displayWidth i.name)
+    |> Stdlib.List.fold 0 (fun acc n -> if n > acc then n else acc)
+
+  // cursor (2) + glyph (2) + space (1) + trailing `/` and badges (4) + both borders (2)
+  let needed = longest + 11
+  let pct = Stdlib.Int.divide (needed * 100) w
+
+  Stdlib.Int.max matterSplitMinPct (Stdlib.Int.min matterSplitMaxPct pct)
+
+
+/// Roughly how many columns the Matter preview pane gives its text.
+///
+/// Mirrors the geometry the render pass actually uses: the body spans the screen, `SplitPane` gives the
+/// tree at most `matterSplitMaxPct` of it, `Box.inner` takes a column of border off each side, and
+/// `renderScrollableLines` insets one more. Used only to bound scrolling; the render pass has the real
+/// region and is authoritative, so being a column or two out costs nothing. Keep in step with
+/// `renderViewBody`'s `SplitPane.render` call.
+let previewInnerWidth () : Int =
+  let (w, _h) = Terminal.getSize ()
+  let w = if w < 24 then 80 else w
+  let treeCols = Stdlib.Int.divide (w * matterSplitMaxPct) 100
+  Stdlib.Int.max 1 (w - treeCols - 3)
+
+
+/// How many screen rows `previewLines` occupies once wrapped: what scrolling is bounded by.
+let previewRowCount (state: State) : Int =
+  let maxFit = previewInnerWidth ()
+
+  previewLines state
+  |> Stdlib.List.map (fun l -> Stdlib.List.length (wrapRow maxFit l))
+  |> Stdlib.List.fold 0 (fun acc n -> acc + n)
 
 let renderPreview (state: State) (region: Stdlib.Cli.UI.Layout.Region) : List<Stdlib.Cli.UI.Layout.Span> =
   let plain = previewLines state
   // Syntax-highlight Matter's source preview. Nothing else here is code: Docs, the History summary and the
-  // Conflicts detail are prose, and Changes shows a pre-coloured +/- diff.
+  // Conflicts detail are prose, and Changes shows a pre-colored +/- diff.
   //
-  // Anything already carrying ANSI is left alone - a pre-coloured diff or a tree-native render peek is not
-  // plain source, and re-highlighting it would mangle the colours it already has. In practice that means
+  // Anything already carrying ANSI is left alone - a pre-colored diff or a tree-native render peek is not
+  // plain source, and re-highlighting it would mangle the colors it already has. In practice that means
   // highlighting only fires under the values lens, because Matter's ordinary preview comes from
-  // `inspectPageLines`, which pre-colours.
+  // `inspectPageLines`, which pre-colors.
   let alreadyColored = Stdlib.String.contains (Stdlib.String.join plain "\n") ""
   let doHighlight = (state.activeView == vMatter) && (Stdlib.Bool.not alreadyColored)
   let highlighted =
@@ -129,7 +206,7 @@ let renderHome (state: State) (region: Stdlib.Cli.UI.Layout.Region) : List<Stdli
         owners ]
 
   // Every tab: its number key, its name, what it's for, and whether it's real. `Layout.at` measures in
-  // terminal columns and ignores SGR, so the colour doesn't count toward the width and get clipped.
+  // terminal columns and ignores SGR, so the color doesn't count toward the width and get clipped.
   //
   // The number key is the row's position in the *full* visible list (Home is 1), which is what the digit keys
   // index; past nine there's no digit, and the row says so by leaving the column blank.
@@ -137,7 +214,7 @@ let renderHome (state: State) (region: Stdlib.Cli.UI.Layout.Region) : List<Stdli
     // Local rather than `String.padEnd`, which returns a Result (it can reject a multi-char pad) and would
     // need unwrapping at both call sites for a column of spaces.
     let pad (s: String) (n: Int) : String =
-      s ++ (Stdlib.String.repeat " " (Stdlib.Int.max 0 (n - (Stdlib.String.length s))))
+      s ++ (Stdlib.String.repeat " " (Stdlib.Int.max 0 (n - (Stdlib.String.displayWidth s))))
     visibleViews state
     |> Stdlib.List.indexedMap (fun i v -> (i, v))
     |> Stdlib.List.filter (fun pair -> let (_i, v) = pair in v != vHome)

--- a/packages/darklang/cli/workbench/types.dark
+++ b/packages/darklang/cli/workbench/types.dark
@@ -3,6 +3,17 @@
 /// Part of `Darklang.Cli.Workbench`, split across files (see app.dark for the overview).
 module Darklang.Cli.Workbench
 
+
+/// The most of the Matter body the tree pane may take, as a percent.
+///
+/// A ceiling rather than the split itself: `matterSplitFor` narrows it to what the names actually need.
+/// A flat 45 gave eight short names 117 columns on a wide terminal while the pane that was clipping got
+/// the smaller half.
+val matterSplitMaxPct = 45
+
+/// The least of it, so the tree doesn't collapse to nothing in a narrow window.
+val matterSplitMinPct = 18
+
 type BodyItem =
   { name: String
     kind: String

--- a/packages/darklang/internal/darklang-internal-mcp-server/tools.dark
+++ b/packages/darklang/internal/darklang-internal-mcp-server/tools.dark
@@ -8,7 +8,7 @@ let executeDarklang () : ModelContextProtocol.ServerBuilder.Tool =
     description = "Execute Darklang code and return the result"
     handler =
       fun code ->
-        match Cli.Eval.evaluateRaw (Stdlib.Option.Option.None) SCM.Branch.mainBranchId code false with
+        match Cli.Eval.evaluateRaw (Stdlib.Option.Option.None) SCM.Branch.mainBranchId code [] false with
         | Ok (Some result) -> $"Result: {result}"
         | Ok None -> "Result: ()"
         | Error err ->

--- a/packages/darklang/languageTools/lsp-server/fileSystemProvider.dark
+++ b/packages/darklang/languageTools/lsp-server/fileSystemProvider.dark
@@ -55,8 +55,9 @@ module ReadFile =
         let ctx =
           PrettyPrinter.ProgramTypes.Context
             { branchId = branchId
-              currentModule = Stdlib.Option.Option.None
-              currentFunction = Stdlib.Option.Option.None }
+              currentModule = []
+              currentFunction = Stdlib.Option.Option.None
+              width = 80 }
 
         // Try to find as a specific entity (type, function, or value)
         let entityContent =
@@ -98,8 +99,9 @@ module ReadFile =
           let ctx =
             PrettyPrinter.ProgramTypes.Context
               { branchId = state.currentBranchId
-                currentModule = Stdlib.Option.Option.None
-                currentFunction = Stdlib.Option.Option.None }
+                currentModule = []
+                currentFunction = Stdlib.Option.Option.None
+                width = 80 }
 
           let results =
             LanguageTools.PackageManager.Search.search state.currentBranchId searchQuery
@@ -486,8 +488,9 @@ module WriteFile =
               let ctx =
                 PrettyPrinter.ProgramTypes.Context
                   { branchId = state.currentBranchId
-                    currentModule = Stdlib.Option.Option.None
-                    currentFunction = Stdlib.Option.Option.None }
+                    currentModule = []
+                    currentFunction = Stdlib.Option.Option.None
+                    width = 80 }
 
               let results =
                 LanguageTools.PackageManager.Search.search state.currentBranchId searchQuery

--- a/packages/darklang/prettyPrinter/capabilities.dark
+++ b/packages/darklang/prettyPrinter/capabilities.dark
@@ -8,10 +8,11 @@ module Darklang.PrettyPrinter.Capabilities
 
 let methodLabel (m: String) : String = if m == "*" then "any" else m
 
+/// Pad to `goal` terminal columns. Measured in columns, not graphemes: `padEnd` counts characters, and
+/// a domain token containing anything double-width would then leave the detail column ragged.
 let pad (s: String) (goal: Int) : String =
-  match Stdlib.String.padEnd s " " goal with
-  | Ok r -> r
-  | Error _ -> s
+  let n = goal - (Stdlib.String.displayWidth s)
+  if n <= 0 then s else s ++ (Stdlib.String.repeat " " n)
 
 /// The domain token of a spec — its first word. "http-client GET" → "http-client".
 let domainOf (spec: String) : String =
@@ -52,8 +53,26 @@ let line (spec: String) : String =
     $"{PrettyPrinter.Capabilities.pad (PrettyPrinter.Capabilities.domainOf spec) 14}{det}"
 
 /// The multi-line view: one aligned line per spec.
+///
+/// The domain column is as wide as the widest domain actually present, rather than a fixed 14. A fixed
+/// column is either too narrow for `http-client` or leaves a corridor of blanks in front of every
+/// `random`, and it can only be right for one set of specs.
 let lines (specs: List<String>) : List<String> =
-  Stdlib.List.map specs (fun s -> PrettyPrinter.Capabilities.line s)
+  let width =
+    specs
+    |> Stdlib.List.map (fun s ->
+      Stdlib.String.displayWidth (PrettyPrinter.Capabilities.domainOf s))
+    |> Stdlib.List.fold 0 (fun acc n -> if n > acc then n else acc)
+
+  specs
+  |> Stdlib.List.map (fun s ->
+    let det = PrettyPrinter.Capabilities.detail s
+
+    if det == "" then
+      PrettyPrinter.Capabilities.domainOf s
+    else
+      let domain = PrettyPrinter.Capabilities.pad (PrettyPrinter.Capabilities.domainOf s) (width + 2)
+      $"{domain}{det}")
 
 /// A one-line summary: the distinct domains, e.g. "http-client, file, random".
 let compact (specs: List<String>) : String =

--- a/packages/darklang/prettyPrinter/cliScript.dark
+++ b/packages/darklang/prettyPrinter/cliScript.dark
@@ -7,8 +7,9 @@ let sourceFile
   let ctx =
     PrettyPrinter.ProgramTypes.Context
       { branchId = branchId
-        currentModule = Stdlib.Option.Option.None
-        currentFunction = Stdlib.Option.Option.None }
+        currentModule = []
+        currentFunction = Stdlib.Option.Option.None
+        width = 80 }
 
   let declsPart =
     (Stdlib.List.fold source.declarations [] (fun acc decl ->

--- a/packages/darklang/prettyPrinter/common.dark
+++ b/packages/darklang/prettyPrinter/common.dark
@@ -101,7 +101,15 @@ let formatFieldName (name: String) : String =
   let isReserved =
     reserved |> Stdlib.List.findFirst (fun k -> k == name) |> Stdlib.Option.isSome
 
-  if hasBareShape && (Stdlib.Bool.not isReserved) then name else $"``{name}``"
+  // An empty name has no valid quoted form either -- `````` is four backticks, not an empty identifier --
+  // so quoting it adds noise without adding validity. Left as-is, like the other names this comment says
+  // aren't source-round-trippable.
+  if name == "" then
+    name
+  else if hasBareShape && (Stdlib.Bool.not isReserved) then
+    name
+  else
+    $"``{name}``"
 
 let processRemainder (remainder: String) : String =
   match $".{remainder}" |> Stdlib.Float.parse with
@@ -109,3 +117,147 @@ let processRemainder (remainder: String) : String =
     floatValue |> Stdlib.Float.toString |> Stdlib.String.dropFirst 2
   | Error _ ->
     remainder
+
+/// Shorten a fully-qualified package name for display from inside `currentModule`.
+///
+/// The rule mirrors how names are actually resolved, which is the only rule that produces output the
+/// parser will accept back. `LibDB.NameLookup.namesToTry` tries the given name with progressively
+/// shorter prefixes of the current module glued on the front: from
+/// `Darklang.LanguageTools.ProgramTypes.PackageFn`, a bare `TypeReference` is tried as
+/// `…PackageFn.TypeReference`, then `…ProgramTypes.TypeReference` (a hit), then `Darklang.TypeReference`,
+/// then bare. So the shortest spelling that still resolves is the target's path with its longest common
+/// prefix with the current module removed, and that is what this returns.
+///
+/// Two rules on top, both of which exist because `namesToTry` has them:
+///  - `Option` and `Result` resolve unqualified from anywhere, so they are never qualified here.
+///  - A path starting `Stdlib` resolves with `Darklang` implied, so the owner comes off.
+///
+/// Caveat: a name is shortened, not verified. If the current module happened to contain something that
+/// captures the short spelling first, the resolver would pick that instead. Checking would mean walking
+/// every candidate against the package store for every name printed, which is far too expensive for a
+/// listing; the parser round-trip suite is what catches it.
+let shortenName
+  (currentModule: List<String>)
+  (owner: String)
+  (modules: List<String>)
+  (name: String)
+  : String =
+  let fullPath = Stdlib.List.push modules owner
+
+  // `Option` / `Result` and nothing else: the resolver gives these an unconditional stdlib fallback.
+  let isAlwaysBare =
+    (fullPath == [ "Darklang"; "Stdlib"; "Option" ] && name == "Option")
+    || (fullPath == [ "Darklang"; "Stdlib"; "Result" ] && name == "Result")
+
+  if isAlwaysBare then
+    name
+  else
+    let shared =
+      Darklang.LanguageTools.PackageManager.countMatchingPrefix currentModule fullPath
+
+    let remaining = Stdlib.List.drop fullPath shared
+
+    // Nothing shared and not ours: an explicit `Stdlib.` prefix still resolves, so drop the owner for
+    // Darklang's own packages and leave anyone else's fully qualified.
+    let remaining =
+      if shared == 0 && owner == "Darklang" then
+        Stdlib.List.drop fullPath 1
+      else if shared == 0 && owner == "Tests" then
+        Stdlib.List.drop fullPath 1
+      else
+        remaining
+
+    match remaining with
+    | [] -> name
+    | segments -> (Stdlib.String.join segments ".") ++ "." ++ name
+
+
+/// How to paint the pieces of a rendered value.
+///
+/// The printer knows what KIND each piece is; the caller decides how it looks. That keeps terminal
+/// escapes out of `PrettyPrinter`, which has no business knowing about `Cli.Colors`, and means the same
+/// value can be painted for a terminal, left plain for a pipe, or styled some other way entirely
+/// without the printer changing.
+type Palette =
+  { string_: String
+    number: String
+    typeName: String
+    caseName: String
+    keyword: String
+    /// Emitted after every painted piece, so it has to end whatever the others start.
+    reset: String }
+
+module Palette =
+  /// No decoration at all. The default, because a printer's output is text until someone says otherwise.
+  val plain =
+    Palette
+      { string_ = ""
+        number = ""
+        typeName = ""
+        caseName = ""
+        keyword = ""
+        reset = "" }
+
+
+/// How to render something, threaded through the printers rather than read from anywhere.
+///
+/// No printer looks up the terminal, a config file, or a global. Everything that varies with where the
+/// output is going lives here and comes from the caller, so the same value can be printed for a 60-column
+/// pane, a piped stdout and a test with the only difference being the record passed in. That is also what
+/// makes the printers safely nestable: an inner call cannot disagree with its caller about the rules.
+type DisplayOptions =
+  {
+    /// Columns available for the whole line, counted from column 0. A printer that starts partway
+    /// along a line accounts for that itself; this is the page width, not the room remaining.
+    width: Int
+
+    /// The module the reader is standing in, owner-first. Names are spelled relative to it.
+    currentModule: List<String>
+
+    /// Print type arguments on enum and record values (`Option<Int>.Some(1)`). Off is usually right for
+    /// a person reading a value, since the payload shows the type; on is useful when the type is the
+    /// question being asked.
+    showTypeArgs: Bool
+
+    /// How to paint each kind of piece. `Palette.plain` for none.
+    palette: Palette
+
+    /// Stop descending past this depth and print a marker instead. `None` means print it all. Traces and
+    /// error messages want a shallow cap; `eval` generally doesn't.
+    maxDepth: Stdlib.Option.Option<Int>
+  }
+
+module DisplayOptions =
+  /// The defaults every existing caller gets. 80 columns because that is what the printers assumed
+  /// before this record existed, not because it is a good width; callers that know better should say so.
+  val default =
+    DisplayOptions
+      { width = 80
+        currentModule = []
+        showTypeArgs = true
+        // Written out rather than `Palette.plain`, which is the same value one line up. A package
+        // `val` whose body references another `val` evaluates that reference to Unit under the test
+        // harness -- the field is present and correctly typed, and reading it still yields Unit. Every
+        // other field here is a literal, which is why this was the only one affected.
+        palette =
+          Palette
+            { string_ = ""
+              number = ""
+              typeName = ""
+              caseName = ""
+              keyword = ""
+              reset = "" }
+        maxDepth = Stdlib.Option.Option.None }
+
+  /// The defaults, printed from inside `path`.
+  let inModule (path: List<String>) : DisplayOptions =
+    { DisplayOptions.default with currentModule = path }
+
+  /// The defaults, painted with `p`.
+  let painted (p: Palette) : DisplayOptions =
+    { DisplayOptions.default with palette = p }
+
+  /// The defaults at a given width.
+  let atWidth (width: Int) : DisplayOptions =
+    { DisplayOptions.default with width = width }
+

--- a/packages/darklang/prettyPrinter/instructions.dark
+++ b/packages/darklang/prettyPrinter/instructions.dark
@@ -5,7 +5,7 @@
 /// listing is the only place the answer is legible.
 ///
 /// `opcode` and `operands` are separate functions rather than one rendered line, so a caller can align
-/// the columns and colour them independently. `listing` is the plain-text version for anyone who just
+/// the columns and color them independently. `listing` is the plain-text version for anyone who just
 /// wants the text.
 module Darklang.PrettyPrinter.RuntimeTypes.Instructions
 
@@ -124,7 +124,7 @@ let inlineDval (branchId: Uuid) (dv: LanguageTools.RuntimeTypes.Dval) : String =
   | other -> PrettyPrinter.RuntimeTypes.dval branchId other
 
 
-/// The opcode name on its own, so callers can colour or align it.
+/// The opcode name on its own, so callers can color or align it.
 let opcode (i: LanguageTools.RuntimeTypes.Instruction) : String =
   match i with
   | LoadVal(_, _) -> "LoadVal"
@@ -223,12 +223,15 @@ let header (instrs: LanguageTools.RuntimeTypes.Instructions) : String =
 
 /// `Stdlib.String.padStart`/`padEnd` return a `Result` (they can reject a multi-character pad), which
 /// is noise for a fixed single-space pad. These just widen.
+// Padding is positional, so it measures columns rather than graphemes. `Stdlib.String.length` counts
+// grapheme clusters, which is the wrong question here: one CJK character is a single grapheme two
+// columns wide, so a column padded by grapheme count comes out ragged.
 let padTo (width: Int) (s: String) : String =
-  let n = width - (Stdlib.String.length s)
+  let n = width - (Stdlib.String.displayWidth s)
   if n <= 0 then s else s ++ (Stdlib.String.repeat " " n)
 
 let padFrom (width: Int) (s: String) : String =
-  let n = width - (Stdlib.String.length s)
+  let n = width - (Stdlib.String.displayWidth s)
   if n <= 0 then s else (Stdlib.String.repeat " " n) ++ s
 
 

--- a/packages/darklang/prettyPrinter/moduleDeclaration.dark
+++ b/packages/darklang/prettyPrinter/moduleDeclaration.dark
@@ -74,7 +74,10 @@ module ModuleDeclaration =
     : List<Module> =
     match Darklang.LanguageTools.PackageManager.pickLocation Darklang.LanguageTools.PackageManager.PickContext.empty (LanguageTools.PackageManager.Type.locations branchId t.hash) with
     | Some location ->
-      let fullPath = Stdlib.List.push location.modules location.owner
+      // The owner is NOT a module. The parser takes it as a separate input, so printing it as one
+      // means the output re-parses a level deeper than it started: `module Tests = ...` fed back in
+      // with owner "Tests" becomes `Tests.Tests.*`, and again on every pass after that.
+      let fullPath = location.modules
       withTypeHelper ms t fullPath
     | None ->
       [ Module
@@ -151,7 +154,10 @@ module ModuleDeclaration =
     : List<Module> =
     match Darklang.LanguageTools.PackageManager.pickLocation Darklang.LanguageTools.PackageManager.PickContext.empty (LanguageTools.PackageManager.Function.locations branchId f.hash) with
     | Some location ->
-      let fullPath = Stdlib.List.push location.modules location.owner
+      // The owner is NOT a module. The parser takes it as a separate input, so printing it as one
+      // means the output re-parses a level deeper than it started: `module Tests = ...` fed back in
+      // with owner "Tests" becomes `Tests.Tests.*`, and again on every pass after that.
+      let fullPath = location.modules
       withFnHelper ms f fullPath
     | None ->
       [ Module
@@ -227,7 +233,10 @@ module ModuleDeclaration =
     : List<Module> =
     match Darklang.LanguageTools.PackageManager.pickLocation Darklang.LanguageTools.PackageManager.PickContext.empty (LanguageTools.PackageManager.Value.locations branchId v.hash) with
     | Some location ->
-      let fullPath = Stdlib.List.push location.modules location.owner
+      // The owner is NOT a module. The parser takes it as a separate input, so printing it as one
+      // means the output re-parses a level deeper than it started: `module Tests = ...` fed back in
+      // with owner "Tests" becomes `Tests.Tests.*`, and again on every pass after that.
+      let fullPath = location.modules
       withValueHelper ms v fullPath
     | None ->
       [ Module
@@ -322,7 +331,15 @@ module ModuleDeclaration =
       Stdlib.List.fold
         p.exprs
         modulesWithTypesAndFnsAndValues
-        (fun modules e -> withExpr modules e)
+        (fun modules e ->
+          // Same rule as the declarations above: the owner is not a module. An expr's path arrives
+          // from the parser owner-first, so drop that segment before nesting it.
+          let (expr, path) = e
+          let path =
+            match path with
+            | [] -> []
+            | _ :: rest -> rest
+          withExpr modules ((expr, path)))
 
 
     modulesWithTypesAndFnsAndValuesAndExprs

--- a/packages/darklang/prettyPrinter/programTypes.dark
+++ b/packages/darklang/prettyPrinter/programTypes.dark
@@ -43,26 +43,42 @@ module NameResolutionError =
 // we can shorten names that share the same prefix
 type Context =
   { branchId: Uuid
-    currentModule: Stdlib.Option.Option<String>
+    /// The module we're printing from, owner-first (`["Darklang"; "Stdlib"; "Option"]`), or empty for
+    /// "no context". A path rather than a dotted string, because shortening compares segments and
+    /// `PickContext` wants a path too; the two used to disagree and be converted by splitting on ".".
+    currentModule: List<String>
     /// Used to resolve ESelf and EArg expressions when pretty-printing function bodies.
     /// When Some, contains (functionName, argMap) where argMap maps parameter names to indices.
-    currentFunction: Stdlib.Option.Option<(String * Dict<Int>)> }
+    currentFunction: Stdlib.Option.Option<(String * Dict<Int>)>
+
+    /// Columns available. Layout decisions are made against this; it is a field rather than something
+    /// looked up so that printing stays reproducible and a caller can print for a pane.
+    width: Int }
 
 module Context =
   let forBranch (branchId: Uuid) : Context =
     Context
       { branchId = branchId
-        currentModule = Stdlib.Option.Option.None
-        currentFunction = Stdlib.Option.Option.None }
+        currentModule = []
+        currentFunction = Stdlib.Option.Option.None
+        width = 80 }
 
   val forMain = forBranch SCM.Branch.mainBranchId
 
+  /// A context anchored at `path` (owner-first, e.g. `["Darklang"; "Stdlib"; "Option"]`).
+  ///
+  /// References inside a printed definition are then spelled the way someone standing in that module
+  /// would say them. Anything that knows which module it is showing should use this rather than
+  /// `forBranch`, whose `currentModule` is None and so forces every name to its full path.
+  let forModule (branchId: Uuid) (path: List<String>) : Context =
+    Context
+      { branchId = branchId
+        currentModule = path
+        currentFunction = Stdlib.Option.Option.None
+        width = 80 }
+
   let toPickContext (ctx: Context) : LanguageTools.PackageManager.PickContext =
-    LanguageTools.PackageManager.PickContext
-      { currentModule =
-          match ctx.currentModule with
-          | Some m -> Stdlib.String.split m "."
-          | None -> [] }
+    LanguageTools.PackageManager.PickContext { currentModule = ctx.currentModule }
 
 let packageNameWithContext
   (ctx: Context)
@@ -70,36 +86,8 @@ let packageNameWithContext
   (modules: List<String>)
   (name: String)
   : String =
-  let modulesPart =
-    match modules with
-    | [] -> ""
-    | modules ->
-      let modules = Stdlib.String.join modules "."
-      $"{modules}."
+  PrettyPrinter.shortenName ctx.currentModule owner modules name
 
-  let fullName = $"{owner}.{modulesPart}{name}"
-
-  // Try to shorten relative to current context
-  match ctx.currentModule with
-  | Some currentModule ->
-    // If we're in Darklang.Stdlib and referencing Darklang.Stdlib.Option.Option,
-    // just show "Option.Option"
-    if Stdlib.String.startsWith fullName currentModule then
-      let prefix = currentModule ++ "."
-      Stdlib.String.dropFirst fullName (Stdlib.String.length prefix)
-    else if owner == "Darklang" then
-      // For Darklang packages, drop the "Darklang." prefix for brevity
-      let withoutDarklang = Stdlib.String.dropFirst fullName 9 // "Darklang.".length
-      withoutDarklang
-    else
-      fullName
-  | None ->
-    match owner with
-    | "Tests" -> $"{modulesPart}{name}"
-    | "Darklang" ->
-      // For Darklang packages, just show module path
-      $"{modulesPart}{name}"
-    | _ -> $"{owner}.{modulesPart}{name}"
 
 // CLEANUP: this function exists for backwards compatibility
 // Prefer using packageNameWithContext with a proper Context
@@ -130,13 +118,6 @@ module FQTypeName =
         packageNameWithContext ctx l.owner l.modules l.name
       | None -> shortHash hash
 
-
-  let atDefinition
-    (ctx: Context)
-    (t: LanguageTools.ProgramTypes.FQTypeName.FQTypeName)
-    : String =
-    match t with
-    | Package p -> FQTypeName.Package.atDefinition ctx p
 
   let fullForReference
     (ctx: Context)
@@ -183,16 +164,6 @@ module FQValueName =
 
 
 
-  let atDefinition
-    (ctx: Context)
-    (t: LanguageTools.ProgramTypes.FQValueName.FQValueName)
-    : String =
-    match t with
-    | Builtin b ->
-      FQValueName.Builtin.fullForReference b
-    | Package p ->
-      FQValueName.Package.atDefinition ctx p
-
   let fullForReference
     (ctx: Context)
     (t: LanguageTools.ProgramTypes.FQValueName.FQValueName)
@@ -238,15 +209,6 @@ module FQFnName =
         packageNameWithContext ctx l.owner l.modules l.name
       | None -> shortHash hash
 
-
-  let atDefinition
-    (ctx: Context)
-    (t: LanguageTools.ProgramTypes.FQFnName.FQFnName)
-    : String =
-    match t with
-    | Builtin _b ->
-      "why are you trying to print a stdlib type name _definition_?"
-    | Package p -> FQFnName.Package.atDefinition ctx p
 
   let fullForReference
     (ctx: Context)
@@ -546,7 +508,374 @@ let pipeExpr (ctx: Context) (p: LanguageTools.ProgramTypes.PipeExpr) : String =
       $"{typeNamePart}.{caseName}{fieldPart}"
 
 
+/// Text that may already contain newlines, as a Doc.
+///
+/// Splitting on the newlines matters: a `Text` holding one would be measured as though it were a single
+/// long line, so an enclosing group could decide it fits and then emit something several lines tall.
+/// As `hardLine`s, the group is forced to break, which is the truth.
+let docOfText (s: String) : Stdlib.Pretty.Doc =
+  s
+  |> Stdlib.String.split "\n"
+  |> Stdlib.List.map (fun l -> Stdlib.Pretty.text l)
+  |> Stdlib.Pretty.join Stdlib.Pretty.hardLine
+
+
+/// Binding power of an infix operator, and whether it associates right.
+///
+/// Mirrors `infixBindingPower` in `LibParser/Parser.fs`, loosest to tightest:
+///   1 `||`  2 `&&`  3 comparisons  4 `@` (right)  5 `+ - ++`  6 `* / %`  7 `^` (right)
+/// If that table moves, this has to move with it, or the printer starts emitting parens that change
+/// what the parser builds.
+let infixPower (i: LanguageTools.ProgramTypes.Infix) : (Int * Bool) =
+  match i with
+  | BinOp BinOpOr -> (1, false)
+  | BinOp BinOpAnd -> (2, false)
+  | InfixFnCall op ->
+    match op with
+    | ComparisonEquals
+    | ComparisonNotEquals
+    | ComparisonLessThan
+    | ComparisonGreaterThan
+    | ComparisonLessThanOrEqual
+    | ComparisonGreaterThanOrEqual -> (3, false)
+    | ArithmeticPlus
+    | ArithmeticMinus
+    | StringConcat -> (5, false)
+    | ArithmeticMultiply
+    | ArithmeticDivide
+    | ArithmeticModulo -> (6, false)
+    | ArithmeticPower -> (7, true)
+
+
+/// How tightly an expression binds, for deciding whether it needs parentheses inside a larger one.
+///
+/// 0 is for the constructs that swallow whatever follows them -- an `if`, a `match`, a lambda -- which
+/// always need wrapping when they appear inside something else. 100 is everything self-delimiting: a
+/// literal, a variable, a record, an application. Application binds tighter than any operator, so
+/// `factorial n * 2L` needs no parens around the call, which is the main thing the old printer got
+/// wrong by bracketing every operand unconditionally.
+let exprPower (e: LanguageTools.ProgramTypes.Expr) : Int =
+  match e with
+  | EInfix(_, op, _, _) ->
+    let (p, _) = infixPower op
+    p
+  | EIf(_, _, _, _) -> 0
+  | EMatch(_, _, _) -> 0
+  | ELet(_, _, _, _) -> 0
+  | ELambda(_, _, _) -> 0
+  | EPipe(_, _, _) -> 0
+  | EStatement(_, _, _) -> 0
+  | _ -> 100
+
+
+/// Whether an operand of an infix expression has to be parenthesised.
+///
+/// Looser than its parent always does. At equal power it depends on the side: `a - b - c` groups left,
+/// so a right operand of the same power needs parens to mean anything else; `2 ^ 3 ^ 2` groups right,
+/// so the left one does.
+let infixOperandNeedsParens
+  (operand: LanguageTools.ProgramTypes.Expr)
+  (parentPower: Int)
+  (parentIsRightAssoc: Bool)
+  (isRightOperand: Bool)
+  : Bool =
+  let p = exprPower operand
+
+  if p < parentPower then
+    true
+  else if p == parentPower then
+    if parentIsRightAssoc then Stdlib.Bool.not isRightOperand else isRightOperand
+  else
+    false
+
+
+/// Whether an argument in an application has to be parenthesised.
+///
+/// Application is left-associative and binds tightest, so anything that isn't self-delimiting has to be
+/// wrapped or it would be read as further arguments: `f (g x)`, `f (a + b)`, `f (fun x -> x)`.
+let applyArgNeedsParens (arg: LanguageTools.ProgramTypes.Expr) : Bool =
+  match arg with
+  | EApply(_, _, _, _) -> true
+  // A lambda prints its own parentheses, so wrapping it again just gives `((fun x -> ...))`.
+  | ELambda(_, _, _) -> false
+  | _ -> (exprPower arg) < 100
+
+
+/// `opening parts... closing`, on one line if it fits and one part per line if it doesn't.
+///
+/// `opener` decides whether the delimiters hug: `softLine` for brackets (`[1; 2]`), `line` for braces
+/// (`{ a = 1 }`). `sep` stays in the output either way, so the broken form still parses.
+let wrapExprs
+  (opening: String)
+  (closing: String)
+  (sep: String)
+  (opener: Stdlib.Pretty.Doc)
+  (parts: List<Stdlib.Pretty.Doc>)
+  : Stdlib.Pretty.Doc =
+  match parts with
+  | [] -> Stdlib.Pretty.text (opening ++ closing)
+  | parts ->
+    let separated =
+      Stdlib.Pretty.join
+        parts
+        (Stdlib.Pretty.concat (Stdlib.Pretty.text sep) Stdlib.Pretty.line)
+
+    Stdlib.Pretty.group (
+      Stdlib.Pretty.concat
+        (Stdlib.Pretty.text opening)
+        (Stdlib.Pretty.concat
+          (Stdlib.Pretty.nest 2 (Stdlib.Pretty.concat opener separated))
+          (Stdlib.Pretty.concat opener (Stdlib.Pretty.text closing))))
+
+
+/// An expression as a Doc: the layouts it could take, for the caller to choose between.
+///
+/// Ported construct by construct. Anything not yet ported falls back to `exprString`, whose output is
+/// spliced in via `docOfText` so it still forces enclosing groups to break correctly -- an unported
+/// child can't make its parent claim to fit.
+let exprDoc (ctx: Context) (e: LanguageTools.ProgramTypes.Expr) : Stdlib.Pretty.Doc =
+  let txt (s: String) : Stdlib.Pretty.Doc = Stdlib.Pretty.text s
+
+  match e with
+  // `let x = 1` on one line when it fits; the old printer always broke after the `=`, which turned
+  // every binding into two lines and a chain of four into eight.
+  | ELet(_id, pattern, rhs, body) ->
+    let binding =
+      Stdlib.Pretty.group (
+        Stdlib.Pretty.concat
+          (txt $"let {letPattern pattern} =")
+          (Stdlib.Pretty.nest 2 (
+            Stdlib.Pretty.concat Stdlib.Pretty.line (exprDoc ctx rhs))))
+
+    Stdlib.Pretty.concat
+      binding
+      (Stdlib.Pretty.concat Stdlib.Pretty.hardLine (exprDoc ctx body))
+
+  // `| Some v -> Some(fn v)` on the arm's own line when it fits.
+  | EMatch(_id, arg, cases) ->
+    let arms =
+      cases
+      |> Stdlib.List.map (fun case ->
+        let whenPart =
+          match case.whenCondition with
+          | Some cond -> $" when {expr ctx cond}"
+          | None -> ""
+
+        Stdlib.Pretty.group (
+          Stdlib.Pretty.concat
+            (txt $"| {matchPattern case.pat}{whenPart} ->")
+            (Stdlib.Pretty.nest 2 (
+              Stdlib.Pretty.concat Stdlib.Pretty.line (exprDoc ctx case.rhs)))))
+      |> Stdlib.Pretty.join Stdlib.Pretty.hardLine
+
+    Stdlib.Pretty.concat
+      (txt $"match {expr ctx arg} with")
+      (Stdlib.Pretty.concat Stdlib.Pretty.hardLine arms)
+
+  // `if c then a else b` on one line when it fits. An `else if` chain keeps the `else if` together
+  // rather than indenting a whole nested if under it.
+  | EIf(_id, cond, thenBranch, elseBranch) ->
+    let head =
+      Stdlib.Pretty.concat
+        (txt $"if {expr ctx cond} then")
+        (Stdlib.Pretty.nest 2 (
+          Stdlib.Pretty.concat Stdlib.Pretty.line (exprDoc ctx thenBranch)))
+
+    match elseBranch with
+    | None -> Stdlib.Pretty.group head
+    | Some eb ->
+      match eb with
+      | EIf(_, _, _, _) ->
+        Stdlib.Pretty.group (
+          Stdlib.Pretty.concat
+            head
+            (Stdlib.Pretty.concat
+              Stdlib.Pretty.line
+              (Stdlib.Pretty.concat (txt "else ") (exprDoc ctx eb))))
+      | _ ->
+        Stdlib.Pretty.group (
+          Stdlib.Pretty.concat
+            head
+            (Stdlib.Pretty.concat
+              Stdlib.Pretty.line
+              (Stdlib.Pretty.concat
+                (txt "else")
+                (Stdlib.Pretty.nest 2 (
+                  Stdlib.Pretty.concat Stdlib.Pretty.line (exprDoc ctx eb))))))
+
+  // `xs |> List.length` on one line when it fits; longer chains keep one stage per line.
+  | EPipe(_id, e, pipeExprs) ->
+    let stages =
+      pipeExprs
+      |> Stdlib.List.map (fun pe -> txt $"|> {pipeExpr ctx pe}")
+      |> Stdlib.Pretty.join Stdlib.Pretty.line
+
+    Stdlib.Pretty.group (
+      Stdlib.Pretty.concat
+        (exprDoc ctx e)
+        (Stdlib.Pretty.concat Stdlib.Pretty.line stages))
+
+  // Parenthesise only where precedence or associativity requires it. The old printer wrapped both
+  // operands unconditionally, which turned `n * (factorial n - 1L)` into `(n) * ((factorial n) - (1L))`
+  // and meant printing its own output kept adding brackets.
+  | EInfix(_id, infixOp, left, right) ->
+    let (power, rightAssoc) = infixPower infixOp
+
+    let side (e: LanguageTools.ProgramTypes.Expr) (isRight: Bool) : Stdlib.Pretty.Doc =
+      let inner = exprDoc ctx e
+
+      if infixOperandNeedsParens e power rightAssoc isRight then
+        Stdlib.Pretty.concat (txt "(") (Stdlib.Pretty.concat inner (txt ")"))
+      else
+        inner
+
+    Stdlib.Pretty.group (
+      Stdlib.Pretty.concat
+        (side left false)
+        (Stdlib.Pretty.concat
+          (txt $" {infix infixOp} ")
+          (side right true)))
+
+  | EApply(_id, fnName, typeArgs, args) ->
+    let typeArgsPart =
+      match typeArgs with
+      | [] -> ""
+      | _ ->
+        typeArgs
+        |> Stdlib.List.map (fun typeArg -> typeReference ctx typeArg)
+        |> Stdlib.String.join ", "
+        |> fun parts -> $"<{parts}>"
+
+    let argDocs =
+      args
+      |> Stdlib.List.map (fun arg ->
+        let inner = exprDoc ctx arg
+
+        if applyArgNeedsParens arg then
+          Stdlib.Pretty.concat (txt "(") (Stdlib.Pretty.concat inner (txt ")"))
+        else
+          inner)
+
+    match argDocs with
+    | [] -> Stdlib.Pretty.concat (exprDoc ctx fnName) (txt typeArgsPart)
+    | argDocs ->
+      // Args are separated by `line`, not a literal space, so the choice is made for the call as a whole:
+      // one line when it fits, otherwise one arg per line under a 2-space indent. Joining with a hard
+      // space meant the outer group could never break, so each arg decided alone and the result was
+      // ragged -- `f (fun x ->` , continuation, then the next arg starting mid-line.
+      Stdlib.Pretty.group (
+        Stdlib.Pretty.concat
+          (Stdlib.Pretty.concat (exprDoc ctx fnName) (txt typeArgsPart))
+          (Stdlib.Pretty.nest 2 (
+            Stdlib.Pretty.concat
+              Stdlib.Pretty.line
+              (Stdlib.Pretty.join argDocs Stdlib.Pretty.line))))
+
+  // Collections: one line when they fit, one element per line when they don't. They never broke before,
+  // at any length, so a forty-element list was a single four-hundred-column line.
+  //
+  // Brackets hug their contents (`softLine`, so `[1; 2]` gains no inner spaces) while braces keep theirs
+  // (`line`, so a record reads `T { a = 1 }`). Separators stay explicit either way, which is what makes
+  // the broken form parse back.
+  | EList(_id, items) ->
+    let parts = items |> Stdlib.List.map (fun i -> exprDoc ctx i)
+    wrapExprs "[" "]" ";" Stdlib.Pretty.softLine parts
+
+  | ETuple(_id, first, second, theRest) ->
+    let parts =
+      (Stdlib.List.append [ first; second ] theRest)
+      |> Stdlib.List.map (fun i -> exprDoc ctx i)
+    wrapExprs "(" ")" "," Stdlib.Pretty.softLine parts
+
+  | ERecord(_id, typeName, typeArgs, fields) ->
+    let typeArgsPart =
+      match typeArgs with
+      | [] -> ""
+      | _ ->
+        typeArgs
+        |> Stdlib.List.map (fun typeArg -> typeReference ctx typeArg)
+        |> Stdlib.String.join ", "
+        |> fun parts -> $"<{parts}>"
+
+    let parts =
+      fields
+      |> Stdlib.List.map (fun pair ->
+        let (name, value) = pair
+        Stdlib.Pretty.concat
+          (txt $"{PrettyPrinter.formatFieldName name} = ")
+          (exprDoc ctx value))
+
+    Stdlib.Pretty.concat
+      (txt $"{NameResolution.typeName ctx typeName}{typeArgsPart} ")
+      (wrapExprs "{" "}" ";" Stdlib.Pretty.line parts)
+
+  // Dicts and enum payloads break like the other collections. A lambda's body is nested and hard-lined,
+  // since `fun x ->` followed by its body on the same line only reads well when the body is tiny, and
+  // the group above it already decides that. `EStatement` is always a hard line: that is what it means.
+  | EDict(_id, pairs) ->
+    let parts =
+      pairs
+      |> Stdlib.List.map (fun pair ->
+        let (key, value) = pair
+        Stdlib.Pretty.concat
+          (txt $"{PrettyPrinter.formatFieldName key} = ")
+          (exprDoc ctx value))
+
+    Stdlib.Pretty.concat (txt "Dict ") (wrapExprs "{" "}" ";" Stdlib.Pretty.line parts)
+
+  | EEnum(_id, typeName, typeArgs, caseName, fields) ->
+    let typeNamePart = NameResolution.typeName ctx typeName
+
+    let typeArgsPart =
+      match typeArgs with
+      | [] -> ""
+      | _ ->
+        typeArgs
+        |> Stdlib.List.map (fun typeArg -> typeReference ctx typeArg)
+        |> Stdlib.String.join ", "
+        |> fun parts -> $"<{parts}>"
+
+    // A bare, unqualified case (no type name) prints as just the case name; the `.` only separates a
+    // present type name from its case.
+    let sep = if typeNamePart == "" then "" else "."
+    let head = txt $"{typeNamePart}{typeArgsPart}{sep}{caseName}"
+
+    match fields with
+    | [] -> head
+    | fields ->
+      let parts = fields |> Stdlib.List.map (fun f -> exprDoc ctx f)
+      Stdlib.Pretty.concat head (wrapExprs "(" ")" "," Stdlib.Pretty.softLine parts)
+
+  | ELambda(_id, pats, body) ->
+    let patsPart =
+      pats
+      |> Stdlib.List.map (fun pat -> letPattern pat)
+      |> Stdlib.String.join " "
+
+    // Grouped, so a short lambda stays on one line. It used to break unconditionally, which cost two
+    // lines for `(fun x -> x + 1L)` and pushed the body of every `List.map` down a line for nothing.
+    Stdlib.Pretty.group (
+      Stdlib.Pretty.concat
+        (txt $"(fun {patsPart} ->")
+        (Stdlib.Pretty.concat
+          (Stdlib.Pretty.nest 2 (
+            Stdlib.Pretty.concat Stdlib.Pretty.line (exprDoc ctx body)))
+          (txt ")")))
+
+  | EStatement(_id, first, next) ->
+    Stdlib.Pretty.concat
+      (exprDoc ctx first)
+      (Stdlib.Pretty.concat Stdlib.Pretty.hardLine (exprDoc ctx next))
+
+  | e -> docOfText (exprString ctx e)
+
+
 let expr (ctx: Context) (e: LanguageTools.ProgramTypes.Expr) : String =
+  Stdlib.Pretty.render ctx.width (exprDoc ctx e)
+
+
+/// The original string-building printer, still handling every construct the Doc layer hasn't taken over.
+let exprString (ctx: Context) (e: LanguageTools.ProgramTypes.Expr) : String =
   match e with
   | EUnit _id -> "()"
 
@@ -584,12 +913,6 @@ let expr (ctx: Context) (e: LanguageTools.ProgramTypes.Expr) : String =
 
 
   // structures of data
-  | EList(_id, items) ->
-    items
-    |> Stdlib.List.map (fun item -> expr ctx item)
-    |> Stdlib.String.join "; "
-    |> fun parts -> "[" ++ parts ++ "]"
-
   | EDict(_id, pairs) ->
     let pairPart =
       pairs
@@ -601,35 +924,6 @@ let expr (ctx: Context) (e: LanguageTools.ProgramTypes.Expr) : String =
 
     $"Dict {pairPart}"
 
-
-  | ETuple(_id, first, second, theRest) ->
-    (Stdlib.List.append [ first; second ] theRest)
-    |> Stdlib.List.map (fun item -> expr ctx item)
-    |> Stdlib.String.join ", "
-    |> fun parts -> "(" ++ parts ++ ")"
-
-  | ERecord(_id, typeName, typeArgs, fields) ->
-    let typeNamePart = NameResolution.typeName ctx typeName
-
-    let typeArgsPart =
-      match typeArgs with
-      | [] -> ""
-      | _ ->
-        typeArgs
-        |> Stdlib.List.map (fun typeArg ->
-          typeReference ctx typeArg)
-        |> Stdlib.String.join ", "
-        |> fun parts -> $"<{parts}>"
-
-    let fieldPart =
-      fields
-      |> Stdlib.List.map (fun pair ->
-        let (name, value) = pair
-        $"{PrettyPrinter.formatFieldName name} = {expr ctx value}")
-      |> Stdlib.String.join "; "
-      |> fun parts -> "{ " ++ parts ++ " }"
-
-    $"{typeNamePart}{typeArgsPart} {fieldPart}"
 
   | EEnum(_id, typeName, typeArgs, caseName, fields) ->
     let typeNamePart = NameResolution.typeName ctx typeName
@@ -660,12 +954,6 @@ let expr (ctx: Context) (e: LanguageTools.ProgramTypes.Expr) : String =
 
 
   // declaring and accessing variables
-  | ELet(_id, pattern, rhs, body) ->
-    let patternPart = letPattern pattern
-    let rhsPart = expr ctx rhs
-    let bodyPart = expr ctx body
-    $"let {patternPart} =\n{PrettyPrinter.indent rhsPart}\n{bodyPart}"
-
   | ERecordFieldAccess(_id, e, fieldName) ->
     let exprPart = expr ctx e
 
@@ -690,74 +978,6 @@ let expr (ctx: Context) (e: LanguageTools.ProgramTypes.Expr) : String =
     | None -> $"earg{Stdlib.Int.toString index}"
 
   // control flow
-  | EIf(_id, cond, thenBranch, elseBranch) ->
-    let condPart = expr ctx cond
-
-    let thenPart =
-      (expr ctx thenBranch) |> PrettyPrinter.indent
-
-    match elseBranch with
-    | None -> $"if {condPart} then\n{thenPart}"
-    | Some elseBranch ->
-      match elseBranch with
-      | EIf(_, _, _, _) ->
-        let elsePart = (expr ctx elseBranch)
-        $"if {condPart} then\n{thenPart}\nelse {elsePart}"
-
-      | _ ->
-        let elsePart = (expr ctx elseBranch) |> PrettyPrinter.indent
-        $"if {condPart} then\n{thenPart}\nelse\n{elsePart}"
-
-  | EMatch(_id, arg, cases) ->
-    let cases =
-      cases
-      |> Stdlib.List.map (fun case ->
-        let patternPart = matchPattern case.pat
-
-        let whenPart =
-          match case.whenCondition with
-          | Some cond ->
-            let whenCondition = expr ctx cond
-            $" when {whenCondition}"
-          | None -> ""
-
-        let rhsPart =
-          (expr ctx case.rhs) |> PrettyPrinter.indent
-
-        $"| {patternPart}{whenPart} ->\n{rhsPart}")
-
-    let casesPart = Stdlib.String.join cases "\n"
-
-    let argPart = expr ctx arg
-
-    $"match {argPart} with\n{casesPart}"
-
-
-  | EPipe(_id, e, pipeExprs) ->
-    // LanguageTools.ID *
-    // LanguageTools.ProgramTypes.Expr *
-    // List<LanguageTools.ProgramTypes.PipeExpr>
-    let exprPart = expr ctx e
-
-    let pipeParts =
-      pipeExprs
-      |> Stdlib.List.map (fun pe ->
-        pipeExpr ctx pe)
-      |> Stdlib.String.join "\n|> "
-
-    $"{exprPart}\n|> {pipeParts}"
-
-
-
-  // function calls
-
-  | EInfix(_id, infixOp, left, right) ->
-    let infixPart = infix infixOp
-    let leftPart = expr ctx left
-    let rightPart = expr ctx right
-    // TODO: might need to wrap in parens
-    $"({leftPart}) {infixPart} ({rightPart})"
-
   | ELambda(_id, pats, body) ->
     let patsPart =
       pats
@@ -767,28 +987,6 @@ let expr (ctx: Context) (e: LanguageTools.ProgramTypes.Expr) : String =
     let bodyPart = expr ctx body
 
     $"(fun {patsPart} ->\n{PrettyPrinter.indent bodyPart})"
-
-  | EApply(_id, fnName, typeArgs, args) ->
-    let fnNamePart = expr ctx fnName
-
-    let argsPart =
-      args
-      |> Stdlib.List.map (fun arg ->
-        match arg with
-        | EApply(_, _, _, _) -> $"({expr ctx arg})"
-        | _ -> expr ctx arg)
-      |> Stdlib.String.join " "
-
-    match typeArgs with
-    | [] -> $"{fnNamePart} {argsPart}"
-    | _ ->
-      let typeArgsPart =
-        typeArgs
-        |> Stdlib.List.map (fun typeArg ->
-          typeReference ctx typeArg)
-        |> Stdlib.String.join ", "
-
-      $"{fnNamePart}<{typeArgsPart}> {argsPart}"
 
   | EFnName(_id, fnName) ->
     NameResolution.fnName ctx fnName
@@ -825,11 +1023,10 @@ let expr (ctx: Context) (e: LanguageTools.ProgramTypes.Expr) : String =
     // CLEANUP: consider making this a runtime error instead
     | None -> "ESelf"
 
-  // CLEANUP: remove this case before shipping to users
-  | expr ->
-    let s = Stdlib.Json.serialize<LanguageTools.ProgramTypes.Expr> expr
-
-    $"{s}"
+  // Everything above is a real case; this arm only fires if `Expr` gains one the printer wasn't taught.
+  // It used to dump the whole expression as JSON into the middle of the source, which buries the
+  // problem in output nobody can read. Say what happened instead, in one line that stands out.
+  | _expr -> "<expression this printer doesn't handle yet>"
 
 // CLEANUP this isn't currently used
 // if/when we uncomment this, take note that the `m` argument is a function
@@ -954,6 +1151,18 @@ let packageValue
 
 
 module PackageLocation =
+  /// A location as seen from `currentModule`.
+  ///
+  /// The plain `packageLocation` below stays fully qualified, and that is right where each line stands
+  /// alone and may be from any owner: `show` and `ops` list ops across the whole store, and a shortened
+  /// name there would be ambiguous. Anywhere the reader has a place -- browsing a module, reading one
+  /// item's references -- the full path is the noise it looks like.
+  let packageLocationIn
+    (currentModule: List<String>)
+    (loc: LanguageTools.ProgramTypes.PackageLocation)
+    : String =
+    PrettyPrinter.shortenName currentModule loc.owner loc.modules loc.name
+
   let packageLocation (loc: LanguageTools.ProgramTypes.PackageLocation) : String =
     let modulesPart =
       match loc.modules with
@@ -1033,9 +1242,14 @@ let packageFn
     |> Stdlib.List.fold Stdlib.Dict.empty (fun acc (name, idx) ->
       Stdlib.Dict.set acc name idx)
 
+  // The body is laid out and THEN indented two columns, so it has to be laid out for two columns less
+  // or every decision is off by the indent it is about to receive. Found by the 1B.A audit: a printer
+  // that emits a leading indent has to account for it, and this one didn't -- a body line landing
+  // exactly on the width came out two columns over.
   let contextWithFn =
     { ctx with
-        currentFunction = Stdlib.Option.Option.Some((namePart, argMap)) }
+        currentFunction = Stdlib.Option.Option.Some((namePart, argMap))
+        width = Stdlib.Int.max 20 (ctx.width - 2) }
 
   let bodyPart = expr contextWithFn p.body
 

--- a/packages/darklang/prettyPrinter/runtimeError.dark
+++ b/packages/darklang/prettyPrinter/runtimeError.dark
@@ -96,9 +96,7 @@ module RuntimeError =
           | InlineParamName p -> p // Inline versions don't have quotes
           | TypeName t -> typeName branchId t
           | ValueName v -> valueName branchId v
-          | ShortTypeName t ->
-            // TODO: make it short
-            typeName branchId t
+          | ShortTypeName t -> shortTypeName branchId t
           | TypeReference t -> typeReference branchId t
           | TypeOfValue dv -> Dval.valueTypeName branchId dv
           | ValueType vt -> valueType branchId vt

--- a/packages/darklang/prettyPrinter/runtimeTypes.dark
+++ b/packages/darklang/prettyPrinter/runtimeTypes.dark
@@ -58,6 +58,75 @@ let resolvePackageHashWithOriginalName
     | [] -> resolvePackageHash ctx locations hash
 
 
+/// A type's name for value output, spelled relative to `opts.currentModule`.
+let typeNameWith
+    (branchId: Uuid)
+    (opts: PrettyPrinter.DisplayOptions)
+    (t: LanguageTools.RuntimeTypes.FQTypeName.FQTypeName)
+  : String =
+  match t with
+  | Package hash ->
+    let locations = Darklang.LanguageTools.PackageManager.Type.locations branchId hash
+    match
+      Darklang.LanguageTools.PackageManager.pickLocation
+        (LanguageTools.PackageManager.PickContext { currentModule = opts.currentModule })
+        locations
+    with
+    | Some l -> PrettyPrinter.shortenName opts.currentModule l.owner l.modules l.name
+    | None -> Darklang.LanguageTools.RuntimeTypes.hashToString hash
+
+
+/// Whether a value of this type says its type name before its case.
+///
+/// `Some`, `None`, `Ok` and `Error` are unambiguous everywhere and resolve unqualified, so naming their
+/// type in front of them is pure noise: `Some(Some([1, 2, 3]))` says everything
+/// `Option.Some(Option.Some([1, 2, 3]))` does. Every other enum keeps its type name, because `Red` on
+/// its own doesn't tell you it came from `Color`.
+let caseNameStandsAlone
+    (branchId: Uuid)
+    (currentModule: List<String>)
+    (t: LanguageTools.RuntimeTypes.FQTypeName.FQTypeName)
+  : Bool =
+  match t with
+  | Package hash ->
+    let locations = Darklang.LanguageTools.PackageManager.Type.locations branchId hash
+
+    // Several names for one type, and nothing in the reader's context to choose between them.
+    //
+    // Types are content-addressed, so two declarations with the same shape ARE one type:
+    // `Stdlib.Int.ParseError`, `Stdlib.Float.ParseError` and `Stdlib.Uuid.ParseError` are all
+    // `| BadFormat`, which makes them a single type with three names. Printing one of those names is
+    // picking arbitrarily, and it picks wrong most of the time -- `Stdlib.Int.parse "abc"` reporting a
+    // `Stdlib.Uuid.ParseError` is a real thing this used to print. The case name alone is the most that
+    // can honestly be said, so say that.
+    let ambiguous =
+      match locations with
+      | []
+      | [ _ ] -> false
+      | _ ->
+        locations
+        |> Stdlib.List.map (fun l ->
+          Darklang.LanguageTools.PackageManager.countMatchingPrefix
+            currentModule
+            (Stdlib.List.push l.modules l.owner))
+        |> Stdlib.List.fold 0 (fun acc n -> if n > acc then n else acc)
+        |> fun best -> best == 0
+
+    if ambiguous then
+      true
+    else
+      match
+        Darklang.LanguageTools.PackageManager.pickLocation
+          LanguageTools.PackageManager.PickContext.empty
+          locations
+      with
+      | Some l ->
+        let path = Stdlib.List.push l.modules l.owner
+        (path == [ "Darklang"; "Stdlib"; "Option" ] && l.name == "Option")
+        || (path == [ "Darklang"; "Stdlib"; "Result" ] && l.name == "Result")
+      | None -> false
+
+
 module FQTypeName =
   let package
         (branchId: Uuid)
@@ -72,6 +141,27 @@ let typeName
   : String =
   match t with
   | Package p -> FQTypeName.package branchId p
+
+
+/// Just the type's own name, without the module path that leads to it.
+///
+/// For error messages, where the surrounding sentence already says what kind of thing is being talked
+/// about and the full path is noise: "expects Option, but got Result" reads better than the same line
+/// with two forty-character paths in it. Falls back to the full name when the type has no location.
+let shortTypeName
+    (branchId: Uuid)
+    (t: LanguageTools.RuntimeTypes.FQTypeName.FQTypeName)
+  : String =
+  match t with
+  | Package hash ->
+    let locations = Darklang.LanguageTools.PackageManager.Type.locations branchId hash
+    match
+      Darklang.LanguageTools.PackageManager.pickLocation
+        LanguageTools.PackageManager.PickContext.empty
+        locations
+    with
+    | Some l -> l.name
+    | None -> Darklang.LanguageTools.RuntimeTypes.hashToString hash
 
 
 module FQValueName =
@@ -357,195 +447,247 @@ module Dval =
     | DBlobEphemeral _ -> "Blob"
     | DStreamStub vt -> $"Stream<{valueType branchId vt}>"
 
+  /// The field names of a record type, in the order they were declared.
+  ///
+  /// Empty when the type isn't resolvable or isn't a record, which callers treat as "no opinion".
+  let declaredFieldOrder
+    (typeName: LanguageTools.RuntimeTypes.FQTypeName.FQTypeName)
+    : List<String> =
+    match typeName with
+    | Package hash ->
+      match Darklang.LanguageTools.PackageManager.Type.get hash with
+      | Some t ->
+        match t.declaration.definition with
+        | Record fields -> fields |> Stdlib.List.map (fun f -> f.name)
+        | _ -> []
+      | None -> []
+
+
+  /// Put `pairs` into `order`, keeping anything `order` doesn't mention on the end.
+  ///
+  /// A record's fields live in a `Dict`, which iterates alphabetically, so a value printed straight
+  /// from it comes out in an order nobody wrote: `PackageLocation` declared as owner/modules/name
+  /// printed as modules/name/owner, and so didn't match its own `view`.
+  /// Subject first, because `|>` supplies the first parameter.
+  let inDeclaredOrder
+    (pairs: List<(String * LanguageTools.RuntimeTypes.Dval)>)
+    (order: List<String>)
+    : List<(String * LanguageTools.RuntimeTypes.Dval)> =
+    match order with
+    | [] -> pairs
+    | _ ->
+      let ordered =
+        order
+        |> Stdlib.List.filterMap (fun n ->
+          pairs |> Stdlib.List.findFirst (fun pair -> (Stdlib.Tuple2.first pair) == n))
+
+      let extra =
+        pairs
+        |> Stdlib.List.filter (fun pair ->
+          Stdlib.Bool.not (Stdlib.List.member order (Stdlib.Tuple2.first pair)))
+
+      Stdlib.List.append ordered extra
+
+
   let makeSpaces (len: Int) : String =
     match Stdlib.List.repeat len " " with
     | Ok spaces -> spaces |> Stdlib.String.join ""
     | Error _ -> ""
 
-  let withIndent
+  /// A value as a `Pretty.Doc`: the shapes it could take, not one it has already been forced into.
+  ///
+  /// Every container is a `group`, so it renders on one line when it fits and breaks when it doesn't --
+  /// and, unlike the string version this replaces, the decision counts everything on the line. A record
+  /// used to be measured by its fields alone, so a 51-character type name in front of them didn't count
+  /// and a 118-column line reported as fitting. Here the name is part of the same document.
+  ///
+  /// `depth` is compared against `opts.maxDepth`; past it, a value is elided rather than descended into.
+  let toDoc
     (branchId: Uuid)
-    (indent: Int)
+    (opts: PrettyPrinter.DisplayOptions)
+    (depth: Int)
     (dv: LanguageTools.RuntimeTypes.Dval)
-    : String =
-    let nl = "\n" ++ (makeSpaces indent)
-    let inl = "\n" ++ (makeSpaces (indent + 2))
-    let indent = indent + 2
+    : Stdlib.Pretty.Doc =
+    let txt (s: String) : Stdlib.Pretty.Doc = Stdlib.Pretty.text s
+
+    // Painted by kind. With the default plain palette every style is an empty string, so the output is
+    // byte-for-byte what it was before anyone asked for color.
+    let paint (style: String) (t: String) : Stdlib.Pretty.Doc =
+      Stdlib.Pretty.styled style t opts.palette.reset
+
+    let tooDeep =
+      match opts.maxDepth with
+      | None -> false
+      | Some max -> depth > max
+
+    if tooDeep then
+      txt "..."
+    else
+
+    // `[a, b]` flat, and one per line when broken. `open`/`close` hug their contents via `softLine`, so
+    // fitting on one line doesn't gain a pair of spaces the way `{ a, b }` deliberately does.
+    let wrapped
+      (opening: String)
+      (closing: String)
+      (opener: Stdlib.Pretty.Doc)
+      (parts: List<Stdlib.Pretty.Doc>)
+      : Stdlib.Pretty.Doc =
+      let sep = Stdlib.Pretty.concat (txt ",") Stdlib.Pretty.line
+      let inner = Stdlib.Pretty.join parts sep
+
+      Stdlib.Pretty.group (
+        Stdlib.Pretty.concat
+          (txt opening)
+          (Stdlib.Pretty.concat
+            (Stdlib.Pretty.nest 2 (Stdlib.Pretty.concat opener inner))
+            (Stdlib.Pretty.concat opener (txt closing))))
+
+    let bracketed (o: String) (c: String) (parts: List<Stdlib.Pretty.Doc>) : Stdlib.Pretty.Doc =
+      wrapped o c Stdlib.Pretty.softLine parts
+
+    let braced (o: String) (c: String) (parts: List<Stdlib.Pretty.Doc>) : Stdlib.Pretty.Doc =
+      wrapped o c Stdlib.Pretty.line parts
+
+    let child (v: LanguageTools.RuntimeTypes.Dval) : Stdlib.Pretty.Doc =
+      Dval.toDoc branchId opts (depth + 1) v
 
     let valueTypeName = valueTypeName branchId dv
 
     match dv with
-    | DUnit -> "()"
+    | DUnit -> paint opts.palette.keyword "()"
 
-    | DBool true -> "true"
-    | DBool false -> "false"
+    | DBool true -> paint opts.palette.keyword "true"
+    | DBool false -> paint opts.palette.keyword "false"
 
-    // RuntimeTypes.Dval declares DChar as carrying a String, so no conversion here
-    | DChar c -> $"'{c}'"
-    | DString s -> $"\"{s}\""
+    | DChar c -> paint opts.palette.string_ $"'{PrettyPrinter.escapeCharLiteral (Stdlib.Char.toString c)}'"
+    | DString s -> paint opts.palette.string_ $"\"{PrettyPrinter.escapeSpecialCharacters s}\""
 
-    | DInt8 i -> Stdlib.Int8.toString i
-    | DUInt8 i -> Stdlib.UInt8.toString i
-    | DInt16 i -> Stdlib.Int16.toString i
-    | DUInt16 i -> Stdlib.UInt16.toString i
-    | DInt32 i -> Stdlib.Int32.toString i
-    | DUInt32 i -> Stdlib.UInt32.toString i
-    | DInt64 i -> Stdlib.Int64.toString i
-    | DUInt64 i -> Stdlib.UInt64.toString i
-    | DInt128 i -> Stdlib.Int128.toString i
-    | DUInt128 i -> Stdlib.UInt128.toString i
-    | DInt i -> Stdlib.Int.toString i
+    | DInt8 i -> paint opts.palette.number (Stdlib.Int8.toString i)
+    | DUInt8 i -> paint opts.palette.number (Stdlib.UInt8.toString i)
+    | DInt16 i -> paint opts.palette.number (Stdlib.Int16.toString i)
+    | DUInt16 i -> paint opts.palette.number (Stdlib.UInt16.toString i)
+    | DInt32 i -> paint opts.palette.number (Stdlib.Int32.toString i)
+    | DUInt32 i -> paint opts.palette.number (Stdlib.UInt32.toString i)
+    | DInt64 i -> paint opts.palette.number (Stdlib.Int64.toString i)
+    | DUInt64 i -> paint opts.palette.number (Stdlib.UInt64.toString i)
+    | DInt128 i -> paint opts.palette.number (Stdlib.Int128.toString i)
+    | DUInt128 i -> paint opts.palette.number (Stdlib.UInt128.toString i)
+    | DInt i -> paint opts.palette.number (Stdlib.Int.toString i)
 
-    | DFloat f -> Stdlib.Float.toString f // CLEANUP: deal with Infinity, NegativeInfinity, and NaN
+    | DFloat f -> paint opts.palette.number (Stdlib.Float.toString f)
 
-    | DDateTime d -> $"<{valueTypeName}: {Stdlib.DateTime.toString d}>"
-
-    | DUuid uuid -> $"<{valueTypeName}: {Stdlib.Uuid.toString uuid}>"
-
+    | DDateTime d -> txt $"<{valueTypeName}: {Stdlib.DateTime.toString d}>"
+    | DUuid uuid -> txt $"<{valueTypeName}: {Stdlib.Uuid.toString uuid}>"
 
     | DTuple(first, second, theRest) ->
-      let l = Stdlib.List.append [ first; second ] theRest
-
       let parts =
-        Stdlib.List.map l (fun item -> withIndent branchId indent item)
+        (Stdlib.List.append [ first; second ] theRest) |> Stdlib.List.map (fun i -> child i)
+      bracketed "(" ")" parts
 
-      let short = Stdlib.String.join parts ", "
-
-      if Stdlib.String.length short <= 80 then
-        $"({short})"
-      else
-        let long = Stdlib.String.join parts $"{inl}, "
-
-        $"({inl}{long}{nl})"
-
-
-    | DList(vt, l) ->
+    | DList(_vt, l) ->
       if Stdlib.List.isEmpty l then
-        $"{valueTypeName} []"
+        txt $"{valueTypeName} []"
       else
-        let parts =
-          Stdlib.List.map l (fun item -> withIndent branchId indent item)
-        let short = Stdlib.String.join parts ", "
-
-        if Stdlib.String.length short <= 80 then
-          $"[{short}]"
-        else
-          let long = Stdlib.String.join parts $",{inl}"
-          $"[{inl}{long}{nl}]"
-
+        bracketed "[" "]" (l |> Stdlib.List.map (fun i -> child i))
 
     | DDict(_, d) ->
       if d == Stdlib.Dict.empty then
-        "{}"
+        txt "{}"
       else
-        let strs =
+        let parts =
           d
           |> Stdlib.Dict.toList
           |> Stdlib.List.map (fun pair ->
             let (key, value) = pair
-            $"{key}: {withIndent branchId indent value}")
+            let key = PrettyPrinter.formatFieldName key
+            Stdlib.Pretty.concat (txt $"{key}: ") (child value))
+        braced "{" "}" parts
 
-        let short = Stdlib.String.join strs ", "
-
-        if Stdlib.String.length short <= 80 then
-          "{ " ++ short ++ " }"
-        else
-          let long = Stdlib.String.join strs $",{inl}"
-          "{" ++ inl ++ long ++ nl ++ "}"
-
-
-    // Don't fetch the bytes for rendering — payloads can be many MB.
+    // Don't fetch the bytes for rendering -- payloads can be many MB.
     | DBlobPersistent(hash, length) ->
       let short = Stdlib.String.first hash 8
-      $"<Blob: {short}… {Stdlib.Int.toString length} bytes>"
-    | DBlobEphemeral _ -> "<Blob: ephemeral>"
+      txt $"<Blob: {short}… {Stdlib.Int.toString length} bytes>"
+    | DBlobEphemeral _ -> txt "<Blob: ephemeral>"
 
-    | DStreamStub _ -> "<stream: stub>"
+    | DStreamStub _ -> txt "<stream: stub>"
 
     | DEnum(_, typeName, typeArgs, caseName, fields) ->
       let typeArgsPart =
-        match typeArgs with
-        | [] -> ""
-        | typeArgs ->
-          typeArgs
-          |> Stdlib.List.map (fun typeArg -> valueType branchId typeArg)
-          |> Stdlib.String.join ", "
-          |> fun parts -> $"<{parts}>"
+        if Stdlib.Bool.not opts.showTypeArgs then
+          ""
+        else
+          match typeArgs with
+          | [] -> ""
+          | typeArgs ->
+            typeArgs
+            |> Stdlib.List.map (fun typeArg -> valueType branchId typeArg)
+            |> Stdlib.String.join ", "
+            |> fun parts -> $"<{parts}>"
 
-      let short =
-        let fieldStr =
-          fields
-          |> Stdlib.List.map (fun value -> withIndent branchId indent value)
-          |> Stdlib.String.join ", "
+      // `Some(1)`, not `Option.Some(1)`; but `Color.Red`, not `Red`.
+      let prefix =
+        if caseNameStandsAlone branchId opts.currentModule typeName then
+          ""
+        else
+          (typeNameWith branchId opts typeName) ++ typeArgsPart ++ "."
 
-        let fieldStr = if fieldStr == "" then "" else $"({fieldStr})"
-
-        let typeStr = RuntimeTypes.typeName branchId typeName
-        $"{typeStr}{typeArgsPart}.{caseName}{fieldStr}"
-
-      if Stdlib.String.length short <= 80 then
-        short
-      else
-        let fieldStr =
-          fields
-          |> Stdlib.List.map (fun value -> withIndent branchId indent value)
-          |> Stdlib.String.join $",{inl}"
-
-        let fieldStr = if fieldStr == "" then "" else $"({inl}{fieldStr}{nl})"
-
-        let typeStr = RuntimeTypes.typeName branchId typeName
-        $"{typeStr}{typeArgsPart}.{caseName}{fieldStr}"
-
+      match fields with
+      | [] -> txt $"{prefix}{caseName}"
+      | fields ->
+        Stdlib.Pretty.concat
+          (txt $"{prefix}{caseName}")
+          (bracketed "(" ")" (fields |> Stdlib.List.map (fun f -> child f)))
 
     | DRecord(_, typeName, typeArgs, o) ->
-      let strs =
-        o
-        |> Stdlib.Dict.toList
-        |> Stdlib.List.map (fun pair ->
-          let (key, value) = pair
-          $"{key}: {withIndent branchId indent value}")
-
-      let typeStr = RuntimeTypes.typeName branchId typeName
+      let typeStr = typeNameWith branchId opts typeName
 
       let typeArgsPart =
-        match typeArgs with
-        | [] -> ""
-        | args ->
-          args
-          |> Stdlib.List.map (fun t -> valueType branchId t)
-          |> Stdlib.String.join ", "
-          |> fun betweenBrackets -> "<" ++ betweenBrackets ++ ">"
+        if Stdlib.Bool.not opts.showTypeArgs then
+          ""
+        else
+          match typeArgs with
+          | [] -> ""
+          | args ->
+            args
+            |> Stdlib.List.map (fun t -> valueType branchId t)
+            |> Stdlib.String.join ", "
+            |> fun betweenBrackets -> "<" ++ betweenBrackets ++ ">"
 
-      let short = Stdlib.String.join strs ", "
+      let parts =
+        o
+        |> Stdlib.Dict.toList
+        |> Dval.inDeclaredOrder (Dval.declaredFieldOrder typeName)
+        |> Stdlib.List.map (fun pair ->
+          let (key, value) = pair
+          let key = PrettyPrinter.formatFieldName key
+          Stdlib.Pretty.concat (txt $"{key}: ") (child value))
 
-      if Stdlib.String.length short <= 80 then
-        typeStr ++ typeArgsPart ++ " { " ++ short ++ " }"
-      else
-        let long = Stdlib.String.join strs $",{inl}"
-        typeStr ++ typeArgsPart ++ " {" ++ inl ++ long ++ nl ++ "}"
-
+      // The type name is part of the document, so it counts toward the fit.
+      Stdlib.Pretty.concat (txt $"{typeStr}{typeArgsPart} ") (braced "{" "}" parts)
 
     | DApplicable(AppNamedFn namedFn) ->
-      PrettyPrinter.RuntimeTypes.fnName branchId namedFn.name
+      txt (PrettyPrinter.RuntimeTypes.fnName branchId namedFn.name)
 
-    | DApplicable(AppLambda _lambda) ->
-      // // Note: this use case is safe (RE docs/dblock-serialization.md)
-      // let ps =
-      //   impl.parameters
-      //   |> Stdlib.List.map Stdlib.Tuple2.second
-      //   |> Stdlib.String.join ", "
+    | DApplicable(AppLambda _lambda) -> txt "(lambda)"
 
-      // // TODO
-      // // let body = impl.body |> RuntimeTypes.Expr.toString
-      // $"\\ {ps} {{ ... }}"
-      "(lambda)"
+    | DDB name -> txt $"<{valueTypeName}: {name}>"
 
 
-    | DDB name -> $"<{valueTypeName}: {name}>"
+let dvalWith
+    (branchId: Uuid)
+    (opts: PrettyPrinter.DisplayOptions)
+    (dv: LanguageTools.RuntimeTypes.Dval)
+  : String =
+  // The one place a `Doc` is collapsed into text. Everything above builds alternatives; this picks.
+  Stdlib.Pretty.render opts.width (Dval.toDoc branchId opts 0 dv)
 
 
-
+/// Render a value with the default options.
+///
+/// Kept at this exact signature because `Execution.fs` reaches it through `PackageRefs`, which is how
+/// every F#-side value repr is produced. Prefer `dvalWith` in Dark code.
 let dval
     (branchId: Uuid)
     (dv: LanguageTools.RuntimeTypes.Dval)
   : String =
-  Dval.withIndent branchId 0 dv
+  dvalWith branchId PrettyPrinter.DisplayOptions.default dv

--- a/packages/darklang/stdlib/cli/tui/text.dark
+++ b/packages/darklang/stdlib/cli/tui/text.dark
@@ -15,7 +15,7 @@ module Darklang.Stdlib.Cli.Tui.Text
 ///
 /// The width is valid only when the control-character flag is false.
 let inspect (text: String) : (Int * Bool) =
-  Builtin.cliTerminalInspectText text
+  Stdlib.String.inspectDisplay text
 
 
 /// Return the number of terminal columns occupied by plain, single-line text.

--- a/packages/darklang/stdlib/cli/ui/table.dark
+++ b/packages/darklang/stdlib/cli/ui/table.dark
@@ -9,20 +9,21 @@ let print (columns: List<String>) (rows: List<List<String>>) : Unit =
   let colWidths =
     columns
     |> Stdlib.List.indexedMap (fun i header ->
-      let headerLen = Stdlib.String.length header
+      let headerLen = Stdlib.String.displayWidth header
 
       let maxCellLen =
         rows
         |> Stdlib.List.fold 0 (fun mx row ->
           match Stdlib.List.getAt row i with
-          | Some cell -> Stdlib.Int.max mx (Stdlib.String.length cell)
+          | Some cell -> Stdlib.Int.max mx (Stdlib.String.displayWidth cell)
           | None -> mx)
 
       Stdlib.Int.max headerLen maxCellLen)
 
-  // Pad a string to a given width with spaces
+  // Pad a string to a given width. Terminal columns, not characters: a cell holding a CJK character is
+  // one grapheme two columns wide, so padding by character count leaves the next column ragged.
   let pad = (fun s width ->
-    let padding = width - (Stdlib.String.length s)
+    let padding = width - (Stdlib.String.displayWidth s)
 
     if padding <= 0 then s
     else s ++ (Stdlib.String.repeat " " padding))
@@ -35,6 +36,9 @@ let print (columns: List<String>) (rows: List<List<String>>) : Unit =
       | Some w -> pad header w
       | None -> header)
     |> Stdlib.String.join "  "
+    // Padding on the final column is trailing whitespace with nothing after it to line up against. It
+    // shows up as a corridor of highlighted blanks once the header is bolded.
+    |> Stdlib.String.trimEnd
 
   Stdlib.printLine (Color.bold headerLine)
 
@@ -62,6 +66,7 @@ let print (columns: List<String>) (rows: List<List<String>>) : Unit =
           | Some w -> pad cell w
           | None -> cell)
         |> Stdlib.String.join "  "
+        |> Stdlib.String.trimEnd
 
       Stdlib.printLine line)
 

--- a/packages/darklang/stdlib/pretty.dark
+++ b/packages/darklang/stdlib/pretty.dark
@@ -1,0 +1,206 @@
+/// Width-aware layout, in the Wadler/Leijen tradition.
+///
+/// A `Doc` is not text; it is a description of the ways some text *could* be laid out. Nothing decides
+/// between them until `render`, which is given a width and picks. That is the whole point: a printer
+/// that returns a `String` has already committed, so its caller can't lay it out against the room that
+/// actually turned out to be available. A printer that returns a `Doc` leaves the choice where the
+/// information is.
+///
+/// The two combinators that matter are `nest`, which says "indent the inside of this if it breaks", and
+/// `group`, which says "put this on one line if it fits, otherwise break every soft line in it". Groups
+/// nest, and each decides independently, so a long outer structure can break while a short inner one
+/// stays flat.
+module Darklang.Stdlib.Pretty
+
+/// A document: text plus the places it may be broken.
+type Doc =
+  /// Renders to nothing.
+  | Empty
+
+  /// Literal text. Never broken, so it can exceed the width if a single token is wider than the page.
+  | Text of String
+
+  /// A soft break: a space when the enclosing group fits on one line, a newline plus the current
+  /// indentation when it doesn't.
+  | Line
+
+  /// A break that is always a newline, and which forces every enclosing group to break.
+  | HardLine
+
+  /// A break that is nothing at all when the enclosing group fits, and a newline plus indentation when
+  /// it doesn't. The difference from `Line` is what separates `[1, 2]` from `[ 1, 2 ]`: use this where a
+  /// delimiter shouldn't gain a space just because everything fit.
+  | SoftLine
+
+  /// Two documents, one after the other, with nothing between them.
+  | Concat of Doc * Doc
+
+  /// Indent everything inside by `n` columns, applied after each break rather than once at the front.
+  | Nest of Int * Doc
+
+  /// Try to fit the inside on one line.
+  | Group of Doc
+
+  /// Text with something wrapped around it that occupies no columns -- a terminal escape, typically.
+  /// Only the middle is measured, which is the entire point: decoration must not change where a
+  /// document breaks, and it silently would if the escapes were part of a `Text`.
+  | Styled of opening: String * text: String * closing: String
+
+
+/// Whether we are currently rendering a group flat or broken.
+type Mode =
+  | Flat
+  | Break
+
+
+val empty = Doc.Empty
+
+val line = Doc.Line
+
+val hardLine = Doc.HardLine
+
+val softLine = Doc.SoftLine
+
+let text (s: String) : Doc = Doc.Text s
+
+/// `text`, wrapped in zero-width decoration. `opening`/`closing` are emitted but never measured.
+let styled (opening: String) (t: String) (closing: String) : Doc = Doc.Styled(opening, t, closing)
+
+let concat (a: Doc) (b: Doc) : Doc = Doc.Concat(a, b)
+
+let concatSpace (a: Doc) (b: Doc) : Doc = Doc.Concat(a, Doc.Concat(Doc.Text " ", b))
+
+let concatLine (a: Doc) (b: Doc) : Doc = Doc.Concat(a, Doc.Concat(Doc.Line, b))
+
+let nest (n: Int) (d: Doc) : Doc = Doc.Nest(n, d)
+
+let group (d: Doc) : Doc = Doc.Group d
+
+
+/// Join with spaces.
+let hsep (ds: List<Doc>) : Doc =
+  match ds with
+  | [] -> Doc.Empty
+  | first :: rest -> Stdlib.List.fold rest first (fun acc d -> Pretty.concatSpace acc d)
+
+/// Join with soft breaks: one line if the group fits, one per item if it doesn't.
+let vsep (ds: List<Doc>) : Doc =
+  match ds with
+  | [] -> Doc.Empty
+  | first :: rest -> Stdlib.List.fold rest first (fun acc d -> Pretty.concatLine acc d)
+
+/// Join with `sep` between items.
+///
+/// Subject first, so it pipes: `docs |> Pretty.join sep`.
+let join (ds: List<Doc>) (sep: Doc) : Doc =
+  match ds with
+  | [] -> Doc.Empty
+  | first :: rest ->
+    Stdlib.List.fold rest first (fun acc d ->
+      Doc.Concat(acc, Doc.Concat(sep, d)))
+
+
+/// Would the rest of this line fit in `room` columns?
+///
+/// Walks the pending work until it reaches a break that ends the line (at which point everything so far
+/// fits) or runs out of room. `HardLine` answers no, which is what makes a group containing one always
+/// break. The pending items after the group are included, so a group isn't kept flat only to have the
+/// text that follows it overflow anyway.
+let fits (room: Int) (items: List<(Int * Mode * Doc)>) : Bool =
+  if room < 0 then
+    false
+  else
+    match items with
+    | [] -> true
+    | (i, m, d) :: rest ->
+      match d with
+      | Empty -> Pretty.fits room rest
+      | Text s -> Pretty.fits (room - (Stdlib.String.displayWidth s)) rest
+      | Styled(_, t, _) -> Pretty.fits (room - (Stdlib.String.displayWidth t)) rest
+
+      // Inside the group being tested (Flat) a hard line means it cannot be one line, so it doesn't
+      // fit. After the group (Break) it simply ends the line, so everything measured so far does fit.
+      // Answering `false` in both cases made every group followed by a hard line break -- which is
+      // every match arm, since the arms are hard-lined apart.
+      | HardLine ->
+        match m with
+        | Flat -> false
+        | Break -> true
+      | Line ->
+        match m with
+        | Flat -> Pretty.fits (room - 1) rest
+        | Break -> true
+      | SoftLine ->
+        match m with
+        | Flat -> Pretty.fits room rest
+        | Break -> true
+      | Concat(a, b) ->
+        Pretty.fits room (Stdlib.List.push (Stdlib.List.push rest ((i, m, b))) ((i, m, a)))
+      | Nest(j, x) -> Pretty.fits room (Stdlib.List.push rest ((i + j, m, x)))
+      | Group x -> Pretty.fits room (Stdlib.List.push rest ((i, Mode.Flat, x)))
+
+
+/// The rendering loop: walk the pending work, emitting text and deciding each group as it is reached.
+let renderLoop
+  (width: Int)
+  (col: Int)
+  (acc: String)
+  (items: List<(Int * Mode * Doc)>)
+  : String =
+  match items with
+  | [] -> acc
+  | (i, m, d) :: rest ->
+    match d with
+    | Empty -> Pretty.renderLoop width col acc rest
+
+    | Text s ->
+      Pretty.renderLoop width (col + (Stdlib.String.displayWidth s)) (acc ++ s) rest
+
+    | Styled(opening, t, closing) ->
+      Pretty.renderLoop
+        width
+        (col + (Stdlib.String.displayWidth t))
+        (acc ++ opening ++ t ++ closing)
+        rest
+
+    | HardLine ->
+      let pad = Stdlib.String.repeat " " i
+      Pretty.renderLoop width i (acc ++ "\n" ++ pad) rest
+
+    | Line ->
+      match m with
+      | Flat -> Pretty.renderLoop width (col + 1) (acc ++ " ") rest
+      | Break ->
+        let pad = Stdlib.String.repeat " " i
+        Pretty.renderLoop width i (acc ++ "\n" ++ pad) rest
+
+    | SoftLine ->
+      match m with
+      | Flat -> Pretty.renderLoop width col acc rest
+      | Break ->
+        let pad = Stdlib.String.repeat " " i
+        Pretty.renderLoop width i (acc ++ "\n" ++ pad) rest
+
+    | Concat(a, b) ->
+      Pretty.renderLoop
+        width
+        col
+        acc
+        (Stdlib.List.push (Stdlib.List.push rest ((i, m, b))) ((i, m, a)))
+
+    | Nest(j, x) ->
+      Pretty.renderLoop width col acc (Stdlib.List.push rest ((i + j, m, x)))
+
+    | Group x ->
+      // The one decision this whole module exists to make.
+      let flat = Stdlib.List.push rest ((i, Mode.Flat, x))
+
+      if Pretty.fits (width - col) flat then
+        Pretty.renderLoop width col acc flat
+      else
+        Pretty.renderLoop width col acc (Stdlib.List.push rest ((i, Mode.Break, x)))
+
+
+/// Lay out `doc` for a page `width` columns wide.
+let render (width: Int) (doc: Doc) : String =
+  Pretty.renderLoop width 0 "" [ ((0, Mode.Break, doc)) ]

--- a/packages/darklang/stdlib/string.dark
+++ b/packages/darklang/stdlib/string.dark
@@ -65,6 +65,26 @@ let toLowercase (s: String) : String = Builtin.stringToLowercase s
 let length (s: String) : Int = Builtin.stringLength s
 
 
+/// How many terminal columns <param s> occupies.
+///
+/// Not the same question as <fn length>, which counts extended grapheme clusters: `界` is one grapheme
+/// in two columns, and so is a ZWJ emoji. Use this for anything positional -- laying out, padding,
+/// deciding whether something fits -- and <fn length> for "how many characters is this".
+///
+/// Assumes plain text. Terminal escape sequences are not text and are not measured here.
+let displayWidth (s: String) : Int =
+  let (width, _containsControl) = Stdlib.String.inspectDisplay s
+  width
+
+
+/// Measure <param s> in terminal columns, and report whether it contains control characters.
+///
+/// The width is only meaningful when the flag is false. The single place this builtin is reached;
+/// `Cli.Tui.Text` layers escape-awareness on top of it.
+let inspectDisplay (s: String) : (Int * Bool) =
+  Builtin.cliTerminalInspectText s
+
+
 /// Concatenates the two strings by appending <param s2> to <param s1> and returns the joined string.
 let append (s1: String) (s2: String) : String = $"{s1}{s2}"
 


### PR DESCRIPTION
The printers are what you see from `view`, `eval`, `search`, `show`, `deps`, the workbench and every runtime error. Most of what they printed was fine. This fixes the parts that weren't: names longer than they need to be, lines that didn't fit and were cut, and a few constructs that always broke across lines whether or not they needed to.

The one structural change is that the printers now build a `Doc` (`Stdlib.Pretty`, new here) instead of a string, and a single `render` at the edge decides the layout against the width it is actually given. A string has already picked its layout, so a caller can't lay it out for the space available; that is why the width bugs below existed at all.

---

## Names

Names were spelled in full regardless of where you were standing, and the shortening that did exist compared strings rather than path segments, so from `Darklang.Stdlib.List` a reference to `Darklang.Stdlib.ListView.render` came out as `iew.render`.

There is one shortener now, and its rule comes from `LibDB.NameLookup.namesToTry` rather than taste: drop the longest prefix the name shares with the current module, because that is exactly the suffix the resolver will find again. `view`, the workbench, `search`, `deps` and `eval` all pass where the reader is.

    type PackageFn =                                        type PackageFn =
      { hash: LanguageTools.ProgramTypes.FQFnName.Package      { hash: FQFnName.Package
        body: LanguageTools.ProgramTypes.Expr        ->        body: Expr
        parameters: List<...PackageFn.Parameter>               parameters: List<Parameter>
        returnType: LanguageTools.ProgramTypes.TypeReference   returnType: TypeReference }

Values also named their type in full and repeated its type arguments, which buried the data:

    - Darklang.Stdlib.Option.Option<Darklang.Stdlib.Option.Option<List<Int>>>.Some(
    -   Darklang.Stdlib.Option.Option<List<Int>>.Some([1, 2, 3])
    - )
    + Some(Some([1, 2, 3]))

`Some`, `None`, `Ok` and `Error` resolve unqualified everywhere, so naming their type says nothing. Every other enum keeps its name: `Error(Stdlib.List.ChunkBySizeError.SizeMustBeGreaterThanZero)`.

One case where the printer now says less on purpose. Types are content-addressed, so `Stdlib.Int.ParseError`, `Stdlib.Float.ParseError` and `Stdlib.Uuid.ParseError` -- all `| BadFormat` -- are one type with three names, and picking one is a guess that used to make `Stdlib.Int.parse` report a `Stdlib.Uuid.ParseError`. If the reader's module picks a winner it is used; otherwise the case name alone is what can honestly be said.

    - Stdlib.Int.parse "abc"  ->  Error(Stdlib.Uuid.ParseError.BadFormat)
    + Stdlib.Int.parse "abc"  ->  Error(BadFormat)     (or ParseError.BadFormat, from inside Stdlib.Int)

---

## Widths

A record was measured by its joined fields alone, so the type name in front of them didn't count and a 118-column line reported as fitting in 80. Measurement was also in grapheme clusters rather than terminal columns, so CJK and emoji undercounted by half.

Widths now come from the caller: `eval` asks the terminal, the workbench passes its pane width. The printer can't ask, which keeps output reproducible in tests.

    - [
    -   LanguageTools.ProgramTypes.PackageLocation { owner: "Darklang", modules: ["Stdlib", "List"], name: "map" }
    - ]
    + [
    +   LanguageTools.ProgramTypes.PackageLocation {
    +     owner: "Darklang",
    +     modules: ["Stdlib", "List"],
    +     name: "map"
    +   }
    + ]

The workbench used to cut anything past the pane edge -- not wrapped, not reachable by scrolling, no mark that it had been there. It wraps now, and the tree pane is sized to its contents rather than a flat 45 percent, so eight short names stop taking 117 columns while the pane that was cutting got the rest.

---

## Layout

The source printer had no line-breaking decisions: `let`, match arms, `if` and pipes always broke, collections never did at any length.

    - let map<'a, 'b> (option: Stdlib.Option.Option<'a>) (fn: 'a -> 'b): Stdlib.Option.Option<'b> =
    -   match option with
    -   | Some(v) ->
    -     Stdlib.Option.Option.Some(fn v)
    -   | None ->
    -     Stdlib.Option.Option.None
    + let map<'a, 'b> (option: Option<'a>) (fn: 'a -> 'b): Option<'b> =
    +   match option with
    +   | Some(v) -> Option.Some(fn v)
    +   | None -> Option.None

Where something fits, it stays on one line. Two places ignored that. A lambda always broke after its arrow, and a call joined its arguments with a literal space inside a group, which meant the group could never break and every argument decided its own layout independently. Long calls came out ragged as a result, with one argument's continuation line sharing a row with the start of the next. Both are grouped now: one line when it fits, otherwise one argument per line under a single indent. A lambda argument also stopped getting a second pair of parentheses on top of the ones it prints itself.

    - Stdlib.Tuple3.mapAllThree ((fun x ->
    -   Stdlib.String.toUppercase x)) ((fun x ->
    -   x - 2L)) ((fun x ->
    -   Stdlib.String.toUppercase x)) ("one", 2L, "pi")
    + Stdlib.Tuple3.mapAllThree
    +   (fun x -> Stdlib.String.toUppercase x)
    +   (fun x -> x - 2L)
    +   (fun x -> Stdlib.String.toUppercase x)
    +   ("one", 2L, "pi")

The same rule pulls short bodies back up rather than pushing them down:

    - let double =
    -   (fun x ->
    -     x * 2L)
    + let double = (fun x -> x * 2L)

Parentheses are added only where precedence or associativity needs them. `infixPower` mirrors `infixBindingPower` in `LibParser/Parser.fs`, with a comment on each pointing at the other, because a printer that disagrees with the parser about precedence emits text that means something else.

    - (n) * ((factorial n) - (1L))    + n * (factorial n - 1L)
    - (person.age) + (1L)             + person.age + 1L

Strings and chars are escaped (they weren't, so a value containing a newline printed a real line break inside its own quotes), record fields print in declaration order rather than alphabetically, and the printer no longer emits the owner as a `module`, which meant printed source re-parsed a level deeper every pass.

---

## Color

`view` was syntax-highlighted; `eval` printed the same values in plain text. Both are colored now, honoring `NO_COLOR` and a redirected stdout, so `dark eval … > file` still writes text. Escapes cost no columns -- `Doc.Styled` measures only its text -- so a colored value breaks at exactly the widths the plain one does.