### PR TITLE
Stop run-in-docker hanging forever on an agent's stdin

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -192,13 +192,10 @@ functions are self-recursive already.
 **Record update takes no type tag.** `{ state with field = v }` is right.
 `MyType { state with field = v }` looks like F# but parses as function application.
 
-**Don't leave `run-in-docker` reading an agent's stdin.** The non-tty path forwards stdin
-with `cat <&0`, which needs an fd 0 that reaches EOF. Claude Code's Bash tool hands you a
-socket that never does, so the call hangs past its timeout and strands ~10 processes per
-invocation. `run-in-docker` now redirects fd 0 to `/dev/null` unless it's a tty, a pipe or
-a regular file, so this is handled; don't undo that guard. If you ever see stalled
-`run-in-docker` trees, `pkill -f 'scripts/run-in-docker'` clears them, and the container
-work they were driving has usually already finished.
+**`run-in-docker` ignores stdin unless something's on it.** Fd 0 is forwarded through a `cat`
+that needs an EOF, and an agent harness hands you a socket that never gives one, which used to
+hang the call well past its timeout. If you pipe real input and it gets dropped, `DARK_STDIN=1`
+forces it through.
 
 **Value bindings take no type annotation.** `let xs = [...]`, not `let xs : List<String> = [...]`,
 which fails with "Value annotations are not supported". Function bindings do take them, and

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -192,6 +192,14 @@ functions are self-recursive already.
 **Record update takes no type tag.** `{ state with field = v }` is right.
 `MyType { state with field = v }` looks like F# but parses as function application.
 
+**Don't leave `run-in-docker` reading an agent's stdin.** The non-tty path forwards stdin
+with `cat <&0`, which needs an fd 0 that reaches EOF. Claude Code's Bash tool hands you a
+socket that never does, so the call hangs past its timeout and strands ~10 processes per
+invocation. `run-in-docker` now redirects fd 0 to `/dev/null` unless it's a tty, a pipe or
+a regular file, so this is handled; don't undo that guard. If you ever see stalled
+`run-in-docker` trees, `pkill -f 'scripts/run-in-docker'` clears them, and the container
+work they were driving has usually already finished.
+
 **Value bindings take no type annotation.** `let xs = [...]`, not `let xs : List<String> = [...]`,
 which fails with "Value annotations are not supported". Function bindings do take them, and
 nested functions require them.

--- a/scripts/run-in-docker
+++ b/scripts/run-in-docker
@@ -67,6 +67,16 @@ for var in $(env | sed -n 's/^\(DARK_[A-Z0-9_]*\)=.*/\1/p'); do
   DARK_ENV_FLAGS+=( -e "$var" )
 done
 
+# fd 0 has to be something that will actually reach EOF, because the `cat <&0` below
+# reads it to completion. Agent harnesses (Claude Code's Bash tool, at least) hand the
+# command a *socket* that never EOFs and never carries data; `cat` then blocks forever,
+# deadlocking this pipeline long after the `docker exec` has exited, and every call
+# leaks ~10 processes. Pipes and regular files do EOF, so they're forwarded as before;
+# anything else that isn't a tty gets /dev/null.
+if [ ! -t 0 ] && [ ! -p /dev/stdin ] && [ ! -f /dev/stdin ]; then
+  exec 0</dev/null
+fi
+
 if [ -t 0 ] ;
 then
   docker exec "${DARK_ENV_FLAGS[@]}" -it "${NAME}" "${ARGS[@]}" ;

--- a/scripts/run-in-docker
+++ b/scripts/run-in-docker
@@ -67,13 +67,13 @@ for var in $(env | sed -n 's/^\(DARK_[A-Z0-9_]*\)=.*/\1/p'); do
   DARK_ENV_FLAGS+=( -e "$var" )
 done
 
-# fd 0 has to be something that will actually reach EOF, because the `cat <&0` below
-# reads it to completion. Agent harnesses (Claude Code's Bash tool, at least) hand the
-# command a *socket* that never EOFs and never carries data; `cat` then blocks forever,
-# deadlocking this pipeline long after the `docker exec` has exited, and every call
-# leaks ~10 processes. Pipes and regular files do EOF, so they're forwarded as before;
-# anything else that isn't a tty gets /dev/null.
-if [ ! -t 0 ] && [ ! -p /dev/stdin ] && [ ! -f /dev/stdin ]; then
+# The `cat <&0` below reads fd 0 to EOF, so only forward it when something will get there.
+# Pipes and regular files always do. Sockets are ambiguous: agent harnesses hand over one that
+# carries no data and never EOFs, while node/libuv's `stdio: 'pipe'` socketpair does both, so
+# test for readability (which EOF counts as) rather than excluding sockets outright.
+if [[ ! -v DARK_STDIN ]] \
+  && [ ! -t 0 ] && [ ! -p /dev/stdin ] && [ ! -f /dev/stdin ] \
+  && ! read -r -t 0 -u 0 2>/dev/null; then
   exec 0</dev/null
 fi
 


### PR DESCRIPTION
tl;dr I had a bunch of should-be-dead processes hanging around on my machine after hours of claude sessions, and this should help prevent those.

`run-in-docker`'s non-tty path pipes stdin through `cat <&0`, which assumes fd 0 eventually reaches EOF. Agent harnesses (Claude Code's Bash tool, at least) hand the command a *socket* that carries no data and never EOFs, so `cat` blocks forever, long after the `docker exec` has finished cleanly. The call burns its whole timeout, returns nothing, and strands ~10 processes that nothing reaps. One agent working in a clone for a day left 12 such trees.

The `cat` isn't removable: it's what rewrites host paths in piped input to container paths. So the fix is to forward fd 0 only when it will EOF. A tty takes the `-it` branch, and pipes and regular files always EOF, so those are unchanged.

Sockets are the interesting case, and why this isn't a one-liner. My first cut excluded them outright, which is wrong: node/libuv hands a child a socketpair for `stdio: 'pipe'`, and that one does carry data and does EOF. Dropping it would silently eat real input, which is worse than the hang, since an eaten stdin looks exactly like an empty one. `read -t 0` separates them without consuming anything (it reports readability, and EOF counts as readable), so only a socket with nothing on it gets `/dev/null`, and `DARK_STDIN=1` forces forwarding.

Also adds a Gotchas entry, since the symptom points nowhere near the cause: the build actually passed, and all the agent sees is a timeout.

Verified per fd kind: harness socket goes from hanging to 7ms, pipe / file / heredoc still round-trip with rewriting intact, a node socketpair still delivers its input, `DARK_STDIN=1` still blocks as asked, nonzero exits still propagate.

Two things worth a look:

- The `read -t 0` probe is a race in principle, if a producer hasn't written by the time we look. The probe happens after a `docker ps`, so there's slack, and `DARK_STDIN=1` is the escape hatch. Narrow race beats guaranteed hang, imo.
- Unverified on mac: the guard rests on `[ -p /dev/stdin ]` behaving through Darwin's `/dev/fd`. Someone with a mac should run `echo x | scripts/run-in-docker cat` once.

The Gotchas entry started out carrying a `pkill -f 'scripts/run-in-docker'` recovery step. I dropped it: it matches every clone on the box, so it would kill other agents' live builds, and with the guard in place there shouldn't be stalled trees left to clear.
