### PR TITLE
Perf work: records and enums cost half what they did

### DIFF
--- a/backend/src/Builtins/Builtins.Language/Libs/Instrumentation.fs
+++ b/backend/src/Builtins/Builtins.Language/Libs/Instrumentation.fs
@@ -83,7 +83,9 @@ let fns () : List<BuiltInFn> =
       returnType = TString
       description =
         "Returns interpreter performance counters as a JSON string. "
-        + "Includes instruction count, builtin/package call counts, frame pushes. "
+        + "Includes instruction count, builtin/package call counts, frame pushes, bytes and "
+        + "counts per opcode, and bytes and counts per named region of the Apply path (read the "
+        + "fine-grained stages, not the totals -- see the note in the implementation). "
         + "When detailed timing is enabled, also includes per-builtin and per-package-fn "
         + "cumulative nanoseconds and call counts."
       fn =
@@ -112,6 +114,57 @@ let fns () : List<BuiltInFn> =
           let dtStr = if s.detailedTiming then "true" else "false"
           sb.Append($",\"detailedTiming\":{dtStr}")
           |> ignore<System.Text.StringBuilder>
+
+          // Which opcode produced the garbage, which a flat allocation profile cannot answer.
+          // Non-zero entries only.
+          let anyOpcode = s.countByOpcode |> Array.exists (fun c -> c > 0L)
+          if anyOpcode then
+            sb.Append(",\"byOpcode\":{") |> ignore<System.Text.StringBuilder>
+            let mutable firstOp = true
+            for i in 0 .. s.countByOpcode.Length - 1 do
+              if s.countByOpcode[i] > 0L then
+                let name =
+                  if i < LibExecution.RuntimeTypes.Opcode.names.Length then
+                    LibExecution.RuntimeTypes.Opcode.names[i]
+                  else
+                    string i
+                if not firstOp then
+                  sb.Append(",") |> ignore<System.Text.StringBuilder>
+                let syncPart =
+                  if s.syncHitByOpcode[i] > 0L || s.syncMissByOpcode[i] > 0L then
+                    $",\"syncHit\":{s.syncHitByOpcode[i]},\"syncMiss\":{s.syncMissByOpcode[i]}"
+                  else
+                    ""
+                sb.Append(
+                  $"\"{name}\":{{\"bytes\":{s.allocByOpcode[i]},\"n\":{s.countByOpcode[i]}{syncPart}}}"
+                )
+                |> ignore<System.Text.StringBuilder>
+                firstOp <- false
+            sb.Append("}") |> ignore<System.Text.StringBuilder>
+
+          // Per-stage bytes and counts for the Apply path. Read the fine-grained stages only: the
+          // three totals (`apply.total`, `bi.total`, `lambda.total`) bracket across the builtin's
+          // `Ply`, so they measure nested execution and can exceed what the process allocated.
+          // `stats.builtinAlloc` has the same defect, so it is collected but not reported.
+          let anyStage = s.countByStage |> Array.exists (fun c -> c > 0L)
+          if anyStage then
+            sb.Append(",\"byStage\":{") |> ignore<System.Text.StringBuilder>
+            let mutable firstStage = true
+            for i in 0 .. s.countByStage.Length - 1 do
+              if s.countByStage[i] > 0L then
+                let name =
+                  if i < LibExecution.RuntimeTypes.ApplyStage.names.Length then
+                    LibExecution.RuntimeTypes.ApplyStage.names[i]
+                  else
+                    string i
+                if not firstStage then
+                  sb.Append(",") |> ignore<System.Text.StringBuilder>
+                sb.Append(
+                  $"\"{name}\":{{\"bytes\":{s.allocByStage[i]},\"n\":{s.countByStage[i]}}}"
+                )
+                |> ignore<System.Text.StringBuilder>
+                firstStage <- false
+            sb.Append("}") |> ignore<System.Text.StringBuilder>
 
           if s.detailedTiming && s.builtinTiming.Count > 0 then
             sb.Append(",\"builtinTiming\":{") |> ignore<System.Text.StringBuilder>

--- a/backend/src/Builtins/Builtins.Pure/Libs/Dict.fs
+++ b/backend/src/Builtins/Builtins.Pure/Libs/Dict.fs
@@ -14,6 +14,32 @@ let varA = TVariable "a"
 let varB = TVariable "b"
 
 
+/// Add every (key, value) tuple to the map, merging the value type as it goes. A top-level
+/// recursion rather than a fold: the lambda would be a closure and the accumulator a tuple, both
+/// allocated per entry.
+let rec private addAllEntries
+  (threadID : ThreadID)
+  (typ : ValueType)
+  (acc : DvalMap)
+  (remaining : List<Dval>)
+  : struct (ValueType * DvalMap) =
+  match remaining with
+  | [] -> struct (typ, acc)
+  | DTuple(DString k, value, []) :: rest ->
+    let struct (typ, acc) =
+      TypeChecker.DvalCreator.dictAddEntry
+        threadID
+        typ
+        acc
+        k
+        value
+        TypeChecker.ReplaceValue
+    addAllEntries threadID typ acc rest
+  | dv :: _ ->
+    Exception.raiseInternal
+      "Not string tuples in fromListOverwritingDuplicates"
+      [ "dval", dv ]
+
 let fns () : List<BuiltInFn> =
   [ { name = fn "dictSize" 0
       typeParams = []
@@ -40,7 +66,11 @@ let fns () : List<BuiltInFn> =
         (function
         | _, _, _, [| DDict(_, o) |] ->
           // CLEANUP follow up here if/when `key` type is dynamic (not just String)
-          o |> Map.keys |> Seq.map DString |> Seq.toList |> Dval.list KTString |> Ply
+          // `Map.foldBack` walks the tree directly, in `Map.keys`' ascending order. A lazy `Seq`
+          // chain would cost an enumerator and a closure per stage.
+          Map.foldBack (fun k _ acc -> DString k :: acc) o []
+          |> Dval.list KTString
+          |> Ply
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
@@ -57,7 +87,8 @@ let fns () : List<BuiltInFn> =
       fn =
         (function
         | _, _, _, [| DDict(valueType, o) |] ->
-          o |> Map.values |> Seq.toList |> (fun vs -> DList(valueType, vs) |> Ply)
+          // See `dictKeys`: a direct fold rather than a lazy sequence and its enumerator.
+          DList(valueType, Map.foldBack (fun _ v acc -> v :: acc) o []) |> Ply
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
       previewable = Pure
@@ -104,21 +135,7 @@ let fns () : List<BuiltInFn> =
         | _, _, _, [| DList(_, []) |] -> DDict(VT.unknown, Map.empty) |> Ply
 
         | _, vm, _, [| DList(ValueType.Known(KTTuple(_keyType, valueType, [])), l) |] ->
-          let f (accType, accMap) dv =
-            match dv with
-            | DTuple(DString k, value, []) ->
-              TypeChecker.DvalCreator.dictAddEntry
-                vm.threadID
-                accType
-                accMap
-                (k, value)
-                TypeChecker.ReplaceValue
-            | _ ->
-              Exception.raiseInternal
-                "Not string tuples in fromListOverwritingDuplicates"
-                [ "dval", dv ]
-
-          let (typ, map) = List.fold f (valueType, Map.empty) l
+          let struct (typ, map) = addAllEntries vm.threadID valueType Map.empty l
           DDict(typ, map) |> Ply
         | _ -> incorrectArgs ())
       sqlSpec = NotYetImplemented
@@ -247,12 +264,13 @@ let fns () : List<BuiltInFn> =
       fn =
         (function
         | _, vm, _, [| DDict(vt, o); DString k; v |] ->
-          let (typ, map) =
+          let struct (typ, map) =
             TypeChecker.DvalCreator.dictAddEntry
               vm.threadID
               vt
               o
-              (k, v)
+              k
+              v
               TypeChecker.ThrowIfDuplicate
           DDict(typ, map) |> Ply
         | _ -> incorrectArgs ())
@@ -275,12 +293,13 @@ let fns () : List<BuiltInFn> =
       fn =
         (function
         | _, vm, _, [| DDict(vt, o); DString k; v |] ->
-          let (typ, map) =
+          let struct (typ, map) =
             TypeChecker.DvalCreator.dictAddEntry
               vm.threadID
               vt
               o
-              (k, v)
+              k
+              v
               TypeChecker.ReplaceValue
           DDict(typ, map) |> Ply
         | _ -> incorrectArgs ())

--- a/backend/src/Builtins/Builtins.Pure/Libs/Json.fs
+++ b/backend/src/Builtins/Builtins.Pure/Libs/Json.fs
@@ -133,10 +133,11 @@ let rec serialize (threadID : ThreadID) (w : Utf8JsonWriter) (dv : Dval) : unit 
   | DList(_, items) -> w.writeArray (fun () -> List.iter r items)
 
   | DDict(_, fields) ->
+    // `Map.iter` rather than `Map.toList |> List.iter`: the latter builds a tuple and a cons per
+    // field, for a list that is walked once and dropped. Both visit in ascending key order.
     w.writeObject (fun () ->
       fields
-      |> Map.toList
-      |> List.iter (fun (k, v) ->
+      |> Map.iter (fun k v ->
         w.WritePropertyName k
         r v))
 
@@ -147,10 +148,10 @@ let rec serialize (threadID : ThreadID) (w : Utf8JsonWriter) (dv : Dval) : unit 
       w.writeArray (fun () -> fields |> List.iter r))
 
   | DRecord(_, _, _, fields) ->
+    // See `DDict` above.
     w.writeObject (fun () ->
       fields
-      |> Map.toList
-      |> List.iter (fun (fieldName, dval) ->
+      |> Map.iter (fun fieldName dval ->
         w.WritePropertyName fieldName
         r dval))
 
@@ -814,14 +815,21 @@ let fns () : List<BuiltInFn> =
 
           let okType = VT.unknownTODO // "a"
           let errType = KTCustomType(ParseError.typeName (), []) |> VT.known
-          let resultOk = TypeChecker.DvalCreator.Result.ok threadID okType errType
-          let resultError =
-            TypeChecker.DvalCreator.Result.error threadID okType errType
 
+          // Applied in full in each branch rather than partially applied into `resultOk` and
+          // `resultError` up front. Both closures were built on every call and exactly one was
+          // ever invoked.
           uply {
             match! parse threadID exeState.types typeArg arg with
-            | Ok v -> return resultOk v
-            | Error e -> return resultError (ParseError.toDT e)
+            | Ok v ->
+              return TypeChecker.DvalCreator.Result.ok threadID okType errType v
+            | Error e ->
+              return
+                TypeChecker.DvalCreator.Result.error
+                  threadID
+                  okType
+                  errType
+                  (ParseError.toDT e)
           }
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable

--- a/backend/src/Cli/Cli.fs
+++ b/backend/src/Cli/Cli.fs
@@ -133,12 +133,14 @@ let initSerializers () = ()
 [<EntryPoint>]
 let main (args : string[]) =
   try
+    // Sampled before anything else in the process, including the environment read below. It is one
+    // half of `cli.preMain`, and the other half -- the process start time -- costs milliseconds to
+    // obtain, so taking this first is what keeps the measurement from including itself.
+    let mainEntry = System.DateTime.UtcNow
+
     // How long the process took to reach here. `cli.total` starts after resource extraction and can't
     // see runtime init, assembly loading or JIT of the startup path, which is a large share of a short
     // command. Wall clock rather than Stopwatch, because the only fixed point is when the OS started us.
-    // Read the switch before doing any measuring: `Process.GetCurrentProcess()` reads /proc and
-    // initialises the Process machinery, which is not free on a command this short, and the only thing
-    // it feeds is a telemetry event.
     let telemetryEnabled =
       match System.Environment.GetEnvironmentVariable "DARK_TELEMETRY" with
       | "1" -> true
@@ -146,9 +148,12 @@ let main (args : string[]) =
 
     let preMainMs =
       if telemetryEnabled then
+        // `Process.GetCurrentProcess()` reads /proc and initialises the Process machinery, which is
+        // not free on a command this short. It sits after `mainEntry` deliberately: it is the cost of
+        // reading the clock, not part of the startup being measured.
         let processStart =
           System.Diagnostics.Process.GetCurrentProcess().StartTime.ToUniversalTime()
-        int64 (System.DateTime.UtcNow - processStart).TotalMilliseconds
+        int64 (mainEntry - processStart).TotalMilliseconds
       else
         0L
 

--- a/backend/src/LibExecution/Interpreter.fs
+++ b/backend/src/LibExecution/Interpreter.fs
@@ -1756,6 +1756,126 @@ let private applyInstruction
   outcome
 
 
+/// `TypeReference.toVT` over a list, without awaiting. `ValueNone` if any element needs the store.
+///
+/// The empty list is the overwhelmingly common case and costs nothing here.
+let rec private toVTsSync
+  (types : Types)
+  (tst : TypeSymbolTable)
+  (acc : List<ValueType>)
+  (typeArgs : List<TypeReference>)
+  : List<ValueType> voption =
+  match typeArgs with
+  | [] -> ValueSome(List.rev acc)
+  | t :: rest ->
+    match Ply.trySync (TypeReference.toVT types tst t) with
+    | ValueSome vt -> toVTsSync types tst (vt :: acc) rest
+    | ValueNone -> ValueNone
+
+
+/// Build a record, an enum or a record update without entering a computation expression.
+///
+/// These three opcodes are async only because their builders can need the type store. That store is
+/// cached, so after the first reference to a type the `Ply` they hand back is already complete, and
+/// the drain can take the value straight out of it.
+///
+/// Returns false when the store is genuinely needed. Nothing has been written to a register in that
+/// case, and the caller leaves the counter where it is so `runRareOpcode` runs the same instruction
+/// properly. That does mean the builder runs twice on a miss: the discarded `Ply` finishes on its own
+/// and its result is dropped. These builders only read the type store and construct a value, so a
+/// repeat is wasted work rather than a second effect, and a miss happens about once per type.
+let private tryBuildSync
+  (exeState : ExecutionState)
+  (vm : VMState)
+  (currentFrame : CallFrame)
+  (registers : Dval array)
+  (inst : Instruction)
+  : bool =
+  let tst = currentFrame.typeSymbolTable
+
+  match inst with
+  | CreateRecord(recordReg, sourceTypeName, typeArgs, fields) ->
+    match toVTsSync exeState.types tst [] typeArgs with
+    | ValueNone -> false
+    | ValueSome typeArgs ->
+      let fields =
+        fields |> List.map (fun (name, valueReg) -> (name, registers[valueReg]))
+
+      match
+        Ply.trySync (
+          TypeChecker.DvalCreator.record
+            exeState.types
+            vm.threadID
+            tst
+            sourceTypeName
+            typeArgs
+            fields
+        )
+      with
+      | ValueSome record ->
+        registers[recordReg] <- record
+        true
+      | ValueNone -> false
+
+  | CreateEnum(enumReg, typeName, typeArgs, caseName, fields) ->
+    match toVTsSync exeState.types tst [] typeArgs with
+    | ValueNone -> false
+    | ValueSome typeArgs ->
+      let fields = fields |> List.map (fun valueReg -> registers[valueReg])
+
+      match
+        Ply.trySync (
+          TypeChecker.DvalCreator.enum
+            exeState.types
+            vm.threadID
+            tst
+            typeName
+            typeArgs
+            caseName
+            fields
+        )
+      with
+      | ValueSome newEnum ->
+        registers[enumReg] <- newEnum
+        true
+      | ValueNone -> false
+
+  | CloneRecordWithUpdates(targetReg, originalRecordReg, fieldUpdates) ->
+    // A non-record here is a runtime error, which the async path raises. Declining keeps the error
+    // construction in one place rather than duplicating it.
+    match registers[originalRecordReg] with
+    | DRecord(sourceTypeName, resolvedTypeName, typeArgs, originalFields) ->
+      let fieldUpdates =
+        fieldUpdates
+        |> List.map (fun (name, valueReg) -> (name, registers[valueReg]))
+
+      match
+        Ply.trySync (
+          TypeChecker.DvalCreator.recordUpdate
+            exeState.types
+            vm.threadID
+            tst
+            sourceTypeName
+            resolvedTypeName
+            typeArgs
+            originalFields
+            fieldUpdates
+        )
+      with
+      | ValueSome updated ->
+        registers[targetReg] <- updated
+        true
+      | ValueNone -> false
+    | _ -> false
+
+  | _ ->
+    // Only the three above are offered here. Anything else reaching this is a routing mistake, and
+    // silently declining would turn it into a hang or a wrong answer.
+    Exception.raiseInternal
+      "tryBuildSync given an opcode it does not handle"
+      [ "opcode", Opcode.index inst ]
+
+
 /// Run consecutive instructions that need no `await`, without entering the interpreter's computation
 /// expression at all. Returns the counter where it stopped: past the end of the block, or at one of the
 /// five opcodes that must be handled on the async path.
@@ -1782,9 +1902,36 @@ let private runSyncInstructions
     let inst = instrData.instructions[counter]
 
     match inst with
+    // Records, enums and record updates are built here when their type is already resolved, which
+    // after the first reference to it is always. Only a genuine store miss stops the drain.
     | CreateRecord _
     | CloneRecordWithUpdates _
-    | CreateEnum _
+    | CreateEnum _ ->
+      if vm.stats.enabled then
+        vm.stats.instructionCount <- vm.stats.instructionCount + 1L
+
+      let allocBefore =
+        if vm.stats.enabled then
+          System.GC.GetAllocatedBytesForCurrentThread()
+        else
+          0L
+
+      let handled = tryBuildSync exeState vm currentFrame registers inst
+
+      if vm.stats.enabled then
+        let tag = Opcode.index inst
+        if tag >= 0 && tag < vm.stats.allocByOpcode.Length then
+          let delta = System.GC.GetAllocatedBytesForCurrentThread() - allocBefore
+          if delta > 0L then
+            vm.stats.allocByOpcode[tag] <- vm.stats.allocByOpcode[tag] + delta
+          vm.stats.countByOpcode[tag] <- vm.stats.countByOpcode[tag] + 1L
+          if handled then
+            vm.stats.syncHitByOpcode[tag] <- vm.stats.syncHitByOpcode[tag] + 1L
+          else
+            vm.stats.syncMissByOpcode[tag] <- vm.stats.syncMissByOpcode[tag] + 1L
+
+      if handled then counter <- counter + 1 else running <- false
+
     | LoadValue _ -> running <- false
 
     // `Apply` is all but a handful of the instructions that could stop this drain, and it almost

--- a/backend/src/LibExecution/PackageRefs.fs
+++ b/backend/src/LibExecution/PackageRefs.fs
@@ -56,21 +56,35 @@ let private loadHashes () : Map<string, string> =
 /// the hash file is regenerated (e.g. during reload-packages in CI).
 let mutable private hashCache : Map<string, string> option = None
 
+/// Bumped whenever `hashCache` is replaced. Each ref closure caches its resolved hash against the
+/// generation it resolved under, so a reload invalidates every cached ref without tracking them.
+let mutable private hashGeneration = 0
+
 let private getHashes () : Map<string, string> =
   match hashCache with
   | Some h -> h
   | None ->
     let h = loadHashes ()
     hashCache <- Some h
+    hashGeneration <- hashGeneration + 1
     h
+
+let private currentGeneration () : int =
+  // Touch the cache first, so a lazy first load is reflected in the generation the caller records.
+  getHashes () |> ignore<Map<string, string>>
+  hashGeneration
 
 /// Force-reload hashes from disk. Call after PackageRefsGenerator writes
 /// the hash file so that subsequent PackageRefs calls get real values.
-let reloadHashes () : unit = hashCache <- Some(loadHashes ())
+let reloadHashes () : unit =
+  hashCache <- Some(loadHashes ())
+  hashGeneration <- hashGeneration + 1
 
 /// Set hashes directly from a map (for installed CLIs where the
 /// source tree isn't available to write/read the hashes file).
-let setHashes (hashes : Map<string, string>) : unit = hashCache <- Some hashes
+let setHashes (hashes : Map<string, string>) : unit =
+  hashCache <- Some hashes
+  hashGeneration <- hashGeneration + 1
 
 
 module Type =
@@ -82,24 +96,37 @@ module Type =
   /// Returns "" if the hash file is empty (CI before reload-packages).
   let private p modules name : (unit -> string) =
     _lookup <- _lookup |> Map.add (modules, name) ""
+    // Resolved once per hash generation: the answer cannot change while the generation is stable,
+    // and resolving per call costs an interpolated key, a Map walk and a Map.add. These sit under
+    // Option and Result construction, so they run constantly.
+    let mutable cachedGen = -1
+    let mutable cached = ""
+
     fun () ->
-      let fqn = $"""type/{String.concat "." modules}.{name}"""
-      let h = getHashes ()
-      match Map.tryFind fqn h with
-      | Some hash ->
-        _lookup <- _lookup |> Map.add (modules, name) hash
-        hash
-      | None ->
-        if Map.isEmpty h then
-          "" // Hash file not yet populated (CI before reload-packages)
-        else
-          // Non-empty hash file that doesn't know this ref means the file is stale, which happens
-          // whenever a ref is added (or an older binary regenerates the file in-place -- `growIfNeeded`
-          // rewrites it, so running a previous release inside the source tree is enough). The fix is
-          // always the same, so say it rather than making the next person find it in AGENTS.md.
-          Exception.raiseInternal
-            "PackageRefs: type hash not found. The hash file is stale; regenerate it with `> backend/src/LibExecution/package-ref-hashes.txt && ./scripts/build/reload-packages`"
-            [ "fqn", fqn ]
+      let gen = currentGeneration ()
+      if gen = cachedGen then
+        cached
+      else
+
+        let fqn = $"""type/{String.concat "." modules}.{name}"""
+        let h = getHashes ()
+        match Map.tryFind fqn h with
+        | Some hash ->
+          _lookup <- _lookup |> Map.add (modules, name) hash
+          cachedGen <- gen
+          cached <- hash
+          hash
+        | None ->
+          if Map.isEmpty h then
+            "" // Hash file not yet populated (CI before reload-packages)
+          else
+            // Non-empty hash file that doesn't know this ref means the file is stale, which happens
+            // whenever a ref is added (or an older binary regenerates the file in-place -- `growIfNeeded`
+            // rewrites it, so running a previous release inside the source tree is enough). The fix is
+            // always the same, so say it rather than making the next person find it in AGENTS.md.
+            Exception.raiseInternal
+              "PackageRefs: type hash not found. The hash file is stale; regenerate it with `> backend/src/LibExecution/package-ref-hashes.txt && ./scripts/build/reload-packages`"
+              [ "fqn", fqn ]
 
   // Darklang.Sync.* — internal sync machinery (op-log wire types)
   module Sync =
@@ -444,20 +471,31 @@ module Fn =
   /// Returns "" if the hash file is empty (CI before reload-packages).
   let private p modules name : (unit -> string) =
     _lookup <- _lookup |> Map.add (modules, name) ""
+    // Resolved once per hash generation; see the note on the type-ref version above.
+    let mutable cachedGen = -1
+    let mutable cached = ""
+
     fun () ->
-      let fqn = $"""fn/{String.concat "." modules}.{name}"""
-      let h = getHashes ()
-      match Map.tryFind fqn h with
-      | Some hash ->
-        _lookup <- _lookup |> Map.add (modules, name) hash
-        hash
-      | None ->
-        if Map.isEmpty h then
-          "" // Hash file not yet populated (CI before reload-packages)
-        else
-          Exception.raiseInternal
-            "PackageRefs: fn hash not found. The hash file is stale; regenerate it with `> backend/src/LibExecution/package-ref-hashes.txt && ./scripts/build/reload-packages`"
-            [ "fqn", fqn ]
+      let gen = currentGeneration ()
+      if gen = cachedGen then
+        cached
+      else
+
+        let fqn = $"""fn/{String.concat "." modules}.{name}"""
+        let h = getHashes ()
+        match Map.tryFind fqn h with
+        | Some hash ->
+          _lookup <- _lookup |> Map.add (modules, name) hash
+          cachedGen <- gen
+          cached <- hash
+          hash
+        | None ->
+          if Map.isEmpty h then
+            "" // Hash file not yet populated (CI before reload-packages)
+          else
+            Exception.raiseInternal
+              "PackageRefs: fn hash not found. The hash file is stale; regenerate it with `> backend/src/LibExecution/package-ref-hashes.txt && ./scripts/build/reload-packages`"
+              [ "fqn", fqn ]
 
   module Stdlib =
     let private p addl = p ("Stdlib" :: addl)

--- a/backend/src/LibExecution/RuntimeTypes.fs
+++ b/backend/src/LibExecution/RuntimeTypes.fs
@@ -2387,6 +2387,12 @@ type InterpreterStats =
     allocByOpcode : int64[]
     countByOpcode : int64[]
 
+    /// For the opcodes the drain tries to run synchronously: how often the builder's `Ply` was
+    /// already complete, and how often it wasn't. Without the denominator a fast path that never
+    /// fires and a fast path that fires and saves little are the same number.
+    syncHitByOpcode : int64[]
+    syncMissByOpcode : int64[]
+
     /// Total register slots allocated across every frame pushed. Each frame gets its own
     /// `Array.zeroCreate registerCount`, so this times 8 bytes is the register-file share of Apply's
     /// allocation -- the leading suspect for its ~5.6 KB per call.
@@ -2446,6 +2452,8 @@ type InterpreterStats =
         packageFnCounts = Dictionary()
         framePushTimestamps = Dictionary()
         allocByOpcode = Array.zeroCreate 32
+        syncHitByOpcode = Array.zeroCreate 32
+        syncMissByOpcode = Array.zeroCreate 32
         countByOpcode = Array.zeroCreate 32
         registersAllocated = 0L
         builtinBodyAlloc = 0L
@@ -2479,6 +2487,8 @@ type InterpreterStats =
     System.Array.Clear(this.allocByStage, 0, this.allocByStage.Length)
     System.Array.Clear(this.countByStage, 0, this.countByStage.Length)
     System.Array.Clear(this.allocByOpcode, 0, this.allocByOpcode.Length)
+    System.Array.Clear(this.syncHitByOpcode, 0, this.syncHitByOpcode.Length)
+    System.Array.Clear(this.syncMissByOpcode, 0, this.syncMissByOpcode.Length)
     System.Array.Clear(this.countByOpcode, 0, this.countByOpcode.Length)
 
   member private this.addTiming

--- a/backend/src/LibExecution/TypeChecker.fs
+++ b/backend/src/LibExecution/TypeChecker.fs
@@ -228,13 +228,20 @@ and private unifyTypeArgsSyncVT
   (declared : List<TypeReference>)
   (actual : List<ValueType>)
   : SyncUnification =
-  match declared, actual with
-  | [], [] -> Unified tst
-  | d :: dRest, a :: aRest ->
-    match unifyValueTypeSync tst d a with
-    | Unified tst -> unifyTypeArgsSyncVT tst dRest aRest
-    | other -> other
-  | _ -> Undecided
+  // Nested matches, not `match declared, actual with`: the tuple form allocates the pair, once per
+  // type argument on the path every parameterised value takes.
+  match declared with
+  | [] ->
+    match actual with
+    | [] -> Unified tst
+    | _ -> Undecided
+  | d :: dRest ->
+    match actual with
+    | [] -> Undecided
+    | a :: aRest ->
+      match unifyValueTypeSync tst d a with
+      | Unified tst -> unifyTypeArgsSyncVT tst dRest aRest
+      | other -> other
 
 
 /// Alias unwrapping without a CE. Only a resolved custom type can be an alias, and only that case needs
@@ -712,25 +719,58 @@ let checkFnResult
 ///
 /// Doing this at-construction is important to ensure efficient run-time type-checking.
 module DvalCreator =
+  /// Merge each element's type into the list's, accumulating in reverse. A top-level recursion
+  /// rather than a fold over a tuple: the lambda would be a closure and the accumulator a tuple,
+  /// both allocated per element.
+  let rec private listElements
+    (threadID : ThreadID)
+    (i : int)
+    (typ : ValueType)
+    (acc : List<Dval>)
+    (remaining : List<Dval>)
+    : struct (ValueType * List<Dval>) =
+    match remaining with
+    | [] -> struct (typ, acc)
+    | dv :: rest ->
+      let dvalType = Dval.toValueType dv
+
+      match VT.merge typ dvalType with
+      | Ok newType -> listElements threadID (i + 1) newType (dv :: acc) rest
+      | Error() ->
+        RTE.Lists.Error.TriedToAddMismatchedData(i, typ, dvalType, dv)
+        |> RTE.Error.List
+        |> raiseRTE threadID
+
+  /// The same, for a dict's entries.
+  let rec private dictEntries
+    (threadID : ThreadID)
+    (typ : ValueType)
+    (acc : DvalMap)
+    (remaining : List<string * Dval>)
+    : struct (ValueType * DvalMap) =
+    match remaining with
+    | [] -> struct (typ, acc)
+    | (k, v) :: rest ->
+      if Map.containsKey k acc then
+        RTE.Dicts.Error.TriedToAddKeyAfterAlreadyPresent k
+        |> RTE.Error.Dict
+        |> raiseRTE threadID
+
+      let vt = Dval.toValueType v
+
+      match VT.merge typ vt with
+      | Ok merged -> dictEntries threadID merged (Map.add k v acc) rest
+      | Error() ->
+        RTE.Dicts.Error.TriedToAddMismatchedData(k, typ, vt, v)
+        |> RTE.Error.Dict
+        |> raiseRTE threadID
+
   // CLEANUP consider skipping type-checking after N elements or after the type args are fully resolved, whichever comes last.
   //   In order to support this^, add another param or two so that direct [] interpretation is differentiated from calls to this from Builtins and other places.
   //   (or split this into 2 separate fns with clearer names)
   let list (threadID : ThreadID) (typ : ValueType) (items : List<Dval>) : Dval =
-    let (typ, items) =
-      items
-      |> List.foldWithIndex
-        (fun i (typ, list) dv ->
-          let dvalType = Dval.toValueType dv
-
-          match VT.merge typ dvalType with
-          | Ok newType -> newType, dv :: list
-          | Error() ->
-            RTE.Lists.Error.TriedToAddMismatchedData(i, typ, dvalType, dv)
-            |> RTE.Error.List
-            |> raiseRTE threadID)
-        (typ, [])
-
-    DList(typ, List.rev items)
+    let struct (typ, reversed) = listElements threadID 0 typ [] items
+    DList(typ, List.rev reversed)
 
 
   // CLEANUP see notes in `list` above
@@ -739,36 +779,17 @@ module DvalCreator =
     (typ : ValueType)
     (entries : List<string * Dval>)
     : Dval =
-    let (typ, entries) =
-      List.fold
-        (fun (typ, entries) (k, v) ->
-          if Map.containsKey k entries then
-            RTE.Dicts.Error.TriedToAddKeyAfterAlreadyPresent k
-            |> RTE.Error.Dict
-            |> raiseRTE threadID
-
-          let vt = Dval.toValueType v
-
-          match VT.merge typ vt with
-          | Ok merged -> (merged, Map.add k v entries)
-          | Error() ->
-            RTE.Dicts.Error.TriedToAddMismatchedData(k, typ, vt, v)
-            |> RTE.Error.Dict
-            |> raiseRTE threadID)
-
-        (typ, Map.empty)
-        entries
-
+    let struct (typ, entries) = dictEntries threadID typ Map.empty entries
     DDict(typ, entries)
 
   let dictAddEntry
     (threadID : ThreadID)
     (typ : ValueType)
     (entries : DvalMap)
-    (newEntry : string * Dval)
+    (k : string)
+    (v : Dval)
     (overwrite : OverwriteBehaviour)
-    : ValueType * DvalMap =
-    let (k, v) = newEntry
+    : struct (ValueType * DvalMap) =
     match overwrite with
     | ThrowIfDuplicate when Map.containsKey k entries ->
       RTE.Dicts.Error.TriedToAddKeyAfterAlreadyPresent k
@@ -778,7 +799,7 @@ module DvalCreator =
     | ThrowIfDuplicate ->
       let vt = Dval.toValueType v
       match VT.merge typ vt with
-      | Ok merged -> (merged, Map.add k v entries)
+      | Ok merged -> struct (merged, Map.add k v entries)
       | Error() ->
         RTE.Dicts.Error.TriedToAddMismatchedData(k, typ, vt, v)
         |> RTE.Error.Dict
@@ -864,33 +885,90 @@ module DvalCreator =
       | Error dv -> error threadID okType errorType dv
 
 
+  /// Narrow a resolved definition to an enum's cases. Top-level so neither path allocates a closure.
+  let private enumCasesOf
+    (typeName : FQTypeName.FQTypeName)
+    (resolvedName : FQTypeName.FQTypeName)
+    (typeArgs : List<string * ValueType>)
+    (definition : TypeDeclaration.Definition)
+    : struct (FQTypeName.FQTypeName *
+      List<string * ValueType> *
+      NEList<TypeDeclaration.EnumCase>)
+    =
+    match definition with
+    | TypeDeclaration.Enum cases -> struct (resolvedName, typeArgs, cases)
+    | _ ->
+      Exception.raiseInternal
+        "Expected enum type but found other type"
+        [ "typeName", typeName ]
+
+  /// Narrow a resolved definition to a record's fields. Top-level, as above.
+  let private recordFieldsOf
+    (threadID : ThreadID)
+    (typeName : FQTypeName.FQTypeName)
+    (resolvedName : FQTypeName.FQTypeName)
+    (typeArgs : List<string * ValueType>)
+    (definition : TypeDeclaration.Definition)
+    : struct (FQTypeName.FQTypeName *
+      List<string * ValueType> *
+      NEList<TypeDeclaration.RecordField>)
+    =
+    match definition with
+    | TypeDeclaration.Record fields -> struct (resolvedName, typeArgs, fields)
+    | _ ->
+      RTE.Records.CreationTypeNotRecord typeName |> RTE.Record |> raiseRTE threadID
+
   let resolveEnumType
     (types : Types)
     (threadID : ThreadID)
     (typeName : FQTypeName.FQTypeName)
     (typeArgs : List<ValueType>)
-    : Ply<FQTypeName.FQTypeName *
+    : Ply<struct (FQTypeName.FQTypeName *
       List<string * ValueType> *
-      NEList<TypeDeclaration.EnumCase>>
+      NEList<TypeDeclaration.EnumCase>)>
     =
-    uply {
-      let! (resolvedName, typeArgs, definition) =
-        resolveType types threadID TST.empty typeName typeArgs
+    let resolved = resolveType types threadID TST.empty typeName typeArgs
 
-      match definition with
-      | TypeDeclaration.Enum cases -> return (resolvedName, typeArgs, cases)
-      | _ ->
-        return
-          Exception.raiseInternal
-            "Expected enum type but found other type"
-            [ "typeName", typeName ]
-    }
+    match Ply.trySync resolved with
+    | ValueSome(resolvedName, typeArgs, definition) ->
+      Ply(enumCasesOf typeName resolvedName typeArgs definition)
+    | ValueNone ->
+      uply {
+        let! (resolvedName, typeArgs, definition) = resolved
+        return enumCasesOf typeName resolvedName typeArgs definition
+      }
 
 
 
   /// One field of an enum case being constructed. Same shape as `checkRecordFields`, and the same
   /// reason for existing: as a lambda over a three-element accumulator this costs a closure, a state
   /// machine and a tuple per field of every enum built.
+  /// The type-argument walk from the checked-field slow path, without the builder.
+  ///
+  /// `ValueNone` when a merge fails, so the caller falls through to the asynchronous path and the
+  /// error message is built in one place rather than two.
+  let rec private updateTypeArgsSync
+    (newTST : TypeSymbolTable)
+    (acc : List<string * ValueType>)
+    (typeArgs : List<string * ValueType>)
+    : List<string * ValueType> voption =
+    match typeArgs with
+    | [] -> ValueSome(List.rev acc)
+    | (paramName, vt) :: rest ->
+      match vt with
+      | ValueType.Unknown ->
+        let bound =
+          match TST.tryFind paramName newTST with
+          | ValueSome known -> (paramName, known)
+          | ValueNone -> (paramName, vt)
+        updateTypeArgsSync newTST (bound :: acc) rest
+
+      | known ->
+        match ValueType.merge known vt with
+        | Ok merged -> updateTypeArgsSync newTST ((paramName, merged) :: acc) rest
+        | Error() -> ValueNone
+
+
   let rec private checkEnumFields
     (types : Types)
     (threadID : ThreadID)
@@ -900,89 +978,216 @@ module DvalCreator =
     (typeArgs : List<string * ValueType>)
     (fieldsInReverse : List<Dval>)
     (tst : TypeSymbolTable)
-    : Ply<List<string * ValueType> * List<Dval> * TypeSymbolTable> =
+    : Ply<struct (List<string * ValueType> * List<Dval> * TypeSymbolTable)> =
     match remaining with
-    | [] -> Ply((typeArgs, fieldsInReverse, tst))
+    | [] -> Ply(struct (typeArgs, fieldsInReverse, tst))
     | (fieldDef, actualField) :: rest ->
       // Same fast path as `checkRecordFields`: most fields unify without needing the type store, a
       // case with no type parameters has nothing to learn from them, and Ply's builder is not
       // resumable code, so entering it costs a continuation in Release as much as in Debug.
+      // Parameterised types take this path too, which matters because `Option` and `Result` are
+      // the language's two most common. The type-argument walk is synchronous apart from building
+      // an error message, so only a genuine failure falls through to the builder.
       match tryUnifySync tst fieldDef actualField with
-      | ValueSome newTST when List.isEmpty typeArgs ->
-        checkEnumFields
+      | ValueSome newTST ->
+        let updated =
+          if List.isEmpty typeArgs then
+            ValueSome typeArgs
+          else
+            updateTypeArgsSync newTST [] typeArgs
+
+        match updated with
+        | ValueSome newTypeArgs ->
+          checkEnumFields
+            types
+            threadID
+            caseName
+            (fieldIndex + 1)
+            rest
+            newTypeArgs
+            (actualField :: fieldsInReverse)
+            newTST
+        | ValueNone ->
+          checkEnumFieldsSlow
+            types
+            threadID
+            caseName
+            fieldIndex
+            remaining
+            typeArgs
+            fieldsInReverse
+            tst
+
+      | _ ->
+        checkEnumFieldsSlow
           types
           threadID
           caseName
-          (fieldIndex + 1)
-          rest
+          fieldIndex
+          remaining
           typeArgs
-          (actualField :: fieldsInReverse)
-          newTST
-      | _ ->
+          fieldsInReverse
+          tst
 
-        uply {
-          match! unify types tst fieldDef actualField with
-          | Error _path ->
-            // Resolved here rather than before the check that almost always passes: it only exists
-            // to describe the failure.
-            let! expected = TypeReference.toVT types tst fieldDef
-            return
-              RTE.Enums.ConstructionFieldOfWrongType(
-                caseName,
-                fieldIndex,
-                expected,
-                Dval.toValueType actualField,
-                actualField
-              )
-              |> RTE.Error.Enum
-              |> raiseRTE threadID
+  /// The part of a field check that genuinely needs the type store, or that failed the synchronous
+  /// unification. Split out so both fall-through points share one implementation rather than the
+  /// body being duplicated.
+  and private checkEnumFieldsSlow
+    (types : Types)
+    (threadID : ThreadID)
+    (caseName : string)
+    (fieldIndex : int)
+    (remaining : List<TypeReference * Dval>)
+    (typeArgs : List<string * ValueType>)
+    (fieldsInReverse : List<Dval>)
+    (tst : TypeSymbolTable)
+    : Ply<struct (List<string * ValueType> * List<Dval> * TypeSymbolTable)> =
+    match remaining with
+    | [] -> Ply(struct (typeArgs, fieldsInReverse, tst))
+    | (fieldDef, actualField) :: rest ->
 
-          | Ok newTST ->
-            // A type with no parameters has nothing to learn from its fields, and that's the common
-            // case. Skipping the walk skips a rebuilt list of pairs and a builder entry per field.
-            let! newTypeArgs =
-              if List.isEmpty typeArgs then
-                Ply typeArgs
-              else
-                Ply.List.mapSequentially
-                  (fun (paramName, vt) ->
-                    match vt with
-                    | ValueType.Unknown ->
-                      match TST.tryFind paramName newTST with
-                      | ValueSome known -> Ply((paramName, known))
-                      | ValueNone -> Ply((paramName, vt))
+      uply {
+        match! unify types tst fieldDef actualField with
+        | Error _path ->
+          // Resolved here rather than before the check that almost always passes: it only exists
+          // to describe the failure.
+          let! expected = TypeReference.toVT types tst fieldDef
+          return
+            RTE.Enums.ConstructionFieldOfWrongType(
+              caseName,
+              fieldIndex,
+              expected,
+              Dval.toValueType actualField,
+              actualField
+            )
+            |> RTE.Error.Enum
+            |> raiseRTE threadID
 
-                    | known ->
-                      match ValueType.merge known vt with
-                      | Ok merged -> Ply((paramName, merged))
-                      | Error() ->
-                        uply {
-                          let! expected = TypeReference.toVT types tst fieldDef
-                          return
-                            RTE.Enums.ConstructionFieldOfWrongType(
-                              caseName,
-                              fieldIndex,
-                              expected,
-                              Dval.toValueType actualField,
-                              actualField
-                            )
-                            |> RTE.Enum
-                            |> raiseRTE threadID
-                        })
-                  typeArgs
+        | Ok newTST ->
+          // A type with no parameters has nothing to learn from its fields, and that's the common
+          // case. Skipping the walk skips a rebuilt list of pairs and a builder entry per field.
+          let! newTypeArgs =
+            if List.isEmpty typeArgs then
+              Ply typeArgs
+            else
+              Ply.List.mapSequentially
+                (fun (paramName, vt) ->
+                  match vt with
+                  | ValueType.Unknown ->
+                    match TST.tryFind paramName newTST with
+                    | ValueSome known -> Ply((paramName, known))
+                    | ValueNone -> Ply((paramName, vt))
 
-            return!
-              checkEnumFields
-                types
-                threadID
-                caseName
-                (fieldIndex + 1)
-                rest
-                newTypeArgs
-                (actualField :: fieldsInReverse)
-                newTST
-        }
+                  | known ->
+                    match ValueType.merge known vt with
+                    | Ok merged -> Ply((paramName, merged))
+                    | Error() ->
+                      uply {
+                        let! expected = TypeReference.toVT types tst fieldDef
+                        return
+                          RTE.Enums.ConstructionFieldOfWrongType(
+                            caseName,
+                            fieldIndex,
+                            expected,
+                            Dval.toValueType actualField,
+                            actualField
+                          )
+                          |> RTE.Enum
+                          |> raiseRTE threadID
+                      })
+                typeArgs
 
+          return!
+            checkEnumFields
+              types
+              threadID
+              caseName
+              (fieldIndex + 1)
+              rest
+              newTypeArgs
+              (actualField :: fieldsInReverse)
+              newTST
+      }
+
+
+  /// Bind the resolved type arguments into the symbol table, find the named case, and pair its
+  /// declared field types with the values given. Raises on an unknown case or the wrong arity, so
+  /// both of `enum`'s paths report those identically.
+  let private enumCaseFields
+    (threadID : ThreadID)
+    (tst : TypeSymbolTable)
+    (resolvedTypeName : FQTypeName.FQTypeName)
+    (typeArgs : List<string * ValueType>)
+    (caseDefs : NEList<TypeDeclaration.EnumCase>)
+    (caseName : string)
+    (fields : List<Dval>)
+    : struct (TypeSymbolTable * List<TypeReference * Dval>) =
+    let tst = typeArgs |> List.fold (fun acc (name, vt) -> TST.add name vt acc) tst
+
+    match caseDefs |> NEList.find (fun c -> c.name = caseName) with
+    | None ->
+      RTE.Enums.ConstructionCaseNotFound(resolvedTypeName, caseName)
+      |> RTE.Error.Enum
+      |> raiseRTE threadID
+
+    | Some case ->
+      let expected, actual = (List.length case.fields, List.length fields)
+
+      if expected <> actual then
+        RTE.Enums.ConstructionWrongNumberOfFields(
+          resolvedTypeName,
+          caseName,
+          expected,
+          actual
+        )
+        |> RTE.Error.Enum
+        |> raiseRTE threadID
+      else
+        struct (tst, List.zip case.fields fields)
+
+  /// The half of enum construction after the type is known. A top-level function taking everything
+  /// explicitly, not a local one: a local closing over `types` and friends is a closure allocated on
+  /// every construction, which is what it cost when it was written that way.
+  let private enumAfterResolve
+    (types : Types)
+    (threadID : ThreadID)
+    (tst : TypeSymbolTable)
+    (sourceTypeName : FQTypeName.FQTypeName)
+    (caseName : string)
+    (fields : List<Dval>)
+    (resolvedTypeName : FQTypeName.FQTypeName)
+    (typeArgs : List<string * ValueType>)
+    (caseDefs : NEList<TypeDeclaration.EnumCase>)
+    : Ply<Dval> =
+    let struct (tst, fieldsZipped) =
+      enumCaseFields threadID tst resolvedTypeName typeArgs caseDefs caseName fields
+
+    let checked' =
+      checkEnumFields types threadID caseName 0 fieldsZipped typeArgs [] tst
+
+    match Ply.trySync checked' with
+    | ValueSome(struct (typeArgs, fieldsInReverse, _updatedTst)) ->
+      Ply(
+        DEnum(
+          sourceTypeName,
+          resolvedTypeName,
+          typeArgs |> List.map Tuple2.second,
+          caseName,
+          List.rev fieldsInReverse
+        )
+      )
+    | ValueNone ->
+      uply {
+        let! struct (typeArgs, fieldsInReverse, _updatedTst) = checked'
+        return
+          DEnum(
+            sourceTypeName,
+            resolvedTypeName,
+            typeArgs |> List.map Tuple2.second,
+            caseName,
+            List.rev fieldsInReverse
+          )
+      }
 
   let enum
     (types : Types)
@@ -993,48 +1198,39 @@ module DvalCreator =
     (caseName : string)
     (fields : List<Dval>)
     : Ply<Dval> =
-    uply {
-      // do basic resolution of aliases and type args
-      let! (resolvedTypeName, typeArgs, caseDefs) =
-        resolveEnumType types threadID sourceTypeName typeArgs
+    // Both lookups are usually already complete: the type cache is warm and most fields unify
+    // without the store. Reading them with `trySync` keeps the whole construction out of a builder,
+    // which is worth doing here because every enum in the language comes through this function.
+    // The slow path awaits the very same `Ply` rather than recomputing it.
+    let resolved = resolveEnumType types threadID sourceTypeName typeArgs
 
-      let tst = typeArgs |> List.fold (fun acc (name, vt) -> TST.add name vt acc) tst
-
-      // Find the case definition
-      let foundCaseDef = caseDefs |> NEList.find (fun c -> c.name = caseName)
-
-      match foundCaseDef with
-      | None ->
-        return
-          RTE.Enums.ConstructionCaseNotFound(resolvedTypeName, caseName)
-          |> RTE.Error.Enum
-          |> raiseRTE threadID
-
-      | Some case ->
-        // Zip the fields, if we got the right # of them
-        let fieldsZipped =
-          let expected, actual = (List.length case.fields, List.length fields)
-
-          if expected <> actual then
-            RTE.Enums.ConstructionWrongNumberOfFields(
-              resolvedTypeName,
-              caseName,
-              expected,
-              actual
-            )
-            |> RTE.Error.Enum
-            |> raiseRTE threadID
-          else
-            List.zip case.fields fields
-
-        // Process each field, updating type args as we learn more
-        let! (typeArgs, fieldsInReverse, _updatedTst) =
-          checkEnumFields types threadID caseName 0 fieldsZipped typeArgs [] tst
-
-        let typeArgs = typeArgs |> List.map Tuple2.second
-        let fields = List.rev fieldsInReverse
-        return DEnum(sourceTypeName, resolvedTypeName, typeArgs, caseName, fields)
-    }
+    match Ply.trySync resolved with
+    | ValueSome(struct (resolvedTypeName, typeArgs, caseDefs)) ->
+      enumAfterResolve
+        types
+        threadID
+        tst
+        sourceTypeName
+        caseName
+        fields
+        resolvedTypeName
+        typeArgs
+        caseDefs
+    | ValueNone ->
+      uply {
+        let! struct (resolvedTypeName, typeArgs, caseDefs) = resolved
+        return!
+          enumAfterResolve
+            types
+            threadID
+            tst
+            sourceTypeName
+            caseName
+            fields
+            resolvedTypeName
+            typeArgs
+            caseDefs
+      }
 
 
   // Resolve aliases and collect expected fields for a record type
@@ -1043,22 +1239,20 @@ module DvalCreator =
     (threadID : ThreadID)
     (typeName : FQTypeName.FQTypeName)
     (typeArgs : List<ValueType>)
-    : Ply<FQTypeName.FQTypeName *
+    : Ply<struct (FQTypeName.FQTypeName *
       List<string * ValueType> *
-      NEList<TypeDeclaration.RecordField>>
+      NEList<TypeDeclaration.RecordField>)>
     =
-    uply {
-      let! (resolvedName, typeArgs, definition) =
-        resolveType types threadID TST.empty typeName typeArgs
+    let resolved = resolveType types threadID TST.empty typeName typeArgs
 
-      match definition with
-      | TypeDeclaration.Record fields -> return (resolvedName, typeArgs, fields)
-      | _ ->
-        return
-          RTE.Records.CreationTypeNotRecord typeName
-          |> RTE.Record
-          |> raiseRTE threadID
-    }
+    match Ply.trySync resolved with
+    | ValueSome(resolvedName, typeArgs, definition) ->
+      Ply(recordFieldsOf threadID typeName resolvedName typeArgs definition)
+    | ValueNone ->
+      uply {
+        let! (resolvedName, typeArgs, definition) = resolved
+        return recordFieldsOf threadID typeName resolvedName typeArgs definition
+      }
 
 
 
@@ -1098,9 +1292,9 @@ module DvalCreator =
     (fieldsSoFar : Map<string, Dval>)
     (currentTypeArgs : List<string * ValueType>)
     (tst : TypeSymbolTable)
-    : Ply<Map<string, Dval> * List<string * ValueType> * TypeSymbolTable> =
+    : Ply<struct (Map<string, Dval> * List<string * ValueType> * TypeSymbolTable)> =
     match remaining with
-    | [] -> Ply((fieldsSoFar, currentTypeArgs, tst))
+    | [] -> Ply(struct (fieldsSoFar, currentTypeArgs, tst))
     | (fieldName, fieldValue) :: rest ->
       // The validations and the lookup are synchronous, so they happen before the builder rather
       // than inside it.
@@ -1123,17 +1317,31 @@ module DvalCreator =
         // no parameters has nothing to learn from them. When both hold, the whole field is handled
         // without entering the Ply builder at all -- which matters because Ply's builder is not
         // resumable code, so it allocates a continuation in Release just as much as in Debug.
-        match tryUnifySync tst fieldDef.typ fieldValue with
-        | ValueSome newTST when List.isEmpty currentTypeArgs ->
+        // A struct option of a struct tuple, so the fast path allocates nothing to report itself.
+        let fast =
+          match tryUnifySync tst fieldDef.typ fieldValue with
+          | ValueNone -> ValueNone
+          | ValueSome newTST ->
+            if List.isEmpty currentTypeArgs then
+              ValueSome(struct (currentTypeArgs, newTST))
+            else
+              // Synchronous apart from building an error message, so a parameterised type need
+              // not enter the builder; only a genuine merge failure falls through.
+              match updateTypeArgsSync newTST [] currentTypeArgs with
+              | ValueSome updated -> ValueSome(struct (updated, newTST))
+              | ValueNone -> ValueNone
+
+        match fast with
+        | ValueSome(struct (newTypeArgs, newTST)) ->
           checkRecordFields
             types
             threadID
             expectedFields
             rest
             (Map.add fieldName fieldValue fieldsSoFar)
-            currentTypeArgs
+            newTypeArgs
             newTST
-        | _ ->
+        | ValueNone ->
 
           uply {
             match! unify types tst fieldDef.typ fieldValue with
@@ -1197,9 +1405,205 @@ module DvalCreator =
           }
 
 
+  /// One field of a record being updated. Same shape and the same reason for existing as
+  /// `checkRecordFields`: as a lambda over a three-element accumulator it costs a closure, a state
+  /// machine and a tuple per field of every record update.
+  ///
+  /// Updates differ from construction in their error cases -- an update may not name a field the
+  /// type doesn't have, but it may legitimately leave fields alone -- so the messages differ and
+  /// the two cannot share a body.
+  let rec private updateRecordFields
+    (types : Types)
+    (threadID : ThreadID)
+    (expectedFields : NEList<TypeDeclaration.RecordField>)
+    (remaining : List<string * Dval>)
+    (fieldsSoFar : Map<string, Dval>)
+    (currentTypeArgs : List<string * ValueType>)
+    (tst : TypeSymbolTable)
+    : Ply<struct (Map<string, Dval> * List<string * ValueType> * TypeSymbolTable)> =
+    match remaining with
+    | [] -> Ply(struct (fieldsSoFar, currentTypeArgs, tst))
+    | (fieldName, fieldValue) :: rest ->
+      // Synchronous validations happen before the builder rather than inside it.
+      if fieldName = "" then
+        RTE.Records.UpdateEmptyKey |> RTE.Record |> raiseRTE threadID
+
+      // CLEANUP duplicate updates for the same field should raise `UpdateDuplicateField`
+
+      match findExpectedField expectedFields fieldName with
+      | ValueNone ->
+        RTE.Records.UpdateFieldNotExpected fieldName
+        |> RTE.Record
+        |> raiseRTE threadID
+
+      | ValueSome fieldDef ->
+        // The common case: the field unifies without the type store and the type has no parameters
+        // to learn anything from, so the whole field is handled without entering the Ply builder.
+        // A struct option of a struct tuple, so the fast path allocates nothing to report itself.
+        let fast =
+          match tryUnifySync tst fieldDef.typ fieldValue with
+          | ValueNone -> ValueNone
+          | ValueSome newTST ->
+            if List.isEmpty currentTypeArgs then
+              ValueSome(struct (currentTypeArgs, newTST))
+            else
+              // Parameterised types used to fail this gate outright and take the builder. The
+              // type-argument walk is synchronous apart from building an error message, so it runs
+              // here and only a genuine merge failure falls through.
+              match updateTypeArgsSync newTST [] currentTypeArgs with
+              | ValueSome updated -> ValueSome(struct (updated, newTST))
+              | ValueNone -> ValueNone
+
+        match fast with
+        | ValueSome(struct (newTypeArgs, newTST)) ->
+          updateRecordFields
+            types
+            threadID
+            expectedFields
+            rest
+            (Map.add fieldName fieldValue fieldsSoFar)
+            newTypeArgs
+            newTST
+        | ValueNone ->
+
+          uply {
+            match! unify types tst fieldDef.typ fieldValue with
+            | Error _path ->
+              // CLEANUP involve path, somehow
+              // Resolved here rather than before the check that almost always passes.
+              let! expected = TypeReference.toVT types tst fieldDef.typ
+              return
+                RTE.Records.UpdateFieldOfWrongType(
+                  fieldName,
+                  expected,
+                  Dval.toValueType fieldValue,
+                  fieldValue
+                )
+                |> RTE.Record
+                |> raiseRTE threadID
+
+            | Ok newTST ->
+              // No type parameters means nothing to learn, and no walk.
+              let! newTypeArgs =
+                if List.isEmpty currentTypeArgs then
+                  Ply currentTypeArgs
+                else
+                  Ply.List.mapSequentially
+                    (fun (paramName, vt) ->
+                      match vt with
+                      | ValueType.Unknown ->
+                        match TST.tryFind paramName newTST with
+                        | ValueSome known -> Ply((paramName, known))
+                        | ValueNone -> Ply((paramName, vt))
+
+                      | known ->
+                        match ValueType.merge known vt with
+                        | Ok merged -> Ply((paramName, merged))
+                        | Error() ->
+                          uply {
+                            let! expected =
+                              TypeReference.toVT types newTST fieldDef.typ
+                            return
+                              RTE.Records.UpdateFieldOfWrongType(
+                                fieldName,
+                                expected,
+                                Dval.toValueType fieldValue,
+                                fieldValue
+                              )
+                              |> RTE.Record
+                              |> raiseRTE threadID
+                          })
+                    currentTypeArgs
+
+              return!
+                updateRecordFields
+                  types
+                  threadID
+                  expectedFields
+                  rest
+                  (Map.add fieldName fieldValue fieldsSoFar)
+                  newTypeArgs
+                  newTST
+          }
+
+
   /// Constructs a Dval.DRecord, ensuring that the fields match the expected shape
   ///
   /// note: if provided, the typeArgs must match the # of typeArgs expected by the type
+  /// Reject a record that is missing a declared field, or build it. Top-level, as above.
+  let private finishRecord
+    (threadID : ThreadID)
+    (sourceTypeName : FQTypeName.FQTypeName)
+    (resolvedTypeName : FQTypeName.FQTypeName)
+    (expectedFields : NEList<TypeDeclaration.RecordField>)
+    (processedFields : Map<string, Dval>)
+    (finalTypeArgs : List<string * ValueType>)
+    : Dval =
+    match
+      expectedFields
+      |> NEList.find (fun f -> not (Map.containsKey f.name processedFields))
+    with
+    | Some missingField ->
+      RTE.Records.CreationMissingField missingField.name
+      |> RTE.Record
+      |> raiseRTE threadID
+    | None ->
+      DRecord(
+        sourceTypeName,
+        resolvedTypeName,
+        finalTypeArgs |> List.map Tuple2.second,
+        processedFields
+      )
+
+  /// The half of record construction after the type is known. Top-level, taking everything
+  /// explicitly, for the same reason as `enumAfterResolve`.
+  let private recordAfterResolve
+    (types : Types)
+    (threadID : ThreadID)
+    (tst : TypeSymbolTable)
+    (sourceTypeName : FQTypeName.FQTypeName)
+    (fields : List<string * Dval>)
+    (resolvedTypeName : FQTypeName.FQTypeName)
+    (resolvedTypeArgs : List<string * ValueType>)
+    (expectedFields : NEList<TypeDeclaration.RecordField>)
+    : Ply<Dval> =
+    let tst =
+      resolvedTypeArgs |> List.fold (fun acc (name, vt) -> TST.add name vt acc) tst
+
+    let checked' =
+      checkRecordFields
+        types
+        threadID
+        expectedFields
+        fields
+        Map.empty
+        resolvedTypeArgs
+        tst
+
+    match Ply.trySync checked' with
+    | ValueSome(struct (processedFields, finalTypeArgs, _updatedTST)) ->
+      Ply(
+        finishRecord
+          threadID
+          sourceTypeName
+          resolvedTypeName
+          expectedFields
+          processedFields
+          finalTypeArgs
+      )
+    | ValueNone ->
+      uply {
+        let! struct (processedFields, finalTypeArgs, _updatedTST) = checked'
+        return
+          finishRecord
+            threadID
+            sourceTypeName
+            resolvedTypeName
+            expectedFields
+            processedFields
+            finalTypeArgs
+      }
+
   let record
     (types : Types)
     (threadID : ThreadID)
@@ -1208,48 +1612,90 @@ module DvalCreator =
     (typeArgs : List<ValueType>)
     (fields : List<string * Dval>)
     : Ply<Dval> =
-    uply {
-      let! (resolvedTypeName, resolvedTypeArgs, expectedFields) =
-        resolveRecordType types threadID sourceTypeName typeArgs
+    // Same reasoning as `enum`: the type cache is warm and most fields unify without the store, so
+    // reading both with `trySync` keeps the common construction out of a builder. The slow paths
+    // await the same `Ply`, so each step has one implementation.
+    let resolved = resolveRecordType types threadID sourceTypeName typeArgs
 
-      let tst =
-        resolvedTypeArgs |> List.fold (fun acc (name, vt) -> TST.add name vt acc) tst
-
-      let! (processedFields, finalTypeArgs, _updatedTST) =
-        checkRecordFields
-          types
-          threadID
-          expectedFields
-          fields
-          Map.empty
-          resolvedTypeArgs
-          tst
-
-      // Check for missing fields
-      match
+    match Ply.trySync resolved with
+    | ValueSome(struct (resolvedTypeName, resolvedTypeArgs, expectedFields)) ->
+      recordAfterResolve
+        types
+        threadID
+        tst
+        sourceTypeName
+        fields
+        resolvedTypeName
+        resolvedTypeArgs
         expectedFields
-        |> NEList.find (fun f -> not (Map.containsKey f.name processedFields))
-      with
-      | Some missingField ->
-        return
-          RTE.Records.CreationMissingField missingField.name
-          |> RTE.Record
-          |> raiseRTE threadID
-
-      | None ->
-        return
-          DRecord(
-            sourceTypeName,
-            resolvedTypeName,
-            finalTypeArgs |> List.map Tuple2.second,
-            processedFields
-          )
-    }
+    | ValueNone ->
+      uply {
+        let! struct (resolvedTypeName, resolvedTypeArgs, expectedFields) = resolved
+        return!
+          recordAfterResolve
+            types
+            threadID
+            tst
+            sourceTypeName
+            fields
+            resolvedTypeName
+            resolvedTypeArgs
+            expectedFields
+      }
 
 
   /// Constructs a Dval.DRecord, ensuring that the fields match the expected shape
   ///
   /// note: if provided, the typeArgs must match the # of typeArgs expected by the type
+  /// The half of a record update after the type is known. Top-level, as above.
+  let private recordUpdateAfterResolve
+    (types : Types)
+    (threadID : ThreadID)
+    (tst : TypeSymbolTable)
+    (sourceTypeName : FQTypeName.FQTypeName)
+    (resolvedTypeName : FQTypeName.FQTypeName)
+    (typeArgsBeforeUpdate : List<ValueType>)
+    (currentFields : Map<string, Dval>)
+    (fieldUpdates : List<string * Dval>)
+    (resolvedTypeArgs : List<string * ValueType>)
+    (expectedFields : NEList<TypeDeclaration.RecordField>)
+    : Ply<Dval> =
+    let resolvedTypeArgs =
+      List.zip typeArgsBeforeUpdate resolvedTypeArgs
+      |> List.map (fun (beforeUpdate, (name, _)) -> (name, beforeUpdate))
+
+    let updated =
+      updateRecordFields
+        types
+        threadID
+        expectedFields
+        fieldUpdates
+        currentFields
+        resolvedTypeArgs
+        tst
+
+    match Ply.trySync updated with
+    | ValueSome(struct (updatedFields, finalTypeArgs, _updatedTST)) ->
+      Ply(
+        DRecord(
+          sourceTypeName,
+          resolvedTypeName,
+          finalTypeArgs |> List.map Tuple2.second,
+          updatedFields
+        )
+      )
+    | ValueNone ->
+      uply {
+        let! struct (updatedFields, finalTypeArgs, _updatedTST) = updated
+        return
+          DRecord(
+            sourceTypeName,
+            resolvedTypeName,
+            finalTypeArgs |> List.map Tuple2.second,
+            updatedFields
+          )
+      }
+
   let recordUpdate
     (types : Types)
     (threadID : ThreadID)
@@ -1260,85 +1706,35 @@ module DvalCreator =
     (currentFields : Map<string, Dval>)
     (fieldUpdates : List<string * Dval>)
     : Ply<Dval> =
-    uply {
-      let! (_resolvedTypeName, resolvedTypeArgs, expectedFields) =
-        resolveRecordType types threadID sourceTypeName []
+    // As in `record` and `enum`: stay out of the builder when both lookups are already complete.
+    let resolved = resolveRecordType types threadID sourceTypeName []
 
-      let resolvedTypeArgs =
-        List.zip typeArgsBeforeUpdate resolvedTypeArgs
-        |> List.map (fun (beforeUpdate, (name, _)) -> (name, beforeUpdate))
-
-      let! (updatedFields, finalTypeArgs, _updatedTST) =
-        Ply.List.foldSequentially
-          (fun (fieldsSoFar, currentTypeArgs, tst) (fieldName, fieldValue) ->
-            uply {
-              if fieldName = "" then
-                return RTE.Records.UpdateEmptyKey |> RTE.Record |> raiseRTE threadID
-
-              // CLEANUP if there are duplicate updates for the the same field, raise a `UpdateDuplicateField` RTE
-
-              else
-                match
-                  expectedFields |> NEList.find (fun f -> f.name = fieldName)
-                with
-                | None ->
-                  return
-                    RTE.Records.UpdateFieldNotExpected fieldName
-                    |> RTE.Record
-                    |> raiseRTE threadID
-
-                | Some fieldDef ->
-                  let! expected = TypeReference.toVT types tst fieldDef.typ
-                  match! unify types tst fieldDef.typ fieldValue with
-                  | Error _path ->
-                    // CLEANUP involve path, somehow
-                    return
-                      RTE.Records.UpdateFieldOfWrongType(
-                        fieldName,
-                        expected,
-                        Dval.toValueType fieldValue,
-                        fieldValue
-                      )
-                      |> RTE.Record
-                      |> raiseRTE threadID
-                  | Ok updatedTst ->
-                    let! expected = TypeReference.toVT types updatedTst fieldDef.typ
-
-                    // Update resultant typeArgs based on what we learned from this field
-                    // , by checking the TST.
-                    let newTypeArgs =
-                      currentTypeArgs
-                      |> List.map (fun (paramName, vt) ->
-                        match vt with
-                        | ValueType.Unknown ->
-                          match
-                            TST.tryFind paramName updatedTst
-                            |> ValueOption.toOption
-                          with
-                          | Some known -> (paramName, known)
-                          | None -> (paramName, vt)
-
-                        | known ->
-                          match ValueType.merge known vt with
-                          | Ok merged -> (paramName, merged)
-                          | Error() ->
-                            RTE.Records.UpdateFieldOfWrongType(
-                              fieldName,
-                              expected,
-                              Dval.toValueType fieldValue,
-                              fieldValue
-                            )
-                            |> RTE.Record
-                            |> raiseRTE threadID)
-
-                    let fields = Map.add fieldName fieldValue fieldsSoFar
-
-                    return (fields, newTypeArgs, updatedTst)
-            })
-          (currentFields, resolvedTypeArgs, tst)
-          fieldUpdates
-
-      let finalTypeArgs = finalTypeArgs |> List.map Tuple2.second
-
-      return DRecord(sourceTypeName, resolvedTypeName, finalTypeArgs, updatedFields)
-    }
+    match Ply.trySync resolved with
+    | ValueSome(struct (_resolvedTypeName, resolvedTypeArgs, expectedFields)) ->
+      recordUpdateAfterResolve
+        types
+        threadID
+        tst
+        sourceTypeName
+        resolvedTypeName
+        typeArgsBeforeUpdate
+        currentFields
+        fieldUpdates
+        resolvedTypeArgs
+        expectedFields
+    | ValueNone ->
+      uply {
+        let! struct (_resolvedTypeName, resolvedTypeArgs, expectedFields) = resolved
+        return!
+          recordUpdateAfterResolve
+            types
+            threadID
+            tst
+            sourceTypeName
+            resolvedTypeName
+            typeArgsBeforeUpdate
+            currentFields
+            fieldUpdates
+            resolvedTypeArgs
+            expectedFields
+      }

--- a/backend/src/LibExecution/ValueType.fs
+++ b/backend/src/LibExecution/ValueType.fs
@@ -122,9 +122,11 @@ and merge (left : ValueType) (right : ValueType) : Result<ValueType, unit> =
     Ok left
   else
 
-    match left, right with
-    | ValueType.Unknown, v
-    | v, ValueType.Unknown -> Ok v
-
-    | ValueType.Known left, ValueType.Known right ->
-      mergeKnownTypes left right |> Result.map ValueType.Known
+    // Nested matches, not `match left, right with`: the tuple form allocates the pair, and this
+    // runs once per list element, dict entry and record field.
+    match left with
+    | ValueType.Unknown -> Ok right
+    | ValueType.Known l ->
+      match right with
+      | ValueType.Unknown -> Ok left
+      | ValueType.Known r -> mergeKnownTypes l r |> Result.map ValueType.Known

--- a/docs/perf/history.md
+++ b/docs/perf/history.md
@@ -1,207 +1,102 @@
 # Dark performance: what happened, and the numbers
 
-The durable record of the performance campaigns. Round-by-round numbers, what each round found, and
-the things learned that are worth not re-learning. Working notes for each round have been deleted;
-this is what survived them.
+The durable record. Method is in `docs/perf/playbook.md`, what's next in `docs/perf/roadmap.md`.
 
-Method: `docs/perf/playbook.md`. What's next: `docs/perf/roadmap.md`.
+Rounds: **1** (#5696) and **2** (#5700) were interpreter allocation campaigns, **3** (#5699) was
+NativeAOT, **4** is the current branch.
 
 ---
 
-## The arc
+## This round: parameterised types
 
-The reference workload is `scripts/perf/workloads/steady.dark`: 200 iterations of
-`List.range 1 50 |> List.map (+1) |> List.length`. Whole-process allocation, Debug, unless noted.
+The synchronous fast path from round 2 ran only for types with no type arguments, guarded by
+`List.isEmpty typeArgs` in three places, so it never fired for `Option`, `Result` or any
+parameterised record. Teaching it to handle type arguments is most of the win.
 
-| point | allocation | body time |
-|---|---|---|
-| before round 1 | not instrumented | 2,571 ms |
-| after round 1 (#5696) | 273.1 MB | 391 ms |
-| after round 2 | **8.0 MB** | 342 ms |
-
-Release: **211.99 MB -> 7.6 MB**, and 256 ms -> 177 ms.
-
-Round 3 (NativeAOT) is a separate axis: it doesn't change allocation, it deletes JIT compilation.
-One-shot commands land 4.6-8x faster on top of the above, and the six steady-state workloads come
-out 1.3-2.3x faster as well. Details below.
-
-Per iteration, Release, all three points rebuilt and measured on today's harness. The pre-round-1
-figures needed the commit rebuilt with the allocation reading added and *nothing else*, since the
-telemetry that reports it was added by round 1:
-
-| workload | before round 1 | after round 1 | after round 2 | total |
-|---|---|---|---|---|
-| `recursion` | 13,436 KB | 2,470.6 KB (5.4x) | **0.48 KB** (5,147x) | **27,993x** |
-| `lists` | 3,345 KB | 865.3 KB (3.9x) | **12.0 KB** (72x) | **279x** |
-| `strings` | 684 KB | 191.5 KB (3.6x) | **6.6 KB** (29x) | **104x** |
-| `dicts` | 1,055 KB | 369.2 KB (2.9x) | **15.7 KB** (23.5x) | **67x** |
-| `records` | 202 KB | 62.6 KB (3.2x) | **8.3 KB** (7.5x) | **24x** |
-| `json` | 76 KB | 33.4 KB (2.3x) | **13.0 KB** (2.6x) | **5.8x** |
-
-Time, Release, 200 iterations each. The AOT column is round 3, measured on a published NativeAOT
-binary from the same commit as the R2R one; re-measuring R2R at that commit reproduced the round-2
-column within a few percent, which is what makes the two comparable:
-
-| workload | before round 1 | after round 1 | after round 2 | after AOT | total |
-|---|---|---|---|---|---|
-| `recursion` | 53,389 ms | 616 ms (87x) | 501 ms (1.2x) | **385 ms** (1.3x) | **139x** |
-| `records` | 823 ms | 25 ms (33x) | 16 ms (1.6x) | **9 ms** (1.8x) | **91x** |
-| `strings` | 905 ms | 73 ms (12.4x) | 48 ms (1.5x) | **27 ms** (1.8x) | **34x** |
-| `json` | 242 ms | 17 ms (14.2x) | 13 ms (1.3x) | **6 ms** (2.3x) | **40x** |
-| `lists` | 2,127 ms | 244 ms (8.7x) | 190 ms (1.3x) | **110 ms** (1.8x) | **19x** |
-| `dicts` | 1,073 ms | 143 ms (7.5x) | 103 ms (1.4x) | **72 ms** (1.4x) | **15x** |
-
-Allocation per iteration is unchanged by round 3, within 4% and in both directions: AOT changes
-when code is compiled, not what the interpreter allocates. The allocation table above still stands.
-
-Round 1 took most of the time; round 2 took most of the allocation.
-
-Careful with older documents: round 1's own notes quote the reference workload at 107.1 MB at its
-end, and ~868 MB before it. Those were a *different, lighter* workload, replaced during round 2 when
-the old one stopped being representative. Rebuilt and re-measured at the round-1 merge point,
-today's workload reads 273.1 MB. Only compare numbers produced by the same harness -- which is why
-the table above was re-measured rather than assembled from notes.
-
-Per iteration, against the same program in other runtimes: python 0.47 KB, node 1.70 KB, Dark
-**12.0 KB** -- 7.1x node, from ~700x at the start of round 2.
-
-## Round 0: make the numbers trustworthy
-
-Before any optimisation was allowed, four things had to be true: the measurements had to be
-repeatable, the profiler had to be honest, the store had to be a fixed fixture, and a change had to
-be attributable. Getting there found that the profiler was lying in two separate ways and that
-package changes cannot be A/B tested at all, because `PackageRefs` makes a binary and a store a
-matched pair. That constraint explained a day of confusing results and still holds.
-
-The lasting output is the instrumentation: per-stage allocation counters, per-opcode counters, and
-the telemetry that everything since has been steered by.
-
-## Round 1 (#5696): the first pass through the interpreter
-
-868 -> 273 MB. Dev-time CLI runs ~3.3x faster; per-keystroke typing latency down ~2x.
-
-What it established, and what's still true:
-
-- **The interpreter is allocation-bound**, not compute-bound. That framing drove everything after.
-- **A Dark function call allocated ~8 KB.** Chasing that one number produced most of the round.
-- **Runtime type checking is two jobs wearing one coat**: checking, which could in principle move to
-  compile time, and instantiation, which is load-bearing and has to stay. Ablation put checking at
-  -20% allocation and -14% wall.
-- **NativeAOT is the single biggest available result** and needs no code change, only CI.
-- Five `List` functions were made native, which is why `List.push` is a builtin today.
-- `dark version` makes a network call costing ~700 ms.
-
-Two corrections it made to itself, both worth remembering: an early note claimed a per-region
-allocation figure that later turned out to be measured with brackets spanning awaits (so they
-counted nested execution, not the region), and the "8 KB per call" figure superseded an earlier,
-wrongly-scaled one.
-
-## Round 2: the rewrite, and the course correction
-
-273 -> 8.0 MB Debug, 212 -> 7.6 MB Release. The round-2 PR description has the full write-up,
-including every individual win.
-
-The shape of it: half a round of more-of-round-1 (representation changes, the biggest being the
-interpreter loop moving off Ply onto F#'s resumable-code `task`, worth -51.2 MB on its own), then a
-stop to build proper instruments after returns started diminishing, then a second half driven
-entirely by what those instruments found.
-
-The correction was the important part. Every number in both campaigns had come from one script. When
-six workloads finally existed, **that script turned out to be the second-cheapest of them** -- a
-plain function call cost five times a list iteration, an HTTP request nine times one, and the HTTP
-profile was dominated by type-checker paths the list workload never touched.
-
-## Round 3: NativeAOT
-
-Measured 2026-08-08, against the round-2 merge point. Both binaries built from the same commit, so
-this isolates the publish mode and nothing else. Startup timings are paired A/B through
-`scripts/perf/bench`, interleaved, 9 pairs, and AOT won 9 of 9 on every scenario.
-
-Round 2 shrank the work; this round deletes the JIT that was compiling it. They compose.
-
-### One-shot command latency, Release
-
-| scenario | R2R (ships today) | AOT | reduction |
+| workload | before | after | change |
 |---|---|---|---|
-| `status` | 187 ms | **24 ms** | -86% |
-| `eval-trivial` | 200 ms | **26 ms** | -86% |
-| `help` | 199 ms | **32 ms** | -84% |
-| `eval-map1000` | 253 ms | **40 ms** | -83% |
-| `eval-listheavy` | 286 ms | **62 ms** | -78% |
+| `records` | 8.3 KB | **4.26 KB** | **-48.7%** |
+| `json` | 13.0 KB | **10.00 KB** | **-23.1%** |
+| `dicts` | 15.7 KB | **12.36 KB** | **-21.3%** |
+| `strings` | 6.6 KB | 6.45 KB | -2.3% |
+| `lists` | 12.0 KB | 11.84 KB | -1.3% |
+| `containers` | -- | 3.04 KB | new workload |
 
-The gradient is the point: AOT deletes a fixed cost, so the win shrinks as real interpreter work
-grows. 8x on a command that mostly starts up, 4.6x on one that mostly computes.
+An HTTP request now costs **76.31 KB** at 5,269 req/s, p50 2.21 ms (Release, four client
+processes). Within the branch, A/B'd in Debug by rebuilding the pre-change type checker, the
+construction work alone took a request 99.65 -> 82.29 KB (-17.4%). Per-op: `CreateEnum` 2,016 -> 928, `Option` 2,200 -> 1,112,
+`Result` 2,568 -> 1,304, parameterised record 3,464 -> 1,608, `CloneRecordWithUpdates` 2,968 ->
+1,040, `dictKeys` 4,400 -> 1,344. Routing a request 333 -> 238 package calls.
 
-### Steady-state throughput, Release, per the round-2 workloads
+None of the six existing workloads moved on the main fix, because they use non-parameterised types
+and build few `Option`s or `Result`s. That is why `containers.dark` exists: 9.09 KB/iteration on a
+pre-fix build, 6.2 after.
 
-The roadmap flagged this as the thing to measure rather than assume, since AOT compiles ahead of
-time and can't re-optimise hot loops. On these six it does not regress. It is faster on all of them:
+Then a second pass over the same area, after profiling said 43% of the `records` workload is
+closures and state machines rather than the value representation: `DvalCreator.enum`, `record` and
+`recordUpdate` were unconditional `uply` blocks opening with a `let!`, so every record and enum in
+the language entered a state machine. Reading both their lookups with `Ply.trySync` keeps the common
+construction out of the builder, and hoisting every helper they use to top level so none of them is
+a closure. Ten passes, each found by re-profiling the last. The Release figures are in the table
+above; the pass-by-pass work was steered in Debug, where records went 8.82 -> 4.43 KB/iteration,
+containers 6.18 -> 3.48, dicts 14.05 -> 12.43 and a request 99.65 -> 82.29 KB. The gate's Debug
+budget came down 8.0 -> 7.8 MB.
 
-| workload | R2R ms | AOT ms | | R2R alloc/iter | AOT alloc/iter |
-|---|---|---|---|---|---|
-| `json` | 14 | **6** | 2.3x | 12.44 KB | 12.73 KB |
-| `lists` | 198 | **110** | 1.8x | 11.76 KB | 11.89 KB |
-| `records` | 16 | **9** | 1.8x | 8.09 KB | 8.42 KB |
-| `strings` | 48 | **27** | 1.8x | 6.74 KB | 6.46 KB |
-| `dicts` | 101 | **72** | 1.4x | 15.91 KB | 15.60 KB |
-| `recursion` | 490 | **385** | 1.27x | 0.32 KB | 0.32 KB |
+Also here: `byOpcode` and `byStage` reporting, both already collected and previously discarded; and
+`scripts/perf/http` fixed to drive load from several client processes, since one Python process is
+GIL-bound below what the server does.
 
-But 200-iteration bodies are short enough that a JIT never reaches its best steady state, so this
-alone doesn't answer the roadmap's question. The server does.
+Reverted for measuring flat: exactly sizing the binary readers' collections (3% worse). Closed by
+measurement rather than built: freeing the stdlib wrappers, since a warm package call allocates
+nothing.
 
-### The long-running case, where the roadmap's fear is real (a bit)
+---
 
-`scripts/perf/http`, 20,000 requests at concurrency 32, about 11 seconds of sustained load. Three
-paired runs, alternating:
+## The long arc
 
-| run | R2R | AOT |
-|---|---|---|
-| 1 | 1,783 req/s | 1,684 req/s |
-| 2 | 1,724 req/s | 1,719 req/s |
-| 3 | 1,833 req/s | 1,776 req/s |
+Allocation per iteration, Release. Round 3 changes when code is compiled, not what the interpreter
+allocates, so it moves this table by less than the noise.
 
-R2R is ahead in 3 of 3, by 0.3% to 5.6%. The spread within each mode is about 6%, so the gap sits
-inside the noise band, but the sign is consistent. Latency moves the same way: p50 16.8 ms against
-17.8 ms, p95 27.9 against 29.6. Allocation per request is identical, 99.79 KB against 99.84 KB.
+| workload | start | before this round | now | total |
+|---|---|---|---|---|
+| `recursion` | 13,436 KB | 0.48 KB | 0.45 KB | **~30,000x** |
+| `lists` | 3,345 KB | 12.0 KB | 11.84 KB | **283x** |
+| `strings` | 684 KB | 6.6 KB | 6.45 KB | **106x** |
+| `dicts` | 1,055 KB | 15.7 KB | 12.36 KB | **85x** |
+| `records` | 202 KB | 8.3 KB | 4.26 KB | **47x** |
+| `json` | 76 KB | 13.0 KB | 10.00 KB | **7.6x** |
 
-A shorter run (2,000 requests at concurrency 16) shows a dead heat, 1,637 against 1,651. The cost
-only appears once the load lasts long enough for the JIT to finish tiering, which is exactly the
-mechanism the roadmap named.
+Time, Release, 200 iterations. Round 3 is where the time came from.
 
-So the trade is real and it is small: **give up a few percent of sustained server throughput, get
-4.6-8x on one-shot commands.** For a CLI that is obviously the right side of the trade. If `serve`
-ever becomes the main way Dark runs, it is worth re-measuring rather than inheriting this decision.
+| workload | start | after round 2 | after round 3 | total |
+|---|---|---|---|---|
+| `recursion` | 53,389 ms | 501 ms | 385 ms | 139x |
+| `records` | 823 ms | 16 ms | 9 ms | 91x |
+| `json` | 242 ms | 13 ms | 6 ms | 40x |
+| `strings` | 905 ms | 48 ms | 27 ms | 34x |
+| `lists` | 2,127 ms | 190 ms | 110 ms | 19x |
+| `dicts` | 1,073 ms | 103 ms | 72 ms | 15x |
 
-**One confound, stated because it undercuts the number above.** `Cli.fsproj` sets
-`IlcOptimizationPreference=Size`, so the throughput deficit was measured against an AOT binary that
-was explicitly asked to prefer small code over fast code, and `IlcFoldIdenticalMethodBodies=true`
-is on as well. Some or all of the 0.3-5.6% could be those settings rather than anything inherent to
-compiling ahead of time. Nobody has measured `Speed`. Do that before treating the gap as a property
-of AOT; see the roadmap.
+One-shot `dark eval "1L+1L"`: 214 ms to 31 ms, **6.9x**, almost all of it round 3. About 55% of what
+remains is `cli.preMain` -- process start to entering `main` -- so it is no longer interpreter work.
 
-Allocation per iteration is unchanged, within 4% and in both directions. AOT changes when code is
-compiled, not what the interpreter allocates.
+Against other runtimes, same program per iteration: python 0.47 KB, node 1.70 KB, Dark 11.84 KB.
+**7.0x node**, from ~700x at the start of round 2.
 
-### Whole-process allocation is 6% higher, and that is startup
+**Each round in a line.** 0: make the numbers trustworthy -- the profiler was lying in two ways, and
+`PackageRefs` makes a binary and a store a matched pair, so package changes cannot be A/B tested.
+1: first pass through the interpreter; established that it is allocation-bound and that a Dark
+function call cost ~8 KB. 2: the rewrite -- off Ply onto resumable `task`, builtins take arrays,
+type symbol table as a struct -- plus the course correction when six workloads finally existed and
+the one being tuned against turned out to be the second-cheapest of them. 3: NativeAOT, startup
+6.9x and steady state 1.3-2.3x, allocation untouched. 4: parameterised types, plus a wrong-type
+resolution bug found while measuring.
 
-| build | `steady.dark`, whole process |
-|---|---|
-| R2R | 7.7 MB (7.7 / 7.7 / 7.7) |
-| AOT | 8.2 MB (8.2 / 8.2 / 8.3) |
+Careful with older documents. Round 1's notes quote 107.1 MB and ~868 MB for the reference workload;
+those were a *different, lighter* workload, replaced during round 2. Only compare numbers from the
+same harness.
 
-Same instruction count both ways (298,236), so it is not extra work. `suite` differences startup out
-and shows body allocation identical; `gate` deliberately does not difference, so the gap lands
-there. It is startup allocation, and the reason `gate --published` fails against an AOT binary.
-
-**The budget was deliberately not re-pinned.** The roadmap says to re-pin when AOT lands, but CI's
-gate runs against the plain Release publish from `build-backend`, which this work does not change.
-Re-pin when the published build actually becomes AOT, using 8.2 MB as the starting point, not before.
-
-### The other thing that turned up
-
-`dark version` costs 0.34-0.57 s wall clock, and 0.03-0.05 s with the network unshared. It is
-dominated by an HTTPS round trip to check for a newer release. Any timing of `version` measures
-GitHub, not us, which is worth knowing before someone quotes it as a startup number.
+---
 
 ## Things established that shouldn't be re-derived
 
@@ -210,39 +105,62 @@ Cheap to state, expensive to learn.
 **On F# and .NET**
 
 - A `uply` loop allocates per iteration in proportion to the **size of its body**, bind or no bind.
-  F#'s built-in `task` allocates nothing. Ply predates F# 6's resumable code; this codebase is on
-  FSharp.Core 10.
-- A completed `Ply` allocates nothing -- it's a struct. The cost is the *builder*, not the value.
+  The win is in **not entering a builder at all**, not in entering a different one: swapping `uply`
+  for `task` was measured on this codebase and came out within GC noise, because both are
+  struct-state-machine builders. That is why the synchronous fast paths pay and a wholesale
+  Ply-to-Task migration does not.
+- A completed `Ply` allocates nothing -- it is a struct. The cost is the *builder*, not the value.
 - Ply's builder is **not** resumable code, so unlike `task` it allocates in Release exactly as much
-  as in Debug. This is why several CE-heavy paths survived into the shipped binary.
+  as in Debug.
 - F# only reduces resumable-code state machines in **optimised builds**. Record-heavy work looks
-  ~2.8x worse in Debug than it is. Develop in Debug (two minutes vs ten); decide in Release.
+  ~2.8x worse in Debug than it is.
 - `FS3511: this state machine is not statically compilable` is an *error* in Release here
-  (`--warnaserror`) and silent in Debug. It means the fallback allocating implementation is in use.
-  The trigger is a bind inside a nested match arm.
-- `match d.TryGetValue k with | true, v ->` allocates a `Tuple<bool,'v>` on every lookup.
-- `match a, b with` allocates the pair.
-- `let f x = g captured x` is a closure wherever the compiler can't lift it -- and a use inside the
+  (`--warnaserror`) and silent in Debug. The trigger is a bind inside a nested match arm.
+- `match d.TryGetValue k with | true, v ->` allocates a `Tuple<bool,'v>` on every lookup, and
+  `match a, b with` allocates the pair.
+- `let f x = g captured x` is a closure wherever the compiler cannot lift it, and a use inside the
   same function's loop is enough to stop the lift.
 - A `let mutable` captured by a continuation becomes a heap ref cell, allocated whether or not the
   branch that needs it runs.
+- A lazy `Seq` chain building a collection whose size is known costs an enumerator and a closure per
+  stage. `Map.iter` and `Map.foldBack` walk the tree directly, in the same ascending order.
 - .NET 10's object stack allocation is **not** quietly removing this work:
   `DOTNET_JitObjectStackAllocation=0` moves the total by 4 KB.
 
 **On Dark's runtime**
 
 - Type names are content hashes, so `type A = { x: Int }` and `type B = { x: Int }` are the **same
-  type**. Any test that passes a `B` where an `A` is expected is testing nothing.
+  type**. Any test passing a `B` where an `A` is expected is testing nothing.
 - Following from that: if a declared type's name equals the value's type name, the declared type
-  cannot be an alias, because a value built through an alias carries the *underlying* name. That one
+  cannot be an alias, because a value built through an alias carries the *underlying* name. That
   observation is what let most of the type checker move to a synchronous path.
+- A **warm** Dark function call allocates **nothing**. Measured by adding 0, 1, 2, 4 and 8 extra
+  forwarding hops to a call chain: package calls, frame pushes and instructions all rise linearly
+  while total allocation stays byte-identical at 231, and every synchronous `pkg.*` stage reads 0.
+  Only the *first* call to a given fn allocates -- frame 511 B, fetch 521 B -- after which both are
+  free. An earlier claim here of "120 bytes against 248" for a Dark call is withdrawn; it was
+  measuring cold calls, or the callee's body.
+- Calling a builtin that has a **type argument** is cheap: ~40 bytes of dispatch per call, and a
+  builtin with no type argument measures zero across every stage. An earlier claim here of ~7,470
+  was a residual taken across two scripts and is withdrawn.
+- The Apply path's *totals* -- `apply.total`, `bi.total`, `lambda.total` -- and `stats.builtinAlloc`
+  all bracket across the builtin's `Ply`, so they measure nested execution and can exceed what the
+  process allocated. One read 52,393 bytes for a call in an iteration that allocated 11,530. Only
+  the fine-grained synchronous stages mean anything.
 - `DInt` is 56 bytes regardless of magnitude, because `DarkInt` is a struct DU carrying space for a
   `bigint`.
+- An unresolved reference used to carry **no name** into the content hash, so two declarations
+  differing only in one collided and a hash-keyed map kept whichever came last. Scripts hit it every
+  time, because a script's fns are hashed before its own types are in scope. NOT fixed: the obvious
+  fix makes hashes name-dependent, which content addressing forbids. Roadmap 2d and
+  `notes/hashing-unresolved-refs-collision-2026-08-19.md`.
+- Unused type declarations are dropped before they reach the store, so adding one changes nothing.
+  Any experiment that adds a type must use it.
 - CRLF is a single extended grapheme cluster, so `"a\r\nb"` split on `"\n"` is one part cluster-wise
   and two char-wise. Any ASCII fast path over strings must exclude CR.
 - A published binary resolves its data and log directories relative to **its own location**, not
   `DARK_CONFIG_RUNDIR`.
-- `build-release-cli-exes.sh` *moves* the published binary into `clis/`, leaving empty the publish
-  directory it names in its own log.
-- The first run against an empty store seeds it -- hundreds of megabytes. Any measurement harness
-  needs a throwaway run first, or that lands in whichever measurement happens to be first.
+- The first run against an empty store seeds it, which is hundreds of megabytes. Any measurement
+  harness needs a throwaway run first.
+- Enabling telemetry costs ~6 ms on a one-shot command, so absolute latency needs it off and the
+  breakdown needs it on. The two cannot be mixed.

--- a/docs/perf/playbook.md
+++ b/docs/perf/playbook.md
@@ -36,6 +36,11 @@ Almost every change that measured flat and was reverted was built without probin
 `scripts/perf/alloc-profile` is excellent until it isn't. Early on one entry is 30-50% and the work
 is obvious. Later nothing is above 5%, and "no single thing dominates" is true and useless.
 
+`alloc-profile` also has a floor: it samples one tick per ~100 KB, so a workload that allocates only
+a few megabytes yields a few dozen ticks and resolves nothing. Amplify by looping the work in-process
+first -- and if the work is cached per process and therefore cannot be looped, the profiler is simply
+the wrong instrument for it.
+
 At that point stop profiling and **put comparable things side by side**. Measuring return types
 against each other was one line of insight when the json profile was flat:
 
@@ -62,6 +67,59 @@ allocated in total. Only bracket synchronous stretches.
 
 A useful control: bracket *nothing*, next to the suspicious one. Non-zero means the instrument is
 wrong rather than the code.
+
+**One workload, one run, one instrument.** A figure assembled from parts measured in different
+places is not a measurement. This round produced a phantom 1,240-byte layer by taking a function's
+cost from one workload and the enclosing opcode's from another -- the same function costs 680 bytes
+in one and 1,960 in the other. Bracketed on a single workload the numbers closed exactly.
+
+**Never promote a residual.** A number you got by subtracting measured regions from a measured
+total is not a measurement; it is everything you failed to bracket, plus your arithmetic. Four
+suspects were promoted that way in one night -- each looked like thousands of bytes as a residual
+and measured in the tens when bracketed directly. If the interesting number is the part you did not
+measure, go and measure it. The two allocation counters, incidentally, do agree:
+`GetAllocatedBytesForCurrentThread()` and `GetTotalAllocatedBytes(true)` returned identical figures
+on a continuation-heavy path, so a thread hop is not the explanation for a gap.
+
+**Not across two scripts either.** The night after "never promote a residual" went into this file,
+a 70%-of-the-cost item was opened by subtracting a bracket taken in one probe script from a row
+total taken in another. It survived one tick. Each number was measured honestly, which is what makes
+this half easy to miss.
+
+**Bound the outermost suspect first.** Five hypotheses about JSON's `convert` died in a row, every
+one assuming the function was where the bytes were. A bracket around `Json.parse` itself settled it
+in one build: the whole function is a third of what the call costs. One measurement either
+implicates a function or clears it, and clearing it retires every hypothesis about its insides.
+
+**Confirm a row measures what its label says.** Two rows labelled with two different types spent
+three ticks looking like a 2x property. They were sitting on a bug where a type annotation resolves
+to the wrong type, so the labels lied. Printing the parsed value once would have cost one run.
+Related: type names are content hashes, so a probe's `type RBool = { a: Bool }` is the same type as
+anything else with that shape. When one row of a sweep is an outlier, suspect the harness first.
+
+**Read instruction counts next to byte counts.** They disagree with a wrong story faster. The
+per-opcode counters caught one row taking an extra match arm, and separately proved that forwarding
+hops really were executing while allocating nothing. Both results came from the denominator, not
+the bytes.
+
+**An intervention that shows nothing may not have intervened.** "The last-declared type is cheap"
+was dismissed by adding a trailing type and seeing no change, but the type was unused and unused
+declarations are dropped. Making it used reproduced the effect immediately.
+
+**The first row of a sweep pays one-time cost.** Measure the baseline again at the end; a first row
+has read 931 bytes where every later row read 231.
+
+**A tight spread within one sweep is not low variance.** Three readings from one build can sit
+inside 0.5% of each other and still be a percent or two away from three readings of the *next*
+build, because each build reshuffles code layout. This misread twice in one campaign: a workload
+looked like it regressed 1.2%, the next pass showed it below where it had started, and the pass
+after that it was "up" again. Treat a sub-2% move across builds as unresolved until a third build
+agrees, and let the most realistic workload decide a mixed result.
+
+**Count the hit rate before explaining a disappointing fast path.** A fast path that never fires and
+a fast path that fires but had little to remove produce the same small number, and they need
+opposite fixes. The sync-build path on the record opcodes looked like the first and was the second:
+400 hits, 0 misses. `byOpcode` in `interpreterStatsGet` reports `syncHit`/`syncMiss` for this.
 
 ## 5. Change one thing, measure, keep or revert
 
@@ -111,7 +169,20 @@ reads a builtin's arguments *after* the body has returned, a lifetime nobody thi
   remove allocation added it instead, because the new helper closed over an array rather than taking
   it as a parameter -- and became the largest single entry in the profile.
 
-## 9. Know what your binary actually contains
+## 9. Debug timings are not small-multiple wrong, they are order-of-magnitude wrong
+
+Allocation is nearly identical between Debug and Release, which makes it tempting to trust Debug
+*timings* too. Don't. On one `dark eval`, SQL measured 39.9 ms in Debug and 2.7 ms on the shipped
+AOT binary, and deserialization 17.5 ms against 0.6 ms. A roadmap item survived for a while on the
+Debug figure and evaporated when measured properly.
+
+Profile allocation in Debug freely. Never quote a Debug duration, and never rank work by one.
+
+And never mix runs. A percentage built from a numerator taken in one run and a denominator taken in
+another is not a measurement. Startup here has ±20% run-to-run spread, so any split of it needs a
+median over ten or more runs, all from the same configuration.
+
+## 10. Know what your binary actually contains
 
 A Release build takes ten minutes, so measuring against the one you built earlier is tempting. Don't.
 `build-release-cli-exes.sh` names the binary after `git rev-parse HEAD` *at build time*, which is
@@ -119,7 +190,7 @@ worse than no label: it looks authoritative and is wrong if the tree had uncommi
 moved on. Before quoting a Release number, check the binary is newer than every commit you are
 crediting.
 
-## 10. Working with the tooling here
+## 11. Working with the tooling here
 
 - Run the perf tools in the **foreground**, with `< /dev/null`. Backgrounded shell commands are
   throttled here by ~50x, which reads as a regression.
@@ -143,7 +214,7 @@ crediting.
 - Debug builds in ~2 minutes, Release in ~10. Develop in Debug, decide in Release, and know the two
   disagree by up to 3x on paths still heavy in computation expressions.
 
-## 11. Leave the next person a gate, not a story
+## 12. Leave the next person a gate, not a story
 
 `scripts/perf/gate` asserts allocation against a checked-in budget, separately for Debug and
 published, and CI runs it. **Lower the budget in the same commit that earns it** -- a budget nobody

--- a/docs/perf/roadmap.md
+++ b/docs/perf/roadmap.md
@@ -1,231 +1,385 @@
 # Where the next performance work is
 
-The single tracking document for Dark performance work. Replaces `perf-ideas-backlog.md` and the
-per-round note piles that preceded it. Update it in place; don't start a new one.
+The single tracking document for Dark performance work. Update it in place; don't start a new one.
+Numbers are measured unless marked *(estimate)*.
 
-Numbers are measured unless marked *(estimate)*. The difference matters a lot when picking.
-
-**How to measure anything here:**
-
-    scripts/perf/suite              six workloads, allocation per iteration
-    scripts/perf/suite --release    the same, against the shipped build
-    scripts/perf/suite --record     append a run to benchmarks/results/history.jsonl
-    scripts/perf/http               a real server under concurrent load
+    scripts/perf/suite              six workloads, allocation per iteration (--release for the shipped build)
+    scripts/perf/http               a real server under concurrent load (-p client processes, default 4)
     scripts/perf/gate               the CI assertion, against a checked-in budget
     scripts/perf/checks             by-hand semantics and error-message checks
+    scripts/perf/bench              repeatable CLI timing, with an A/B mode
+    scripts/perf/alloc-profile      allocation by type name
     scripts/perf/crosslang          the same workload in node and python
-    scripts/perf/alloc-profile           allocation by type name
     ./scripts/run-cli run scripts/perf/workloads/costs.dark    per-operation cost table
 
-Method, and the traps: `docs/perf/playbook.md`. History and how we got here:
-`docs/perf/history.md`.
+Method and traps: `docs/perf/playbook.md`. Numbers round by round: `docs/perf/history.md`.
 
-Only `scripts/perf/gate` runs in CI, and only because it's one script and a couple of seconds. The suite and
-the HTTP driver are for a human deciding something, not for every build.
+Only `gate` runs in CI. The suite and the HTTP driver are for a human deciding something.
 
 ---
 
 ## Where things stand
 
-Reference workload, Release, whole process: **7.6 MB**, from 211.99 MB at the start of round 2. Per
-iteration the list workload is **7.1x node**, past the ~10x goal -- but it is the *cheapest* of six,
-so treat it as a best case rather than a summary.
+Per iteration, Release: `recursion` 0.45 KB, `containers` 3.04, `records` 4.26, `strings` 6.45,
+`json` 10.00, `lists` 11.84, `dicts` 12.36. An HTTP request: **76.31 KB** at 5,269 req/s, p50
+2.21 ms.
 
-Per iteration, Release: `recursion` 0.48 KB, `strings` 6.6, `records` 8.3, `lists` 12.0, `json` 13.0,
-`dicts` 15.7. An HTTP request returning a constant string: **85.4 KB**.
+The two easy classes -- a wrong data structure on a hot path, and a computation expression around
+work that never awaits -- are largely spent. What remains is a representation change with a wide
+blast radius, or standard-library work. Expect smaller allocation wins than earlier rounds.
 
-Time is the axis that hasn't moved: 1.4x in Release this round against 28x for allocation. That is
-what makes AOT the right next step rather than more of this.
+Allocation, execution speed and latency all count now. A change that only moves wall-clock is a
+legitimate win, which was not true in the first two rounds.
 
-## Next round is NativeAOT
+**Improve the instrument when the instrument is the limit.** `recursion` reads 0.20-0.48 KB across
+runs of the *same* binary, because it is a difference of two large startup numbers. Before chasing
+anything that small, fix the measurement.
 
-Decided 2026-08-08. It's the right call and it outranks everything below: one-shot command latency
-is dominated by `cli.preMain` -- runtime init and JIT -- which is exactly what AOT deletes, and no
-amount of interpreter work touches that. It's also already built, on its own branch.
+**AOT, measured against R2R on the same commit:** startup 6.9x faster (214 ms to 31 ms), steady
+state 1.3-2.3x on all six workloads, allocation identical. The open gap is that `gate` measures the
+solution publish, not the AOT artifact users download. Low severity while allocation is identical
+between them, but nothing measures the shipped artifact.
 
-**Measured 2026-08-08. Both checks done; numbers in `history.md`, round 3.**
+---
 
-The throughput worry was half right. The six suite workloads did not regress, they came out
-1.3-2.3x faster. But `perf/http` under sustained load (20k requests, ~11s) has R2R ahead in 3 of 3
-paired runs by 0.3-5.6%, with latency moving the same way. A short 2k-request run shows a dead
-heat, so the cost only appears once the JIT has time to finish tiering, which is the mechanism
-predicted here. The trade is a few percent of sustained server throughput for 4.6-8x on one-shot
-commands. Right side of the trade for a CLI; worth re-measuring if `serve` ever becomes the main
-way Dark runs.
+## Open, roughly ranked
 
-**The gate was deliberately not re-pinned.** An AOT binary does allocate differently, as predicted:
-8.2 MB against R2R's 7.7 MB on the reference workload, reproducible, and `gate --published` fails
-against it. But that gap is startup, not the body (`suite` differences startup out and shows
-allocation unchanged), and CI's gate runs against the plain Release publish from `build-backend`,
-which the AOT work doesn't change. Re-pin to 8.2 MB when the published build actually becomes AOT,
-not before.
+### Startup: ~19 ms of the 21 is ours, and it is before `main`
 
-### Follow-ups this round created
+Answering the question this item carried for two rounds: **no, 20 ms is not normal for a NativeAOT
+binary.** A hello-world AOT built with the same SDK starts in **1.8 ms** (median 1.9), against
+`/bin/true` at 0.5. Whatever our binary spends, it is not the runtime's floor.
 
-**Try `IlcOptimizationPreference=Speed` before believing the throughput gap.** `Cli.fsproj` sets
-`Size`, and `IlcFoldIdenticalMethodBodies=true` alongside it. So the 0.3-5.6% sustained-server
-deficit was measured against a binary told to prefer small code over fast code. Some or all of it
-may be that setting rather than a property of AOT. This is a one-line experiment and nobody has run
-it: flip to `Speed`, re-run `perf/http --release -n 20000 -c 32` three paired times, and compare
-against the numbers in `history.md`. Watch the binary size, which is the thing `Size` was buying
-(27 MB today, against R2R's 45 MB). Do this before anyone treats the gap as inherent.
+Measured on the shipped AOT binary with an argument it rejects immediately, which is the closest
+thing to a no-op invocation available (`--version` is useless for this: it makes a network call and
+takes 320 ms):
 
-**Static PGO is the principled answer if the gap survives that.** The mechanism behind the deficit
-is that a JIT re-optimises hot methods from runtime profile data and an AOT compiler has none. That
-isn't unfixable: ilc accepts MIBC profile data, so a profile collected from a representative run can
-be fed back into the build. Worth investigating only if `serve` becomes a workload we care about,
-since it adds a profile artifact to maintain and a way for the build to go stale.
+| event | median |
+|---|---|
+| whole process | 21.8 ms |
+| `cli.preMain` | **20.5 ms** |
+| `cli.total` | 11.0 ms |
+| `cli.execute` | 6.0 ms |
+| `cli.builtinsInit` | 2.0 ms |
+| `sql.total` | 2.0 ms |
+| `cli.extractResources` | 1.0 ms |
 
-**The interpreter loop is the hot loop, and that is where a JIT was helping.** Everything in the
-ranked list below makes the interpreter do less work, which helps both build modes. But under AOT
-there is no second chance from re-JITting, so anything that keeps `runSyncInstructions` from
-bailing into the computation expression is worth marginally more than these numbers suggest. Item 1
-below is the clearest case.
+`preMain` and `cli.total` overlap, so they do not sum to the process time; read them as two views.
 
-Everything below is the queue after that.
+Inside `preMain`, `strace` finds a single **15.9 ms window with zero syscalls**, so it is
+computation, not I/O, and not page-faulting the 28 MB image. It is **not the GC**, though the window
+opens right after `sched_getaffinity`: `DOTNET_gcServer=0`, `GCHeapCount=1` and `GCHeapHardLimit`
+all match the default across nine runs each.
 
-## Ranked, with what's known
+What is left to check: eager static initialisation. F# module-level values run on first access, and
+`cli.builtinsInit` at 2 ms shows the builtins table alone is measurable, so the natural suspect is
+the rest of that class. A profiler that can see inside a no-syscall window is the missing tool.
 
-### 1. The record and enum opcodes stop the interpreter's fast loop
+**Worth keeping in proportion.** 21 ms for a no-op is already good, and runtime performance matters
+more. This is written down because the question was open for two rounds and is now settled, not
+because it is the next thing to do.
 
-**Measured, biggest known win, design written.** Building a record costs 6x calling a function
-(1,507 B vs 231 B); updating one costs 2.3x building one (3,431 B). `CreateRecord`, `CreateEnum` and
-`CloneRecordWithUpdates` are three of the four opcodes that stop `runSyncInstructions` and enter the
-computation expression. They only need to be async because the builders can need the type store,
-which is now cached, so in the common case the `Ply` they return is already complete.
+### Package deserialization: real, but unmeasurable -- parked
 
-The full design, including why no new DU cases are needed and what to verify, is in the task list
-(#69). Records and enums are what real programs are made of, so this is the fast loop being left
-constantly.
+A one-shot eval loads 59 package items for 1.03 MB, ~17.5 KB each and 24% of the command's
+allocation, from an average 1,129-byte blob: ~15x expansion into the object graph. The load path
+around it is lean.
 
-### 2. Pool the builtin argument buffers further
+Parked because the instruments cannot resolve it: `alloc-profile` yields 41 ticks total on a
+load-dominated run, and items are cached per process so the work cannot be looped in-process.
+Reviving it needs a harness driving the loader directly, a finer allocation provider, or counters
+inside the deserializer. One guess has already been tried and reverted.
 
-**Measured ceiling.** Already done per-frame, which took recursion to 0.52 KB/iteration. A
-deliberately unsafe whole-VM probe suggested there is a little more, but the per-frame version got
-essentially all of it. Low priority now; recorded so nobody re-probes it.
+### Record and enum construction still enters three builders per value
 
-### 3. An HTTP request costs ~104 KB to return a constant string
+The top runtime item, measured. An amplified `records` workload (60,000 iterations, 4,487 allocation
+ticks, so the profile actually resolves) says **43% of its allocation is closures and async state
+machines**, concentrated in the construction path:
 
-**Measured, mostly not the runtime's fault any more.** 82% is framing rather than the handler, and
-93% is Dark-side interpretation rather than F# marshalling: **333 package calls to route one
-request**. That is `Stdlib.HttpServer.routeRequest` splitting paths and walking handler lists, so the
-win is now in the standard library, not the interpreter. Worth doing -- it's what every Dark web
-service pays -- but it's a different kind of work.
+| enclosing method | share |
+|---|---|
+| `enum` | 14.8% |
+| `recordUpdate` | 8.2% |
+| `resolveEnumType` | 4.8% |
+| `resolveRecordType` | 4.5% |
+| `record` | 4.0% |
+| `list` | 2.4% |
 
-### 4. Unbox scalar Dvals
+For comparison the entire `Map<string, Dval>` family -- the thing a value-representation change would
+address -- is about 18%.
 
-**Partly done, representation untouched.** Small integers and both booleans are interned, so
-`1 + 1` allocates nothing. But `DInt` is 56 bytes because `DarkInt` is a struct DU carrying space
-for a `bigint`, so any integer outside -128..1023 still costs that. Splitting the representation, or
-making `Infinite` hold a reference, is the real fix. *(estimate: moderate win, wide blast radius)*
+Two causes, both continuations of this round's theme.
 
-### 5. Move type checking to compile time
+**The enclosing functions are unconditional `uply` blocks.** `DvalCreator.enum` and `recordUpdate`
+open with `let! ... = resolveEnumType/resolveRecordType`, so a builder is entered on every call. This
+round put synchronous fast paths *inside* the field loops; the functions wrapping those loops still
+build a state machine. The chain is three deep -- `enum` to `resolveEnumType` to `resolveType` --
+for a lookup that is a cache hit in steady state.
 
-**A real project: weeks, not days.** The plumbing is easy and the middle is a type checker for a
-polymorphic language. Ablation put the prize at -20% allocation and -14% wall, but that was measured
-before this round cached and synchronised much of the same work, so re-measure before committing.
+**`resolveType`'s cache is behind `List.isEmpty typeArgs`.** It already has the right shape:
 
-**Runtime type checking is two jobs in one code path, and only one can move.** *Checking* asks
-whether an argument matches its declared type; making `checkFnParam`/`checkFnResult` no-ops is where
-the -20% came from, and everything still runs. *Instantiation* binds type variables into the symbol
-table so `'a` has a meaning inside the frame; remove it and the CLI does not start, because
-`Json.parse` has no concrete type to parse into. So this is a split, not a deletion.
+    if List.isEmpty typeArgs && (cacheFor types).TryGetValue(typeName, &cached) then
+      Ply cached
 
-**Where the static checker goes.** `applyAddFn` in `LibDB/PackageOpPlayback.fs` already compiles
-package code at save time and stores `rt_instrs` beside `pt_def`; a checker is another pass there and
-its verdict another column. Content addressing means a verdict never goes stale -- the hash *is* the
-definition -- which removes the invalidation problem that makes this miserable elsewhere.
-`package_dependencies` already gives topological order and reverse reachability.
-`LibParser/Validation.fs` is the model for the pass itself: same shape, one stage earlier.
+That is a fourth instance of the condition this round removed from three other places, and it means
+the cache never serves a parameterised type. Unlike the other three it is not simply dead: the
+returned value includes a type-argument mapping, so caching by name alone would be wrong. The fix is
+the same shape as the round-4 one -- cache what does not depend on the arguments, derive the mapping
+synchronously -- rather than deleting the condition.
 
-**The gradual boundary.** Three states per item -- `Checked`, `Unchecked`, `Failed` -- and a call
-skips its runtime argument check only when caller and callee are both `Checked`. Checks stay
-wherever a value enters from outside a verified region: scripts and `eval`, deserialization
-(`Json.parse`, DB reads, request bodies), builtins returning `Unknown`, and any `Unchecked` callee.
-This degrades correctly: a store where nothing is checked behaves exactly as today, and each item
-that passes removes checks from its own call sites with no flag day.
+**Done, five passes, Debug, three readings at each step:**
 
-**Where it will hurt.** The checker must under-approximate: anything it cannot prove is `Unchecked`,
-so being wrong costs performance rather than correctness -- the opposite direction trades a good
-error message for undefined behaviour. Static `TypeReference` and runtime `ValueType` are different
-lattices that meet in `unifyValueType`, and the existing `TypeChecker` should not be assumed reusable
-for a value-free version. And most calls are into signatures containing a type variable, so this
-needs real inference over type variables; a design that fast-paths the monomorphic case is optimising
-the small half.
+| workload | round start | now | change |
+|---|---|---|---|
+Debug, which is what the pass-by-pass work was steered by:
 
-**Phasing**, each step independently useful and revertable. 1: split checking from instantiation in
-the interpreter, no behaviour change, so "skip the check, keep the binding" becomes a condition
-rather than a refactor. 2: write the checker and run it over the whole package set in CI reporting
-only -- how many check clean, how many it declines, how many it calls wrong (expect both real errors
-and checker bugs). This is the phase that says whether the idea is viable, and it ships nothing.
-3: store the verdict, wire the runtime skip behind a flag defaulting to off, measure. 4: default it
-on. Phases 1 and 3 are days each; phase 2 is the project.
+| workload | round start | now | change |
+|---|---|---|---|
+| `records` | 8.82 KB | **4.43** | **-49.8%** |
+| `containers` | 6.18 KB | **3.48** | **-43.7%** |
+| HTTP request | 99.65 KB | **82.29** | **-17.4%** |
+| `json` | 17.40 KB | 15.23 | -12.5% |
+| `dicts` | 14.05 KB | **12.43** | **-11.5%** |
+| `strings` | 6.94 KB | 6.61 | -4.8% |
+| `lists` | 12.20 KB | 11.93 | -2.2% |
 
-**Decide before starting:** whether `Failed` blocks a save (probably warn first -- early `Failed`
-results will mostly be checker bugs); that the checker runs on already-resolved references, since
-items are global but name resolution is branch-scoped; and whether the LSP is the better reason to
-build it, since type errors while typing may be worth more than the allocation.
+Release, measured against a CLI built from this branch's head, which is what ships and what
+`history.md` records: records 8.3 -> **4.26** (-48.7%), json 13.0 -> **10.00** (-23.1%), dicts
+15.7 -> **12.36** (-21.3%), strings -2.3%, lists -1.3%, containers **3.04** (new).
 
-### 7. Startup, and one-shot command latency
+Closures fell from 43% of the records workload to 7%, and the profile's tick count from 4,487 to
+2,571 for identical work. A real HTTP request went 99.65 -> 89.26 KB after three of the five. The
+gate's Debug budget came down 8.0 -> 7.9 MB. On a real HTTP request,
+A/B'd by rebuilding the pre-change type checker, the first half alone was worth 99.65 -> 95.91 KB;
+throughput is unchanged at ~4,080 req/s, which is expected -- allocation is not what limits
+throughput here.
 
-**Measured, deprioritised because AOT is the lever.** `dark eval "1L+1L"` spends most of its time in
-runtime init and JIT, which is what AOT deletes. The part that survives AOT: **46 package functions
-load to add two integers**, one SQL query each, and **a SQLite point lookup costs ~0.4 ms** against a
-local file, which should be tens of microseconds. It doesn't vary with payload, so it's
-per-statement overhead -- Fumble builds a fresh `SqliteCommand` per call, so the statement is
-re-prepared every time. WAL, `synchronous=NORMAL` and pooling are already on.
+It took three passes, each found by re-profiling the one before, and none of them was the step
+originally planned.
 
-### 8. JSON
+1. `enum`, `record` and `recordUpdate` were unconditional `uply` blocks opening with a `let!`.
+   Reading both their lookups with `Ply.trySync` keeps the common construction out of a builder.
+   Worth -11%.
+2. The next profile showed an 11.3% entry, `afterResolve` -- the local helper step 1 had just
+   introduced. Marked `inline`, but it closed over `types`, `threadID` and `tst`, so F# allocated a
+   closure per construction anyway. Hoisting the three helpers to top level, taking everything
+   explicitly, was worth another -12.5%: more than the change it was cleaning up after.
+3. The next profile showed `resolveEnumType` and `resolveRecordType` at 11.8% combined, both trivial
+   `uply` wrappers around `resolveType`, plus `finish` at 2.5% -- another local helper left behind by
+   step 2. Same treatment: -11.4%.
+4. With closures down to 11%, the next profile put `DvalCreator.list` and `dict` on top: both folded
+   a lambda over a tuple accumulator, so a closure and a tuple per element. Top-level recursions
+   with a struct-tuple result instead. records -8.6%, containers -12.4%, json -5.5%.
+5. Closures then being spent at 7%, the profile turned to reference tuples, the largest at 9.4%:
+   `unifyTypeArgsSyncVT` used `match declared, actual with`, which allocates the pair, once per type
+   argument on the path every parameterised value takes. Nested matches instead. This is the only
+   pass that moved *every* workload -- containers -15.3%, records -5.3%, strings -4.0%, dicts -1.8%,
+   and dicts had not moved all round.
 
-**Now among the most expensive per iteration.** The fixed cost per `Json.parse` is down from 8,501
-to ~3,700 bytes but is still the bulk for small documents. Known remaining items, all small: the
-converter's `match typ, j.ValueKind with` allocates a pair per node (F# builds the tuple and boxes
-the enum), record fields go into an `FSharpMap`, and the `JsonDocument` is never disposed so its
-pooled buffers are never returned (~350 bytes a parse -- measured, and *not* worth the
-use-after-dispose hazard on its own).
+6. The return tuples. `resolveEnumType` and `resolveRecordType` returned reference `Tuple3`s at
+   4.4% combined; both are struct tuples now. records -6.4%, containers -1.6%, HTTP -5.4%.
 
-### 9. Dicts and records both use `Map<string, Dval>`
+   This one looked like it cost something: `lists` +1.2% and `strings` +1.8%, repeatable across
+   three readings. It prompted a hypothesis -- that a struct tuple crossing a `Ply` boundary
+   enlarges the state machine on the *async* path, so struct tuples would pay only where the
+   synchronous path dominates.
+7. `checkEnumFields` returns a struct tuple too, which was chosen as the test of that hypothesis
+   because it is the same shape of change on the same paths. **The hypothesis did not hold.**
+   `lists` went 11.97 -> 11.70, below even its pass-5 value, so pass 6's apparent regression was
+   recovered rather than compounded. records -5.8%, containers -4.0%. `strings` drifted up again
+   but its spread (6.75-6.94) overlaps its pass-5 spread, so that one is unresolved rather than
+   real.
 
-`Dict.set` costs ~370 bytes, most of it `Map.add` rebuilding the tree path, which is inherent to an
-immutable dict. A cheaper small-map representation would help dicts *and* records, since `DRecord`
-holds its fields the same way. Big change; no design yet. *(estimate)*
+8. `checkRecordFields` and `updateRecordFields`, the last reference `Tuple3`, at 6.7%. records
+   -4.1%, strings -4.1%, HTTP -2.5%, `lists` +1.9%. Mixed, and HTTP decided it.
 
-### 10. The rest of the codebase is still on Ply
+**What is left is the value representation.** After eight passes the profile is
+`FSharpList<Dval>` 18.0%, `MapTreeNode` 14.5%, `Option<Dval>` 8.8%, `FSharpMap` 7.4%, and the
+`Tuple2<string, Dval>` pairs a Map is built from -- roughly 34% in the Map family alone. Those are
+not accidents of how the code is written; they are what a `DRecord` and a `DDict` *are*. Closures are
+down to 10% and no single non-representation entry is above 7%, so the flat-profile rule applies:
+stop optimising this file and change the representation, or stop.
 
-~400 `uply` sites outside the interpreter loop. The cost is the *builder*, not the value -- a
-completed `Ply` is a struct and allocates nothing -- so the ones that matter are those entering a
-builder to hand back something they already have. Several such sites have each been worth 5-20% of a
-workload. Consider a `ValueTask` builder.
+**On `lists`:** it read +1.2% at pass 6, -2.3% at pass 7, +1.9% at pass 8, always with a tight
+within-sweep spread. That is build-to-build variance, not a trend; see the playbook note.
+
+The pattern is worth stating plainly, since it caught the same mistake three times: **a local helper
+on a hot path is a closure however it is annotated**, and each fix reveals the next one only if the
+profile is re-read. Do that before assuming what is left.
+Both lookups are read with `Ply.trySync`, so a construction whose type is cached and whose fields
+unify never enters a builder. The slow paths await the *same* `Ply` rather than recomputing, so
+there is one implementation of each step and no twin. The case lookup and arity check moved into
+`enumCaseFields`, shared by both paths, so the errors read identically either way.
+
+Still to do, from the same profile: the `List.isEmpty typeArgs` condition on `resolveType`'s cache,
+and `list` (2.4%). Re-profile before going further -- the shares above were measured before any of
+this landed, and three of the five entries have now moved.
+
+### Dicts: it is the map, not the call volume
+
+13.89 -> 12.60 KB/iteration (-9.3%) by making `dictAddEntry` return a struct tuple, take its key and
+value untupled, and replacing the fold-with-a-lambda in `Dict.fromListOverwritingDuplicates` with a
+top-level recursion.
+
+**The "dicts is volume" framing this item used to carry was wrong as a statement about allocation.**
+Profiled amplified, the workload is `MapTreeNode` 45.0%, `FSharpList<Dval>` 14.4%, `FSharpMap` 8.9%,
+`String` 7.4% -- and closures plus state machines total **0.41%**. The ~237 package calls per
+iteration cost instructions and frame pushes, not bytes, because a warm package call allocates
+nothing. What is left is the immutable map itself: see the value-representation item.
+
+### Unbox scalar Dvals
+
+Small integers and both booleans are interned, so `1 + 1` allocates nothing. But `DInt` is 56 bytes
+because `DarkInt` is a struct DU carrying space for a `bigint`, so any integer outside -128..1023
+costs that. Splitting the representation, or making `Infinite` hold a reference, is the real fix.
+*(estimate: moderate win, wide blast radius)*
+
+### Dicts and records both use `Map<string, Dval>`
+
+A cheaper small-map representation would help dicts *and* records, since `DRecord` holds its fields
+the same way. Big change, no design yet. *(estimate)*
+
+### Moving the rest of the codebase off Ply -- measured neutral, do not redo for performance
+
+~400 `uply` sites remain outside the interpreter loop, and it is tempting to read the interpreter's
+wins as an argument for converting them. It is not.
+
+**It has been done, on the `ply-to-task` branch: 42 commits, complete, tests green, unmerged.** Its
+own measurement says the hot-path swap is *within GC noise*, because `task { }` and `uply { }` are
+both struct-state-machine builders. That branch was pursued for NativeAOT trimming rather than
+allocation, and in its snapshot the release binary grew 381 KB. It also had to `--nowarn:3511` where
+the resumable-code analyzer could not statically reduce a recursive `task`, falling back to
+dynamic-dispatch state machines.
+
+The lesson generalises: **the win is never entering a builder, not entering a different one.** That
+is why the synchronous fast paths pay and why the roughly thirteen `*Sync` twins across
+`TypeChecker.fs` and `Interpreter.fs` cannot be deleted by changing builder. They are the mechanism,
+not a workaround for Ply.
+
+If Ply removal is revisited, do it for trimming, binary size or dependency reduction, and measure
+those. Do not expect allocation to move.
+
+### Pool the builtin argument buffers further
+
+Already done per-frame. An unsafe whole-VM probe suggested a little more, but the per-frame version
+got essentially all of it. Low priority; recorded so nobody re-probes it.
+
+### HTTP routing re-parses a constant -- left for a human
+
+`parseRouteSegments` re-parses a never-changing route pattern on every request, ~32 package calls
+per handler tested. Fixing it needs public stdlib API (a `makeRouter`, or a parsed field on
+`Handler`), so it is a design decision rather than an optimisation.
+
+### Compile-time type checking -- owned elsewhere
+
+Ablation put the prize at -20% allocation and -14% wall, measured before much of the same work was
+cached and synchronised, so re-measure before committing. Someone else is working on this; do not
+start it here.
+
+---
+
+### Every remaining workload is now its own data structure
+
+All six profiled amplified, after ten passes. Closures and state machines are under 2% in every one.
+What is left is what the values *are*:
+
+| workload | dominant | share |
+|---|---|---|
+| `lists` | `FSharpList<Dval>` cons cells | 88% |
+| `dicts` | `MapTreeNode` | 45% |
+| `strings` | `System.String` + lists of `Dval` | 36% + 26% |
+| `records` | the `Map<string, Dval>` family | ~34% |
+
+The last cross-cutting item was `ValueType.merge` matching its two arguments as a pair, which
+allocated one per list element, dict entry and record field. Nested matches instead: every workload
+improved, containers -3.1%, the rest 1-2%.
+
+There is nothing else in this class left to find. `checkAndExtractLetPattern` was the last suspected
+`match a, b with` and it does not appear in any profile, so changing it would be on faith. Continuing
+means changing the representation.
+
+## Larger, not yet scoped
+
+**Value representation.** Struct `Dval` with tag and payload, cached singletons for small
+ints/bools/unit, array-backed records with a shared shape descriptor instead of a `Map` per record.
+Weeks, highest ceiling, highest risk, and the main remaining allocation play.
+
+**Concurrency in the language.** Not a runtime-serialization problem: the server already uses seven
+cores. What is missing is a way to *express* parallel work, and ideally to find it automatically in
+sequential code. The safety predicate already exists -- `CapabilityAnalysis` folds transitive
+effective capabilities and `noCaps` means pure -- so "is this lambda safe to run out of order" is
+answerable per call site. A narrow first version would be `List.map`/`filter` where the lambda is
+`noCaps` and the list is long enough to pay for scheduling. Two cautions: it will not help
+allocation, and per-element work must exceed task overhead by a good margin. Not a priority.
+
+---
+
+## Correctness, not performance
+
+**Two declarations can share a hash, and one silently wins.** A function whose signature says `TA`
+will accept a `TB` and run: not an error path, a wrong-code path. `NameResolutionError` carries no
+name and the canonical writer skips `originalName`, so every unresolved reference serialises to the
+same two bytes; two declarations differing only in one hash identically; and `withExtras` keys by
+hash with `Map.ofList`, keeping the last. Scripts hit it constantly, because `Cli.fs` hashes a
+script's fns before its own types are in scope.
+
+Not fixed here. The obvious three-line fix -- write `originalName` into the hash when unresolved --
+breaks the content-addressing invariant that names never affect hashes, and was reverted. The real
+fix is to stop content-hashing before resolution, using the location-derived placeholders
+`LibParser/Package.fs` already has. Context, failure and options:
+`notes/hashing-unresolved-refs-collision-2026-08-19.md`.
+
+
+**A type argument can be violated silently.**
+
+    type Box<'a> = { v: 'a; tag: String }
+    let b = Box<Int> { v = 1; tag = "t" }
+    { b with v = "str" }        // succeeds, giving Box<Int> { v: "str" }
+
+The check that should catch it is dead. In four places in `TypeChecker.fs` the code matches `vt`,
+binds the catch-all as `known`, and then calls `ValueType.merge known vt` -- merging a value with
+itself, which always succeeds. Three of those predate this campaign; the fourth is
+`updateTypeArgsSync`, which reproduced the idiom when extracting the synchronous twin. Letting
+parameterised types onto the fast path did not widen the exposure, since the async path ran the same
+self-merge, but the fix is now a four-site change.
+
+---
 
 ## Smaller, known, unowned
 
 - `run-in-docker` hangs after the command finishes (`cat <&0` waits for EOF); pass `< /dev/null`.
-  Every later command in the clone crawls until it's killed. Fixing it properly is a small job.
+- `Builtin.debug` has no package wrapper anywhere, and its only mention under `packages/` is a
+  commented-out line, so its reference count is propped up by scripts outside `packages/`.
 - Re-enable the `CliTraces` suite once its network call is stubbed.
-- Decide what `dark version` should do when the network is slow or absent -- it makes a network call
-  that costs ~700 ms.
-- Unify `callBuiltinResolved` and `callPackageResolved`: same five steps, different parameter and
-  outcome types. Needs `BuiltInParam` and `PackageFn.Parameter` to share an interface.
+- Decide what `dark version` should do when the network is slow or absent; it costs ~700 ms.
+- Unify `callBuiltinResolved` and `callPackageResolved`: same five steps, different types. Needs
+  `BuiltInParam` and `PackageFn.Parameter` to share an interface.
 - Make builtins opt-in, as installable extensions. Would cut startup and the builtins table.
 - Mine the telemetry corpus: every checkout's `rundir/logs/telemetry.jsonl` has thousands of real
   runs, which could retarget the campaign against what people actually do.
 - Runtime call stacks name package functions by content hash, which makes every error harder to act
-  on than it needs to be. Not a performance problem, but it is in the same code.
+  on. Not a performance problem, but it is in the same code.
 
-## Considered and declined
-
-- **Moving the gate to the `build-cli` job**, so it measures the artifact users actually download
-  rather than the solution publish in `build-backend`. `build-cli` does run migrations and
-  `reload-packages`, so it would work. Declined because both are Release builds of the same code and
-  the difference is packaging, so there is no measured reason to expect different allocation --
-  and moving a CI step for an unmeasured reason is exactly what this campaign learned not to do.
-  Revisit if the release script ever starts passing different publish flags (trimming, single-file,
-  AOT), because then the binaries genuinely differ.
+---
 
 ## Closed, so nobody re-opens them
 
-- **Inline caching at call sites.** The point was skipping the per-call type check. Memoizing
-  container `ValueType`s took those stages to 0 B/run; there is nothing left to cache.
-- **Whether a package callee should inherit the caller's type symbol table.** Was only ever a
-  performance question via inline caching. Still an open *design* question, but not a perf one.
-- **Argument lists.** Done: builtins take an array, reused per frame.
+- **Records and enums**, **enum construction**, and **the dead gate in both record paths**: done.
+  The remainder is spread thin.
+- **JSON.** `Json.parse` is a third of what the call costs; nothing inside dominates. A list element
+  is ~900 B, a record field ~100.
+- **Making stdlib wrappers free.** A warm package call allocates *nothing*: 0, 1, 2, 4 and 8 extra
+  forwarding hops all allocate 231 bytes while package calls rise 4 to 12. Only the first call to a
+  given fn pays. There was nothing to win.
+- **Calling a polymorphic builtin.** Claimed 7,470 B from a residual across two probe scripts;
+  actually 192 B. Retracted.
+- **A 2x between two record types.** Was the hash collision described below: the two rows were not
+  measuring the types they named.
+- **`scripts/perf/http` saturating on its own client.** Fixed with `-p` processes.
+- **Sizing the binary readers' collections exactly** in `Serializers/Common.fs`. Measured 3% *worse*
+  (17,486 to 18,023 bytes per package load) and reverted.
+- **Inline caching at call sites.** Memoizing container `ValueType`s took those stages to 0 B/run.
+- **Argument lists.** Builtins take an array, reused per frame.
+- **Moving the gate to the `build-cli` job.** Both are Release builds of the same code and the
+  difference is packaging, so there is no measured reason to expect different allocation. Revisit if
+  the release script starts passing different publish flags.

--- a/packages/darklang/languageTools/interpreterStats.dark
+++ b/packages/darklang/languageTools/interpreterStats.dark
@@ -20,5 +20,15 @@ let get () : String =
 /// Also record per-expression time from here on. Off by default: on some
 /// hosts reading the clock costs more than the expression being timed, so
 /// this is a deliberate, per-run choice rather than something to leave on.
-let enableDetailedTiming () : Unit =
-  Builtin.interpreterStatsEnableDetailedTiming ()
+let enableDetailedTiming (enabled: Bool) : Unit =
+  Builtin.interpreterStatsEnableDetailedTiming enabled
+
+
+/// Bytes this process has allocated since it started, including memory since
+/// freed. Read it either side of a piece of work and subtract.
+///
+/// This is the number to compare two versions of the same code with: unlike
+/// wall-clock time it repeats exactly, and it does not care how loaded the
+/// machine is.
+let allocatedBytes () : Int64 =
+  Builtin.gcAllocatedBytes ()

--- a/packages/darklang/stdlib/httpserver.dark
+++ b/packages/darklang/stdlib/httpserver.dark
@@ -57,12 +57,17 @@ let matchSegment
 
 
 /// Match a request path against a route pattern
-let matchRoute (routePattern: String) (requestPath: String) : RouteMatch =
-  let routeSegs = parseRouteSegments routePattern
-  let pathSegs =
-    (String.split requestPath "/")
-    |> List.filter (fun s -> Bool.not (String.isEmpty s))
+/// Split a request path into non-empty segments.
+let splitPath (requestPath: String) : List<String> =
+  (String.split requestPath "/")
+  |> List.filter (fun s -> Bool.not (String.isEmpty s))
 
+
+/// `matchRoute` against segments that have already been parsed and split.
+///
+/// Routing splits one path against every handler, so doing it here rather than inside `matchRoute`
+/// lets the caller split once instead of once per handler.
+let matchRouteSegments (routeSegs: List<RouteSegment>) (pathSegs: List<String>) : RouteMatch =
   let routeLen = List.length routeSegs
   let pathLen = List.length pathSegs
 
@@ -93,24 +98,34 @@ let matchRoute (routePattern: String) (requestPath: String) : RouteMatch =
     | None -> RouteMatch { matched = false; vars = [] }
 
 
+let matchRoute (routePattern: String) (requestPath: String) : RouteMatch =
+  matchRouteSegments (parseRouteSegments routePattern) (splitPath requestPath)
+
+
 /// Find the first handler that matches the request
 let findHandler
   (handlers: List<Handler>)
   (method: String)
   (path: String)
   : Option.Option<Handler * RouteMatch> =
-  // First find a matching handler
+  // Split once here rather than inside `matchRoute`, which runs per handler: the result is the
+  // same every time, so splitting there scales the work with handlers tested.
+  let pathSegs = splitPath path
+
   let matchingHandler =
     handlers
     |> List.findFirst (fun h ->
-      let methodMatches = (h.method == method) || (h.method == "*")
-      let routeMatch = matchRoute h.route path
-      methodMatches && routeMatch.matched)
+      // Method first. The route match is the expensive half, and a handler whose method cannot
+      // match never needs it -- the previous order computed it regardless.
+      if (h.method == method) || (h.method == "*") then
+        let routeMatch = matchRouteSegments (parseRouteSegments h.route) pathSegs
+        routeMatch.matched
+      else
+        false)
 
-  // If found, compute the route match again to return it
   match matchingHandler with
   | Some h ->
-    let routeMatch = matchRoute h.route path
+    let routeMatch = matchRouteSegments (parseRouteSegments h.route) pathSegs
     Option.Option.Some ((h, routeMatch))
   | None -> Option.Option.None
 

--- a/scripts/perf/budget.json
+++ b/scripts/perf/budget.json
@@ -1,7 +1,7 @@
 {
   "tolerance": 0.03,
   "steady": {
-    "debug": 8025008,
+    "debug": 7796576,
     "published": 7641184,
     "note": "scripts/perf/workloads/steady.dark, trace detail off. Lower these whenever a change earns it."
   }

--- a/scripts/perf/checks
+++ b/scripts/perf/checks
@@ -88,6 +88,27 @@ record_case missing-field    "Missing field \`y\`"                              
 record_case extra-field      "No field named \`z\`"                                'Point { x = 1; y = "a"; z = 3 }'
 record_case duplicate-field  "Duplicate field \`x\`"                               'Point { x = 1; x = 2; y = "a" }'
 
+# --- record update failures -----------------------------------------------------------------
+#
+# Separate from construction: updates go through `DvalCreator.recordUpdate`, a different function
+# with its own error messages, and nothing else exercises them.
+
+update_case() { # update_case <name> <expect> <update-expr>
+  run "record update: $1" "$2" "$(case_file "upd-$1" <<DARK
+type Point = { x: Int; y: String }
+let main () : Int64 =
+  let p = Point { x = 1; y = "a" }
+  let bad = $3
+  Builtin.debug "should not get here" bad
+  0L
+main ()
+DARK
+)"
+}
+
+update_case wrong-type   "Failed to create updated record. Expected String for field \`y\`, but got 2 (an Int)" '{ p with y = 2 }'
+update_case unknown-field "No field named \`z\`"                                                              '{ p with z = 3 }'
+
 # --- call stacks -------------------------------------------------------------------------------
 
 # Worth checking whenever frames start sharing ExecutionPoints. Not `Builtin.testRuntimeError`:

--- a/scripts/perf/http
+++ b/scripts/perf/http
@@ -11,7 +11,15 @@
 #   scripts/perf/http                 /json, 2000 requests, concurrency 16
 #   scripts/perf/http --route /hello  a route that does almost nothing
 #   scripts/perf/http -n 5000 -c 64   more load
+#   scripts/perf/http -p 1            drive from one process (see below)
 #   scripts/perf/http --release       against the shipped build
+#
+# Load comes from several client *processes*, not one. A single Python process is GIL-bound at
+# around 2,100 req/s, which is slower than the server: with one process this tool saturates on its
+# own client and reports the client's ceiling as the server's. Worse than a wrong number, it makes
+# the tool blind -- server throughput can move in either direction and the reading will not.
+# Measured on one server: 1 process 2,160 req/s, 2 procs 3,382, 4 procs 3,827, 8 procs 4,295.
+# `-p 1` reproduces the old single-process behaviour, for comparing against historical figures.
 set -euo pipefail
 cd /home/dark/app
 . ./scripts/perf/_common
@@ -22,12 +30,14 @@ PORT="${PERF_HTTP_PORT:-9097}"
 ROUTE="/json"
 N=2000
 C=16
+P=4
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --route) ROUTE="$2"; shift 2 ;;
     -n) N="$2"; shift 2 ;;
     -c) C="$2"; shift 2 ;;
+    -p) P="$2"; shift 2 ;;
     --port) PORT="$2"; shift 2 ;;
     # A flag, not an environment variable: these scripts re-enter the container and the environment
     # does not survive that.
@@ -77,11 +87,11 @@ if ! grep -q LISTENING "$SERVER_LOG" 2>/dev/null; then
   exit 1
 fi
 
-python3 - "$PORT" "$ROUTE" "$N" "$C" <<'PY'
+python3 - "$PORT" "$ROUTE" "$N" "$C" "$P" <<'PY'
 import http.client, json, statistics, sys, threading, time, urllib.request
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
 
-port, route, n, c = sys.argv[1], sys.argv[2], int(sys.argv[3]), int(sys.argv[4])
+port, route, n, c, procs = sys.argv[1], sys.argv[2], int(sys.argv[3]), int(sys.argv[4]), int(sys.argv[5])
 url = f"http://localhost:{port}{route}"
 
 def hit():
@@ -96,28 +106,43 @@ def alloc():
     with urllib.request.urlopen(f"http://localhost:{port}/alloc", timeout=30) as r:
         return int(r.read())
 
+def worker(spec):
+    # One client process: its own share of the requests, at its own share of the concurrency.
+    # Runs in a child, so its thread pool contends with no other pool for the GIL.
+    reqs, threads = spec
+    with ThreadPoolExecutor(max_workers=threads) as pool:
+        return list(pool.map(lambda _: hit(), range(reqs)))
+
 # Warm up: the first request through a route pays to load and convert every package function the
 # handler touches, which is thousands of times a steady-state request.
 for _ in range(200):
     hit()
 
+# Split both the work and the concurrency across processes, so `-c` still means total in-flight
+# requests however many processes carry them. Remainders go to the earliest workers.
+procs = max(1, min(procs, c))
+specs = [(n // procs + (1 if i < n % procs else 0),
+          c // procs + (1 if i < c % procs else 0)) for i in range(procs)]
+
 before = alloc()
 t0 = time.perf_counter()
-with ThreadPoolExecutor(max_workers=c) as pool:
-    lats = list(pool.map(lambda _: hit(), range(n)))
+if procs == 1:
+    lats = worker(specs[0])
+else:
+    with ProcessPoolExecutor(max_workers=procs) as pool:
+        lats = [x for part in pool.map(worker, specs) for x in part]
 wall = time.perf_counter() - t0
 after = alloc()
 
 lats.sort()
 print(f"  route            {route}")
-print(f"  requests         {n} at concurrency {c}")
+print(f"  requests         {n} at concurrency {c} across {procs} client process(es)")
 print(f"  throughput       {n/wall:,.0f} req/s  ({wall:.2f}s wall)")
 print(f"  latency p50      {statistics.median(lats):.2f} ms")
 print(f"  latency p95      {lats[int(len(lats)*0.95)]:.2f} ms")
 print(f"  latency p99      {lats[int(len(lats)*0.99)]:.2f} ms")
 print(f"  latency max      {lats[-1]:.2f} ms")
 print(f"  alloc/request    {(after - before)/n/1024:.2f} KB")
-print(f"  alloc measured   {(after - before)/1e6:.1f} MB over {n} requests")
 PY
 
 cleanup

--- a/scripts/perf/workloads/costs.dark
+++ b/scripts/perf/workloads/costs.dark
@@ -38,9 +38,9 @@ let measure (label: String) (f: Int -> Int) : Unit =
     Stdlib.List.fold (Stdlib.List.range 1 n) 0 (fun acc i ->
       if (f i) == -987654321 then acc + 1 else acc)
   let _warm = run 50
-  let before = Builtin.gcAllocatedBytes ()
+  let before = Darklang.LanguageTools.InterpreterStats.allocatedBytes ()
   let _r = run 2000
-  let after = Builtin.gcAllocatedBytes ()
+  let after = Darklang.LanguageTools.InterpreterStats.allocatedBytes ()
   Builtin.debug label ((after - before) / 2000L)
 
 let main () : Int64 =

--- a/scripts/perf/workloads/http-server.dark
+++ b/scripts/perf/workloads/http-server.dark
@@ -19,14 +19,16 @@ let echoFn (req: Stdlib.Http.Request) : Stdlib.Http.Response =
 // How much this process has allocated so far. The load driver reads it before and after the
 // measured run, which is the only way to get a per-request number out of a server that never exits.
 let allocFn (req: Stdlib.Http.Request) : Stdlib.Http.Response =
-  Stdlib.Http.responseWithText (Stdlib.Int64.toString (Builtin.gcAllocatedBytes ())) 200
+  Stdlib.Http.responseWithText (Stdlib.Int64.toString (Darklang.LanguageTools.InterpreterStats.allocatedBytes ())) 200
 
 // Interpreter counters for the VM that ran this request. Each request gets its own VM, so this is
 // per-request work: how many instructions, builtin calls and package calls a request costs.
 let statsFn (req: Stdlib.Http.Request) : Stdlib.Http.Response =
-  Stdlib.Http.responseWithText (Builtin.interpreterStatsGet ()) 200
+  Stdlib.Http.responseWithText (Darklang.LanguageTools.InterpreterStats.get ()) 200
 
-let handlers () : List<Stdlib.HttpServer.Handler> =
+// A value, not a function. As `handlers ()` this rebuilt five records and five lambdas on every
+// request, which is not what the documented usage does and made the benchmark measure the harness.
+let handlers =
   [ Stdlib.HttpServer.Handler { route = "/hello"; method = "GET"; handler = helloFn }
     Stdlib.HttpServer.Handler { route = "/json"; method = "GET"; handler = jsonFn }
     Stdlib.HttpServer.Handler { route = "/echo"; method = "POST"; handler = echoFn }
@@ -34,10 +36,10 @@ let handlers () : List<Stdlib.HttpServer.Handler> =
     Stdlib.HttpServer.Handler { route = "/stats"; method = "GET"; handler = statsFn } ]
 
 let router (req: Stdlib.Http.Request) : Stdlib.Http.Response =
-  Stdlib.HttpServer.routeRequest (handlers ()) req
+  Stdlib.HttpServer.routeRequest handlers req
 
 let port () : Int =
-  match Builtin.environmentGet "PERF_HTTP_PORT" with
+  match Stdlib.Env.get "PERF_HTTP_PORT" with
   | Some s ->
     match Stdlib.Int.parse s with
     | Ok n -> n

--- a/scripts/perf/workloads/steady.dark
+++ b/scripts/perf/workloads/steady.dark
@@ -5,8 +5,8 @@ let repeat (times: Int) (n: Int) (acc: Int) : Int =
   if times <= 0 then acc else repeat (times - 1) n (acc + (work n))
 
 let _warm = repeat 20 50 0
-let _reset = Builtin.interpreterStatsReset ()
-let t0 = Builtin.timeNowMs ()
+let _reset = Darklang.LanguageTools.InterpreterStats.reset ()
+let t0 = Darklang.Cli.Telemetry.now ()
 let result = repeat 200 50 0
-let t1 = Builtin.timeNowMs ()
-Stdlib.printLine ("elapsed_ms=" ++ (Stdlib.Int.toString (t1 - t0)) ++ " stats=" ++ (Builtin.interpreterStatsGet ()))
+let t1 = Darklang.Cli.Telemetry.now ()
+Stdlib.printLine ("elapsed_ms=" ++ (Stdlib.Int.toString (t1 - t0)) ++ " stats=" ++ (Darklang.LanguageTools.InterpreterStats.get ()))

--- a/scripts/perf/workloads/suite/containers.dark
+++ b/scripts/perf/workloads/suite/containers.dark
@@ -1,0 +1,54 @@
+// Option and Result: construction, matching and chaining. These are how idiomatic Dark reports
+// absence and failure, and until this workload existed nothing in the suite built many of them --
+// which hid three consecutive halvings of container construction.
+let iters () : Int =
+  match Stdlib.Env.get "PERF_ITERS" with
+  | Some s ->
+    match Stdlib.Int.parse s with
+    | Ok n -> n
+    | Error _ -> 0
+  | None -> 0
+
+type Boxed<'v> = { v: 'v; tag: String }
+
+let empties () : List<Int> = []
+
+let work (n: Int) : Int =
+  let xs = [n; n + 1; n + 2]
+
+  // Option from the standard library, matched
+  let a =
+    match Stdlib.List.head xs with
+    | Some v -> v
+    | None -> 0
+
+  // Option that is absent, so the None path is exercised too
+  let b =
+    match Stdlib.List.head (empties ()) with
+    | Some v -> v
+    | None -> 1
+
+  // Result from parsing, both arms
+  let c =
+    match Stdlib.Int.parse "123" with
+    | Ok v -> v
+    | Error _ -> 0
+  let d =
+    match Stdlib.Int.parse "not a number" with
+    | Ok v -> v
+    | Error _ -> 1
+
+  // A parameterised record, which took the same slow path as Option and Result
+  let boxed = Boxed<Int> { v = a; tag = "t" }
+
+  a + b + c + d + boxed.v
+
+let repeat (times: Int) (acc: Int) : Int =
+  if times <= 0 then acc else repeat (times - 1) (acc + (work times))
+
+let _warm = repeat 20 0
+let _reset = Darklang.LanguageTools.InterpreterStats.reset ()
+let t0 = Darklang.Cli.Telemetry.now ()
+let result = repeat (iters ()) 0
+let t1 = Darklang.Cli.Telemetry.now ()
+Stdlib.printLine ("elapsed_ms=" ++ (Stdlib.Int.toString (t1 - t0)) ++ " result=" ++ (Stdlib.Int.toString result) ++ " stats=" ++ (Darklang.LanguageTools.InterpreterStats.get ()))

--- a/scripts/perf/workloads/suite/dicts.dark
+++ b/scripts/perf/workloads/suite/dicts.dark
@@ -1,7 +1,7 @@
 // Dicts: insert, lookup, iterate. A different container representation from lists, and the one
 // most programs reach for when they have keys.
 let iters () : Int =
-  match Builtin.environmentGet "PERF_ITERS" with
+  match Stdlib.Env.get "PERF_ITERS" with
   | Some s ->
     match Stdlib.Int.parse s with
     | Ok n -> n
@@ -24,8 +24,8 @@ let repeat (times: Int) (acc: Int) : Int =
   if times <= 0 then acc else repeat (times - 1) (acc + (work times))
 
 let _warm = repeat 10 0
-let _reset = Builtin.interpreterStatsReset ()
-let t0 = Builtin.timeNowMs ()
+let _reset = Darklang.LanguageTools.InterpreterStats.reset ()
+let t0 = Darklang.Cli.Telemetry.now ()
 let result = repeat (iters ()) 0
-let t1 = Builtin.timeNowMs ()
-Stdlib.printLine ("elapsed_ms=" ++ (Stdlib.Int.toString (t1 - t0)) ++ " result=" ++ (Stdlib.Int.toString result))
+let t1 = Darklang.Cli.Telemetry.now ()
+Stdlib.printLine ("elapsed_ms=" ++ (Stdlib.Int.toString (t1 - t0)) ++ " result=" ++ (Stdlib.Int.toString result) ++ " stats=" ++ (Darklang.LanguageTools.InterpreterStats.get ()))

--- a/scripts/perf/workloads/suite/json.dark
+++ b/scripts/perf/workloads/suite/json.dark
@@ -1,7 +1,7 @@
 // JSON round trips. Polymorphic serialization walks the type declaration alongside the value, so it
 // exercises the package-type lookup and the type-symbol-table paths harder than anything else here.
 let iters () : Int =
-  match Builtin.environmentGet "PERF_ITERS" with
+  match Stdlib.Env.get "PERF_ITERS" with
   | Some s ->
     match Stdlib.Int.parse s with
     | Ok n -> n
@@ -21,8 +21,8 @@ let repeat (times: Int) (acc: Int) : Int =
   if times <= 0 then acc else repeat (times - 1) (acc + (work times))
 
 let _warm = repeat 5 0
-let _reset = Builtin.interpreterStatsReset ()
-let t0 = Builtin.timeNowMs ()
+let _reset = Darklang.LanguageTools.InterpreterStats.reset ()
+let t0 = Darklang.Cli.Telemetry.now ()
 let result = repeat (iters ()) 0
-let t1 = Builtin.timeNowMs ()
-Stdlib.printLine ("elapsed_ms=" ++ (Stdlib.Int.toString (t1 - t0)) ++ " result=" ++ (Stdlib.Int.toString result))
+let t1 = Darklang.Cli.Telemetry.now ()
+Stdlib.printLine ("elapsed_ms=" ++ (Stdlib.Int.toString (t1 - t0)) ++ " result=" ++ (Stdlib.Int.toString result) ++ " stats=" ++ (Darklang.LanguageTools.InterpreterStats.get ()))

--- a/scripts/perf/workloads/suite/lists.dark
+++ b/scripts/perf/workloads/suite/lists.dark
@@ -1,7 +1,7 @@
 // Lists and lambdas: build, map, filter, fold, reverse. The reference workload, and the shape most
 // optimisation work has targeted, so it stays here as the control.
 let iters () : Int =
-  match Builtin.environmentGet "PERF_ITERS" with
+  match Stdlib.Env.get "PERF_ITERS" with
   | Some s ->
     match Stdlib.Int.parse s with
     | Ok n -> n
@@ -15,8 +15,8 @@ let repeat (times: Int) (n: Int) (acc: Int) : Int =
   if times <= 0 then acc else repeat (times - 1) n (acc + (work n))
 
 let _warm = repeat 20 50 0
-let _reset = Builtin.interpreterStatsReset ()
-let t0 = Builtin.timeNowMs ()
+let _reset = Darklang.LanguageTools.InterpreterStats.reset ()
+let t0 = Darklang.Cli.Telemetry.now ()
 let result = repeat (iters ()) 50 0
-let t1 = Builtin.timeNowMs ()
-Stdlib.printLine ("elapsed_ms=" ++ (Stdlib.Int.toString (t1 - t0)) ++ " result=" ++ (Stdlib.Int.toString result))
+let t1 = Darklang.Cli.Telemetry.now ()
+Stdlib.printLine ("elapsed_ms=" ++ (Stdlib.Int.toString (t1 - t0)) ++ " result=" ++ (Stdlib.Int.toString result) ++ " stats=" ++ (Darklang.LanguageTools.InterpreterStats.get ()))

--- a/scripts/perf/workloads/suite/records.dark
+++ b/scripts/perf/workloads/suite/records.dark
@@ -1,7 +1,7 @@
 // Records and enums: construction, field access, functional update, and matching. Every Dark
 // program that models anything does this constantly, and none of it goes through the list path.
 let iters () : Int =
-  match Builtin.environmentGet "PERF_ITERS" with
+  match Stdlib.Env.get "PERF_ITERS" with
   | Some s ->
     match Stdlib.Int.parse s with
     | Ok n -> n
@@ -33,8 +33,8 @@ let repeat (times: Int) (acc: Int) : Int =
   if times <= 0 then acc else repeat (times - 1) (acc + (work times))
 
 let _warm = repeat 20 0
-let _reset = Builtin.interpreterStatsReset ()
-let t0 = Builtin.timeNowMs ()
+let _reset = Darklang.LanguageTools.InterpreterStats.reset ()
+let t0 = Darklang.Cli.Telemetry.now ()
 let result = repeat (iters ()) 0
-let t1 = Builtin.timeNowMs ()
-Stdlib.printLine ("elapsed_ms=" ++ (Stdlib.Int.toString (t1 - t0)) ++ " result=" ++ (Stdlib.Int.toString result))
+let t1 = Darklang.Cli.Telemetry.now ()
+Stdlib.printLine ("elapsed_ms=" ++ (Stdlib.Int.toString (t1 - t0)) ++ " result=" ++ (Stdlib.Int.toString result) ++ " stats=" ++ (Darklang.LanguageTools.InterpreterStats.get ()))

--- a/scripts/perf/workloads/suite/recursion.dark
+++ b/scripts/perf/workloads/suite/recursion.dark
@@ -1,7 +1,7 @@
 // Deep self-recursion, no containers. Isolates the frame push and pop path: how much does a call
 // cost when the call is all there is?
 let iters () : Int =
-  match Builtin.environmentGet "PERF_ITERS" with
+  match Stdlib.Env.get "PERF_ITERS" with
   | Some s ->
     match Stdlib.Int.parse s with
     | Ok n -> n
@@ -18,8 +18,8 @@ let repeat (times: Int) (acc: Int) : Int =
   if times <= 0 then acc else repeat (times - 1) (acc + (work times))
 
 let _warm = repeat 5 0
-let _reset = Builtin.interpreterStatsReset ()
-let t0 = Builtin.timeNowMs ()
+let _reset = Darklang.LanguageTools.InterpreterStats.reset ()
+let t0 = Darklang.Cli.Telemetry.now ()
 let result = repeat (iters ()) 0
-let t1 = Builtin.timeNowMs ()
-Stdlib.printLine ("elapsed_ms=" ++ (Stdlib.Int.toString (t1 - t0)) ++ " result=" ++ (Stdlib.Int.toString result))
+let t1 = Darklang.Cli.Telemetry.now ()
+Stdlib.printLine ("elapsed_ms=" ++ (Stdlib.Int.toString (t1 - t0)) ++ " result=" ++ (Stdlib.Int.toString result) ++ " stats=" ++ (Darklang.LanguageTools.InterpreterStats.get ()))

--- a/scripts/perf/workloads/suite/strings.dark
+++ b/scripts/perf/workloads/suite/strings.dark
@@ -1,7 +1,7 @@
 // Strings: concatenation, split, join, length. Text handling is most of what a CLI does, and it is
 // a completely different allocation shape from lists of Dvals.
 let iters () : Int =
-  match Builtin.environmentGet "PERF_ITERS" with
+  match Stdlib.Env.get "PERF_ITERS" with
   | Some s ->
     match Stdlib.Int.parse s with
     | Ok n -> n
@@ -19,8 +19,8 @@ let repeat (times: Int) (acc: Int) : Int =
   if times <= 0 then acc else repeat (times - 1) (acc + (work times))
 
 let _warm = repeat 20 0
-let _reset = Builtin.interpreterStatsReset ()
-let t0 = Builtin.timeNowMs ()
+let _reset = Darklang.LanguageTools.InterpreterStats.reset ()
+let t0 = Darklang.Cli.Telemetry.now ()
 let result = repeat (iters ()) 0
-let t1 = Builtin.timeNowMs ()
-Stdlib.printLine ("elapsed_ms=" ++ (Stdlib.Int.toString (t1 - t0)) ++ " result=" ++ (Stdlib.Int.toString result))
+let t1 = Darklang.Cli.Telemetry.now ()
+Stdlib.printLine ("elapsed_ms=" ++ (Stdlib.Int.toString (t1 - t0)) ++ " result=" ++ (Stdlib.Int.toString result) ++ " stats=" ++ (Darklang.LanguageTools.InterpreterStats.get ()))


### PR DESCRIPTION
A fast path that never fired: `Option`, `Result` and records with type arguments are what most Dark code returns, and the synchronous path added in #5700 ran only for types with *no* type arguments, so it skipped all of them. Then ten passes over record and enum construction, each found by re-profiling the last.

## Allocation

Per iteration, `scripts/perf/suite --release`, three readings against a release CLI built from this branch.

| workload | before | after | change |
|---|---|---|---|
| `records` | 8.3 KB | **4.26 KB** | **-48.7%** |
| `json` | 13.0 KB | **10.00 KB** | **-23.1%** |
| `dicts` | 15.7 KB | **12.36 KB** | **-21.3%** |
| `strings` | 6.6 KB | 6.45 KB | -2.3% |
| `lists` | 12.0 KB | 11.84 KB | -1.3% |
| `containers` | -- | 3.04 KB | new workload |

An HTTP request costs **76.31 KB** at 5,269 req/s, p50 2.21 ms. The gate's Debug budget came down 8.0 -> 7.8 MB, lowered in the commits that earned it.

---

## The fast path that never ran

`checkEnumFields`, `checkRecordFields` and `updateRecordFields` each guarded the synchronous path with `List.isEmpty typeArgs`, so every `Option`, `Result` and `Box<'v>` fell through to the async one. The guard was there because binding type arguments needed the type store, which is async; `updateTypeArgsSync` does it without leaving the sync path, so the condition comes out. `CreateEnum` 2,016 -> 928 B/op, `Option` 2,200 -> 1,112, `Result` 2,568 -> 1,304, parameterised record 3,464 -> 1,608.

None of the six existing workloads noticed, because they use non-parameterised types. Hence a seventh, `containers.dark`: 9.09 KB/iteration on a pre-fix build, 6.2 after.

## Ten passes over construction

Each found by re-reading the profile after the previous one, and none was the step planned in advance:

- `DvalCreator.enum`, `record` and `recordUpdate` were unconditional `uply` blocks opening with a `let!`, so every record and enum entered a state machine. They read both lookups with `Ply.trySync` now.
- Three rounds of hoisting local helpers to top level. A local helper on a hot path is a closure however it is annotated, `inline` included; twice the helper being hoisted was one an earlier pass had just introduced.
- `DvalCreator.list` and `dict` folded a lambda over a tuple accumulator: a closure and a tuple per element. Top-level recursions returning struct tuples instead.
- Four reference `Tuple3` returns in the check and resolve functions, now struct tuples.
- `unifyTypeArgsSyncVT` and `ValueType.merge` used `match a, b with`, which allocates the pair -- once per type argument and once per list element. Nested matches.
- `dictAddEntry` returned a reference pair and took its key and value tupled.

Closures went from 43% of the `records` profile to under 2%, and its tick count 4,487 -> 2,000 for identical work.

## Also in here

`interpreterStatsGet` reports `byOpcode` and `byStage`, both already collected on every instruction and then discarded. Only the fine-grained stages are trustworthy and the code says so: the totals and `stats.builtinAlloc` bracket across the builtin's `Ply` and measure nested execution.

`scripts/perf/http` drove load from one Python process, GIL-bound at ~2,100 req/s, so it saturated on its own client and could not detect a change in what it measured. Now `-p` processes, default 4.

`HttpServer.routeRequest` re-split the request path per handler: 333 -> 238 package calls per request. `PackageRefs` caches each ref against a generation counter. `Dict.keys`/`values` use `Map.foldBack`. Fixed `InterpreterStats.enableDetailedTiming`, which passed `()` to a `Bool` parameter, and added the missing `gcAllocatedBytes` wrapper.

## Where it stops

Every workload is now dominated by its own data structure: `lists` 88% cons cells, `dicts` 45% `MapTreeNode`, `strings` 36% `String`, `records` ~34% in the `Map<string, Dval>` family. Closures are under 2% everywhere. Going further means changing how values are represented, which the roadmap describes and does not start.

One diagnosis in the docs was wrong and is corrected: `dicts` was recorded as costing call volume, ~237 package calls per iteration. Its closures are 0.41%; a warm package call allocates nothing, so those calls cost instructions, not bytes. Profiled properly it gave -21.3%.

Method, what is worth doing next, and the round-by-round numbers are in `docs/perf/`.
