### PR TITLE
Join builtin descriptions written across source lines

### DIFF
--- a/backend/src/Builtins/Builtins.Cli/Libs/Stdin.fs
+++ b/backend/src/Builtins/Builtins.Cli/Libs/Stdin.fs
@@ -456,8 +456,8 @@ let fns () : List<BuiltInFn> =
       parameters = [ Param.make "unit" TUnit "" ]
       returnType = TString
       description =
-        "Reads all available input from standard input until EOF.
-        Blocks if stdin is an interactive TTY with no EOF signal."
+        "Reads all available input from standard input until EOF. Blocks if "
+        + "stdin is an interactive TTY with no EOF signal."
       fn =
         (function
         | _, _, _, [| DUnit |] ->

--- a/backend/src/Builtins/Builtins.Http.Client/Libs/HttpClient.fs
+++ b/backend/src/Builtins/Builtins.Http.Client/Libs/HttpClient.fs
@@ -691,9 +691,9 @@ let fns (config : Configuration) : List<BuiltInFn> =
           (TCustomType(NR.ok (responseOKType ()), []))
           (TCustomType(NR.ok (responseErrorType ()), []))
       description =
-        "Make blocking HTTP call to <param uri>. Returns a <type Result> where
-      the response is wrapped in {{ Ok }} if a response was successfully
-      received and parsed, and is wrapped in {{ Error }} otherwise"
+        "Make blocking HTTP call to <param uri>. Returns a <type Result> where "
+        + "the response is wrapped in {{ Ok }} if a response was successfully "
+        + "received and parsed, and is wrapped in {{ Error }} otherwise"
       fn =
         let responseTypeOK = KTCustomType(responseOKType (), [])
         let responseTypeErr = KTCustomType(responseErrorType (), [])
@@ -876,11 +876,12 @@ let fns (config : Configuration) : List<BuiltInFn> =
           (TCustomType(NR.ok (streamResponseType ()), []))
           (TCustomType(NR.ok (responseErrorType ()), []))
       description =
-        "Make a streaming HTTP call to <param uri>. Returns a <type StreamResponse>
-      whose `body` is a lazy <type Stream> that yields bytes as they arrive.
-      Drain with `Builtin.streamToList`/`streamToBlob`, or compose with
-      `streamMap`/`streamFilter`/etc. The underlying HTTP response is released
-      when the stream is drained to completion or `Builtin.streamClose`d."
+        "Make a streaming HTTP call to <param uri>. Returns a <type "
+        + "StreamResponse> whose `body` is a lazy <type Stream> that yields bytes "
+        + "as they arrive. Drain with `Builtin.streamToList`/`streamToBlob`, or "
+        + "compose with `streamMap`/`streamFilter`/etc. The underlying HTTP "
+        + "response is released when the stream is drained to completion or "
+        + "`Builtin.streamClose`d."
       fn =
         let streamTypeOk = KTCustomType(streamResponseType (), [])
         let streamTypeErr = KTCustomType(responseErrorType (), [])

--- a/backend/src/Builtins/Builtins.Language/Libs/Reflection.fs
+++ b/backend/src/Builtins/Builtins.Language/Libs/Reflection.fs
@@ -41,10 +41,10 @@ let fns () : List<BuiltInFn> =
           []
         )
       description =
-        "Returns a meta representation of the real underlying dval, as a
-         <type LanguageTools.RuntimeTypes.Dval>. This is what lets a value be
-         turned back into source (see
-         <fn LanguageTools.RuntimeTypesToProgramTypes.dvalToExpr>)."
+        "Returns a meta representation of the real underlying dval, as a <type "
+        + "LanguageTools.RuntimeTypes.Dval>. This is what lets a value be turned "
+        + "back into source (see <fn "
+        + "LanguageTools.RuntimeTypesToProgramTypes.dvalToExpr>)."
       fn =
         (function
         | _, _, _, [| dv |] ->

--- a/backend/src/Builtins/Builtins.Matter/Libs/DB.fs
+++ b/backend/src/Builtins/Builtins.Matter/Libs/DB.fs
@@ -569,9 +569,10 @@ let fns () : List<BuiltInFn> =
       parameters = [ tableParam "a"; queryFilterParam "a" ]
       returnType = TList(tvar "a")
       description =
-        "Fetch all the values from <param table> for which filter returns true.
-        Note that this does not check every value in <param table>, but rather is optimized to find data with indexes.
-        Errors at compile-time if Dark's compiler does not support the code in question."
+        "Fetch all the values from <param table> for which filter returns true. "
+        + "Note that this does not check every value in <param table>, but rather "
+        + "is optimized to find data with indexes. Errors at compile-time if "
+        + "Dark's compiler does not support the code in question."
       fn =
         (function
         | exeState, vm, _, [| DDB dbname; DApplicable(AppLambda appLambda) |] ->

--- a/backend/src/Builtins/Builtins.Matter/Libs/PM/Caps.fs
+++ b/backend/src/Builtins/Builtins.Matter/Libs/PM/Caps.fs
@@ -31,9 +31,10 @@ let fns : List<BuiltInFn> =
       parameters = [ Param.make "unit" TUnit "" ]
       returnType = capsType
       description =
-        "This instance's current capability grant, as a structured <type Capabilities> value (NONE — the
-         strict default — is the all-empty grant). The CORE read primitive: `.dark` renders it and
-         composes adjustments over it."
+        "This instance's current capability grant, as a structured <type "
+        + "Capabilities> value (NONE — the strict default — is the all-empty "
+        + "grant). The CORE read primitive: `.dark` renders it and composes "
+        + "adjustments over it."
       fn =
         (function
         | _, _, _, [| DUnit |] ->
@@ -52,9 +53,10 @@ let fns : List<BuiltInFn> =
       parameters = [ Param.make "caps" capsType "The full grant to replace with" ]
       returnType = TUnit
       description =
-        "REPLACE the whole grant with exactly this <type Capabilities> — the CORE write primitive. The
-         all-empty grant sets NONE. `.dark` parses/validates spec strings into the structure and builds
-         grant/revoke/clear/profile on top of get+set."
+        "REPLACE the whole grant with exactly this <type Capabilities> — the "
+        + "CORE write primitive. The all-empty grant sets NONE. `.dark` "
+        + "parses/validates spec strings into the structure and builds "
+        + "grant/revoke/clear/profile on top of get+set."
       fn =
         (function
         | _, _, _, [| caps |] ->
@@ -74,8 +76,9 @@ let fns : List<BuiltInFn> =
       parameters = [ Param.make "hash" TString "The package-fn hash to analyze" ]
       returnType = capsType
       description =
-        "The capabilities a package fn (transitively) needs, as a structured <type Capabilities> value
-         (behind `dark caps needed-for <fn>`). See `LibDB.PackageCaps`."
+        "The capabilities a package fn (transitively) needs, as a structured "
+        + "<type Capabilities> value (behind `dark caps needed-for <fn>`). See "
+        + "`LibDB.PackageCaps`."
       fn =
         (function
         | exeState, _, _, [| DString hashStr |] ->

--- a/backend/src/Builtins/Builtins.Matter/Libs/PM/PackageOps.fs
+++ b/backend/src/Builtins/Builtins.Matter/Libs/PM/PackageOps.fs
@@ -54,9 +54,10 @@ let fns (pm : PT.PackageManager) : List<BuiltInFn> =
           Param.make "ops" (TList(TCustomType(NR.ok (packageOpTypeName ()), []))) "" ]
       returnType = TypeReference.result TInt TString
       description =
-        "Add package ops to the database as WIP (uncommitted) on the given branch.
-        Returns the number of inserted ops on success (duplicates are skipped), or an error message on failure.
-        Use scmCommitWipOpsByIds to commit WIP ops."
+        "Add package ops to the database as WIP (uncommitted) on the given "
+        + "branch. Returns the number of inserted ops on success (duplicates are "
+        + "skipped), or an error message on failure. Use scmCommitWipOpsByIds to "
+        + "commit WIP ops."
       fn =
         let resultOk = Dval.resultOk KTInt KTString
         let resultError = Dval.resultError KTInt KTString
@@ -232,9 +233,9 @@ let fns (pm : PT.PackageManager) : List<BuiltInFn> =
           )
         )
       description =
-        "Get all WIP ops on a branch with their DB row id and propagation_id
-        (None unless the op is part of a propagation batch). Use this when you
-        need to operate on individual ops (e.g. partial commit / discard)."
+        "Get all WIP ops on a branch with their DB row id and propagation_id "
+        + "(None unless the op is part of a propagation batch). Use this when you "
+        + "need to operate on individual ops (e.g. partial commit / discard)."
       fn =
         function
         | _, vm, _, [| DUuid branchId |] ->
@@ -269,14 +270,14 @@ let fns (pm : PT.PackageManager) : List<BuiltInFn> =
           Param.make
             "opIds"
             (TList TUuid)
-            "WIP op IDs from scmGetWipOpsWithIds. Every id must belong to this
-            branch and still be WIP, or nothing is committed." ]
+            ("WIP op IDs from scmGetWipOpsWithIds. Every id must belong to this "
+             + "branch and still be WIP, or nothing is committed.") ]
       returnType = TypeReference.result TString TString
       description =
-        "Commit the named WIP ops and their derived projection rows. The caller
-        owns selection policy and dependency closure. Projection rows are matched
-        by content key until they can be tied directly to source op IDs. Returns
-        the commit hash, or an error message on failure."
+        "Commit the named WIP ops and their derived projection rows. The caller "
+        + "owns selection policy and dependency closure. Projection rows are "
+        + "matched by content key until they can be tied directly to source op "
+        + "IDs. Returns the commit hash, or an error message on failure."
       fn =
         let resultOk = Dval.resultOk KTString KTString
         let resultError = Dval.resultError KTString KTString
@@ -314,8 +315,8 @@ let fns (pm : PT.PackageManager) : List<BuiltInFn> =
       parameters = [ Param.make "branchId" TUuid "Branch ID" ]
       returnType = TypeReference.result TInt TString
       description =
-        "Discard all WIP ops on a branch.
-        Returns the count of discarded ops on success, or an error message on failure."
+        "Discard all WIP ops on a branch. Returns the count of discarded ops on "
+        + "success, or an error message on failure."
       fn =
         let resultOk = Dval.resultOk KTInt KTString
         let resultError = Dval.resultError KTInt KTString
@@ -420,9 +421,10 @@ let fns (pm : PT.PackageManager) : List<BuiltInFn> =
           )
         )
       description =
-        "Get the items (content hash + kind) that the given item directly depends
-        on, resolved over the branch chain. Used by partial commit to warn when a
-        selected item references uncommitted items not in the selection."
+        "Get the items (content hash + kind) that the given item directly "
+        + "depends on, resolved over the branch chain. Used by partial commit to "
+        + "warn when a selected item references uncommitted items not in the "
+        + "selection."
       fn =
         (function
         | _, _, _, [| DUuid branchId; hashDval |] ->

--- a/backend/src/Builtins/Builtins.Matter/Libs/PM/Packages.fs
+++ b/backend/src/Builtins/Builtins.Matter/Libs/PM/Packages.fs
@@ -409,8 +409,9 @@ let fns (pm : PT.PackageManager) : List<BuiltInFn> =
       returnType =
         TTuple(TList TString, TList TString, [ TList TString; TList TString ])
       description =
-        "Search, returning only names: (direct submodules, types, values, fns). Submodules are already
-         reduced to the direct children of the query's module and sorted."
+        "Search, returning only names: (direct submodules, types, values, fns). "
+        + "Submodules are already reduced to the direct children of the query's "
+        + "module and sorted."
       fn =
         function
         | _, _, _, [| DUuid branchId; query as DRecord(_, _, _, _fields) |] ->
@@ -473,8 +474,9 @@ let fns (pm : PT.PackageManager) : List<BuiltInFn> =
           TList(TTuple(TString, TCustomType(NR.ok (PT2DT.Hash.typeName ()), []), []))
         TTuple(TList TString, nameAndHash, [ nameAndHash; nameAndHash ])
       description =
-        "Search, returning (direct submodules, types, values, fns) as (name, hash) pairs. Like
-         pmSearchNames but keeps each item's hash, which listings need for deprecation marks."
+        "Search, returning (direct submodules, types, values, fns) as (name, "
+        + "hash) pairs. Like pmSearchNames but keeps each item's hash, which "
+        + "listings need for deprecation marks."
       fn =
         function
         | _, _, _, [| DUuid branchId; query as DRecord(_, _, _, _fields) |] ->

--- a/backend/src/Builtins/Builtins.Matter/Libs/Traces.fs
+++ b/backend/src/Builtins/Builtins.Matter/Libs/Traces.fs
@@ -127,9 +127,9 @@ let fns () : List<BuiltInFn> =
       parameters = [ Param.make "unit" TUnit "" ]
       returnType = TBool
       description =
-        "Whether traces are being recorded. False means every trace query will come
-back empty no matter what ran, so callers can say so instead of showing an empty
-list and letting you conclude nothing happened."
+        "Whether traces are being recorded. False means every trace query will "
+        + "come back empty no matter what ran, so callers can say so instead of "
+        + "showing an empty list and letting you conclude nothing happened."
       fn =
         (function
         | _, _, _, [| DUnit |] ->

--- a/backend/src/Builtins/Builtins.Pure/Libs/Base64.fs
+++ b/backend/src/Builtins/Builtins.Pure/Libs/Base64.fs
@@ -18,10 +18,11 @@ let fns () : List<BuiltInFn> =
       parameters = [ Param.make "s" TString "" ]
       returnType = TypeReference.result TBlob TString
       description =
-        "Base64 decodes a string. Works with both the URL-safe and standard Base64
-         alphabets defined in [RFC 4648](https://www.rfc-editor.org/rfc/rfc4648.html)
-         sections [4](https://www.rfc-editor.org/rfc/rfc4648.html#section-4) and
-         [5](https://www.rfc-editor.org/rfc/rfc4648.html#section-5)."
+        "Base64 decodes a string. Works with both the URL-safe and standard "
+        + "Base64 alphabets defined in [RFC "
+        + "4648](https://www.rfc-editor.org/rfc/rfc4648.html) sections "
+        + "[4](https://www.rfc-editor.org/rfc/rfc4648.html#section-4) and "
+        + "[5](https://www.rfc-editor.org/rfc/rfc4648.html#section-5)."
       fn =
         let resultOk r = Dval.resultOk KTBlob KTString r |> Ply
         let resultError r = Dval.resultError KTBlob KTString r |> Ply
@@ -59,9 +60,10 @@ let fns () : List<BuiltInFn> =
       parameters = [ Param.make "blob" TBlob "" ]
       returnType = TString
       description =
-        "Base64 encodes <param blob> with {{=}} padding. Uses the standard
-         alphabet defined in [RFC 4648](https://www.rfc-editor.org/rfc/rfc4648.html)
-         section [4](https://www.rfc-editor.org/rfc/rfc4648.html#section-4)."
+        "Base64 encodes <param blob> with {{=}} padding. Uses the standard "
+        + "alphabet defined in [RFC "
+        + "4648](https://www.rfc-editor.org/rfc/rfc4648.html) section "
+        + "[4](https://www.rfc-editor.org/rfc/rfc4648.html#section-4)."
       fn =
         (function
         | state, _, _, [| DBlob ref |] ->
@@ -81,9 +83,10 @@ let fns () : List<BuiltInFn> =
       parameters = [ Param.make "blob" TBlob "" ]
       returnType = TString
       description =
-        "Base64URL encodes <param blob> with {{=}} padding. Uses URL-safe encoding
-         with {{-}} and {{_}} instead of {{+}} and {{/}}, as defined in RFC 4648
-         section [5](https://www.rfc-editor.org/rfc/rfc4648.html#section-5)."
+        "Base64URL encodes <param blob> with {{=}} padding. Uses URL-safe "
+        + "encoding with {{-}} and {{_}} instead of {{+}} and {{/}}, as defined "
+        + "in RFC 4648 section "
+        + "[5](https://www.rfc-editor.org/rfc/rfc4648.html#section-5)."
       fn =
         (function
         | state, _, _, [| DBlob ref |] ->

--- a/backend/src/Builtins/Builtins.Pure/Libs/Blob.fs
+++ b/backend/src/Builtins/Builtins.Pure/Libs/Blob.fs
@@ -81,8 +81,9 @@ let fns () : List<BuiltInFn> =
       parameters = [ Param.make "blob" TBlob "" ]
       returnType = TString
       description =
-        "Hex (Base16) encodes <param blob> using an uppercase alphabet. Complies
-         with [RFC 4648 section 8](https://www.rfc-editor.org/rfc/rfc4648.html#section-8)."
+        "Hex (Base16) encodes <param blob> using an uppercase alphabet. "
+        + "Complies with [RFC 4648 section "
+        + "8](https://www.rfc-editor.org/rfc/rfc4648.html#section-8)."
       fn =
         (function
         | state, _, _, [| DBlob ref |] ->

--- a/backend/src/Builtins/Builtins.Pure/Libs/Bool.fs
+++ b/backend/src/Builtins/Builtins.Pure/Libs/Bool.fs
@@ -14,9 +14,8 @@ let fns () : List<BuiltInFn> =
       parameters = [ Param.make "b" TBool "" ]
       returnType = TBool
       description =
-        "Returns the inverse of <param b>:
-        {{true}} if <param b> is {{false}}
-        and {{false}} if <param b> is {{true}}"
+        "Returns the inverse of <param b>: {{true}} if <param b> is {{false}} "
+        + "and {{false}} if <param b> is {{true}}"
       fn =
         (function
         | _, _, _, [| DBool b |] -> Ply(Dval.bool (not b))

--- a/backend/src/Builtins/Builtins.Pure/Libs/Char.fs
+++ b/backend/src/Builtins/Builtins.Pure/Libs/Char.fs
@@ -14,8 +14,8 @@ let fns () : List<BuiltInFn> =
       parameters = [ Param.make "c" TChar "" ]
       returnType = TChar
       description =
-        "Return the uppercase value of <param c>.
-        If <param c> does not have an uppercase value, returns <param c>"
+        "Return the uppercase value of <param c>. If <param c> does not have an "
+        + "uppercase value, returns <param c>"
       fn =
         function
         | _, _, _, [| DChar c |] -> Ply(DChar(c.ToUpper()))
@@ -31,8 +31,8 @@ let fns () : List<BuiltInFn> =
       parameters = [ Param.make "c" TChar "" ]
       returnType = TChar
       description =
-        "Return the lowercase value of <param c>.
-        If <param c> does not have a lowercase value, returns <param c>"
+        "Return the lowercase value of <param c>. If <param c> does not have a "
+        + "lowercase value, returns <param c>"
       fn =
         function
         | _, _, _, [| DChar c |] -> Ply(DChar(c.ToLower()))
@@ -144,9 +144,9 @@ let fns () : List<BuiltInFn> =
       parameters = [ Param.make "codepoint" TInt "" ]
       returnType = TypeReference.option TChar
       description =
-        "Return {{Some <var c>}} for the Unicode codepoint <param codepoint>,
-        or {{None}} if the value is not a valid scalar codepoint
-        (i.e. negative, greater than 0x10FFFF, or a surrogate)."
+        "Return {{Some <var c>}} for the Unicode codepoint <param codepoint>, "
+        + "or {{None}} if the value is not a valid scalar codepoint (i.e. "
+        + "negative, greater than 0x10FFFF, or a surrogate)."
       fn =
         function
         | _, _, _, [| DInt cp |] ->

--- a/backend/src/Builtins/Builtins.Pure/Libs/DateTime.fs
+++ b/backend/src/Builtins/Builtins.Pure/Libs/DateTime.fs
@@ -324,8 +324,8 @@ let fns () : List<BuiltInFn> =
       parameters = [ Param.make "date" TDateTime "" ]
       returnType = TInt
       description =
-        "Returns the weekday of <param date> as an <type Int>.
-        Monday = {{1}}, Tuesday = {{2}}, ... Sunday = {{7}} (in accordance with ISO 8601)"
+        "Returns the weekday of <param date> as an <type Int>. Monday = {{1}}, "
+        + "Tuesday = {{2}}, ... Sunday = {{7}} (in accordance with ISO 8601)"
       fn =
         (function
         | _, _, _, [| DDateTime d |] ->

--- a/backend/src/Builtins/Builtins.Pure/Libs/Dict.fs
+++ b/backend/src/Builtins/Builtins.Pure/Libs/Dict.fs
@@ -101,8 +101,9 @@ let fns () : List<BuiltInFn> =
       parameters = [ Param.make "dict" (TDict varA) "" ]
       returnType = TList(TTuple(TString, varA, []))
       description =
-        "Returns <param dict>'s entries as a list of {{(key, value)}} tuples, in an arbitrary order.
-        This function is the opposite of <fn Dict.fromList>"
+        "Returns <param dict>'s entries as a list of {{(key, value)}} tuples, "
+        + "in an arbitrary order. This function is the opposite of <fn "
+        + "Dict.fromList>"
       fn =
         (function
         | _, _, _, [| DDict(valueType, o) |] ->
@@ -122,14 +123,12 @@ let fns () : List<BuiltInFn> =
       parameters = [ Param.make "entries" (TList(TTuple(TString, varA, []))) "" ]
       returnType = TDict varB
       description =
-        "Returns a <type dict> with <param entries>. Each value in <param entries>
-          must be a {{(key, value)}} tuple, where <var key> is a <type String>.
-
-          If <param entries> contains duplicate <var key>s, the last entry with that
-          key will be used in the resulting dictionary (use <fn Dict.fromList> if you
-          want to enforce unique keys).
-
-          This function is the opposite of <fn Dict.toList>."
+        "Returns a <type dict> with <param entries>. Each value in <param "
+        + "entries> must be a {{(key, value)}} tuple, where <var key> is a <type "
+        + "String>.\n\nIf <param entries> contains duplicate <var key>s, the last "
+        + "entry with that key will be used in the resulting dictionary (use <fn "
+        + "Dict.fromList> if you want to enforce unique keys).\n\nThis function "
+        + "is the opposite of <fn Dict.toList>."
       fn =
         (function
         | _, _, _, [| DList(_, []) |] -> DDict(VT.unknown, Map.empty) |> Ply
@@ -149,14 +148,12 @@ let fns () : List<BuiltInFn> =
       parameters = [ Param.make "entries" (TList(TTuple(TString, varB, []))) "" ]
       returnType = TypeReference.option (TDict varB)
       description =
-        "Each value in <param entries> must be a {{(key, value)}} tuple, where <var
-         key> is a <type String>.
-
-         If <param entries> contains no duplicate keys, returns {{Some <var dict>}}
-         where <var dict> has <param entries>.
-
-         Otherwise, returns {{None}} (use <fn Dict.fromListOverwritingDuplicates>
-         if you want to overwrite duplicate keys)."
+        "Each value in <param entries> must be a {{(key, value)}} tuple, where "
+        + "<var key> is a <type String>.\n\nIf <param entries> contains no "
+        + "duplicate keys, returns {{Some <var dict>}} where <var dict> has "
+        + "<param entries>.\n\nOtherwise, returns {{None}} (use <fn "
+        + "Dict.fromListOverwritingDuplicates> if you want to overwrite duplicate "
+        + "keys)."
       fn =
         let dictType = VT.unknownTODO
         let optType = VT.dict dictType
@@ -191,8 +188,9 @@ let fns () : List<BuiltInFn> =
       parameters = [ Param.make "dict" (TDict varA) ""; Param.make "key" TString "" ]
       returnType = TypeReference.option varA
       description =
-        "If the <param dict> contains <param key>, returns the corresponding value,
-         wrapped in an <type Option>: {{Some value}}. Otherwise, returns {{None}}."
+        "If the <param dict> contains <param key>, returns the corresponding "
+        + "value, wrapped in an <type Option>: {{Some value}}. Otherwise, returns "
+        + "{{None}}."
       fn =
         (function
         | _, vm, _, [| DDict(_vtTODO, o); DString s |] ->
@@ -211,8 +209,8 @@ let fns () : List<BuiltInFn> =
       parameters = [ Param.make "dict" (TDict varA) ""; Param.make "key" TString "" ]
       returnType = TBool
       description =
-        "Returns {{true}} if the <param dict> contains an entry with <param key>, and
-         {{false}} otherwise"
+        "Returns {{true}} if the <param dict> contains an entry with <param "
+        + "key>, and {{false}} otherwise"
       fn =
         (function
         | _, _, _, [| DDict(_, o); DString s |] -> Ply(DBool(Map.containsKey s o))
@@ -229,9 +227,9 @@ let fns () : List<BuiltInFn> =
         [ Param.make "left" (TDict varA) ""; Param.make "right" (TDict varA) "" ]
       returnType = TDict varA
       description =
-        "Returns a combined dictionary with both dictionaries' entries.
-        If the same key exists in both <param left> and <param right>,
-          it will have the value from <param right>."
+        "Returns a combined dictionary with both dictionaries' entries. If the "
+        + "same key exists in both <param left> and <param right>, it will have "
+        + "the value from <param right>."
       fn =
         (function
         | _, _vm, _, [| DDict(vt1, intoMap); DDict(vt2, fromMap) |] ->
@@ -259,8 +257,8 @@ let fns () : List<BuiltInFn> =
           Param.make "val" varA "" ]
       returnType = (TDict(TVariable "a"))
       description =
-        "Returns a copy of <param dict> with the <param key> set to <param val>.
-        If the key already exists in the Dict, an exception is raised."
+        "Returns a copy of <param dict> with the <param key> set to <param "
+        + "val>. If the key already exists in the Dict, an exception is raised."
       fn =
         (function
         | _, vm, _, [| DDict(vt, o); DString k; v |] ->
@@ -288,8 +286,9 @@ let fns () : List<BuiltInFn> =
           Param.make "val" varA "" ]
       returnType = (TDict(TVariable "a"))
       description =
-        "Returns a copy of <param dict> with the <param key> set to <param val>.
-        If the key already exists in the Dict, the previous value is overwritten."
+        "Returns a copy of <param dict> with the <param key> set to <param "
+        + "val>. If the key already exists in the Dict, the previous value is "
+        + "overwritten."
       fn =
         (function
         | _, vm, _, [| DDict(vt, o); DString k; v |] ->

--- a/backend/src/Builtins/Builtins.Pure/Libs/Float.fs
+++ b/backend/src/Builtins/Builtins.Pure/Libs/Float.fs
@@ -57,11 +57,9 @@ let fns () : List<BuiltInFn> =
       parameters = [ Param.make "a" TFloat "" ]
       returnType = TInt
       description =
-        "Round down to an integer value.
-
-        Consider <fn Float.truncate> if your goal
-        is to discard the fractional part of a number: {{Float.floor -1.9 == -2.0}}
-        but {{Float.truncate -1.9 == -1.0}}"
+        "Round down to an integer value.\n\nConsider <fn Float.truncate> if "
+        + "your goal is to discard the fractional part of a number: {{Float.floor "
+        + "-1.9 == -2.0}} but {{Float.truncate -1.9 == -1.0}}"
       fn =
         (function
         | _, vm, _, [| DFloat a |] -> a |> System.Math.Floor |> roundedToInt vm
@@ -77,11 +75,9 @@ let fns () : List<BuiltInFn> =
       parameters = [ Param.make "a" TFloat "" ]
       returnType = TInt
       description =
-        "Round down to an integer value.
-
-         Consider <fn Float.truncate> if your goal is to discard the fractional part
-         of a number: {{Float.floor -1.9 == -2.0}} but {{Float.truncate -1.9 ==
-         -1.0}}"
+        "Round down to an integer value.\n\nConsider <fn Float.truncate> if "
+        + "your goal is to discard the fractional part of a number: {{Float.floor "
+        + "-1.9 == -2.0}} but {{Float.truncate -1.9 == -1.0}}"
 
       fn =
         (function

--- a/backend/src/Builtins/Builtins.Pure/Libs/Int.fs
+++ b/backend/src/Builtins/Builtins.Pure/Libs/Int.fs
@@ -76,10 +76,10 @@ let fns () : List<BuiltInFn> =
       parameters = [ Param.make "a" TInt ""; Param.make "b" TInt "" ]
       returnType = TInt
       description =
-        "Returns the result of wrapping <param a> around so that {{0 <= res < b}}.
-         The modulus <param b> must be greater than 0.
-         Use <fn Int.remainder> if you want the remainder after division, which
-         has a different behavior for negative numbers."
+        "Returns the result of wrapping <param a> around so that {{0 <= res < "
+        + "b}}. The modulus <param b> must be greater than 0. Use <fn "
+        + "Int.remainder> if you want the remainder after division, which has a "
+        + "different behavior for negative numbers."
       fn =
         (function
         | _, vm, _, [| DInt a; DInt b |] ->
@@ -103,10 +103,11 @@ let fns () : List<BuiltInFn> =
       parameters = [ Param.make "value" TInt ""; Param.make "divisor" TInt "" ]
       returnType = TypeReference.result TInt TString
       description =
-        "Returns the integer remainder left over after dividing <param value> by
-         <param divisor>, as a <type Result>. The remainder will be negative only
-         if {{<var value> < 0}}. The sign of <param divisor> doesn't influence the
-         outcome. Returns an {{Error}} if <param divisor> is {{0}}."
+        "Returns the integer remainder left over after dividing <param value> "
+        + "by <param divisor>, as a <type Result>. The remainder will be negative "
+        + "only if {{<var value> < 0}}. The sign of <param divisor> doesn't "
+        + "influence the outcome. Returns an {{Error}} if <param divisor> is "
+        + "{{0}}."
       fn =
         let resultOk = Dval.resultOk KTInt KTString
         let resultError = Dval.resultError KTInt KTString
@@ -176,8 +177,8 @@ let fns () : List<BuiltInFn> =
       parameters = [ Param.make "base" TInt ""; Param.make "exponent" TInt "" ]
       returnType = TInt
       description =
-        "Raise <param base> to the power of <param exponent>. <param exponent>
-         must be non-negative. The arbitrary-precision result grows as needed."
+        "Raise <param base> to the power of <param exponent>. <param exponent> "
+        + "must be non-negative. The arbitrary-precision result grows as needed."
       fn =
         (function
         | _, vm, _, [| DInt b; DInt exp |] ->
@@ -307,8 +308,8 @@ let fns () : List<BuiltInFn> =
       parameters = [ Param.make "a" TInt "" ]
       returnType = TFloat
       description =
-        "Get the square root of an <type Int> as a <type Float>. Note that very
-         large values lose precision when converted to a float."
+        "Get the square root of an <type Int> as a <type Float>. Note that very "
+        + "large values lose precision when converted to a float."
       fn =
         (function
         | _, _, _, [| (DInt _) as v |] -> Ply(DFloat(sqrt (float (Dval.asBigInt v))))
@@ -324,8 +325,8 @@ let fns () : List<BuiltInFn> =
       parameters = [ Param.make "a" TInt "" ]
       returnType = TFloat
       description =
-        "Converts an <type Int> to a <type Float>. Very large values lose
-         precision."
+        "Converts an <type Int> to a <type Float>. Very large values lose "
+        + "precision."
       fn =
         (function
         | _, _, _, [| (DInt _) as v |] -> Ply(DFloat(float (Dval.asBigInt v)))
@@ -341,9 +342,9 @@ let fns () : List<BuiltInFn> =
       parameters = [ Param.make "a" TFloat "" ]
       returnType = TInt
       description =
-        "Converts a <type Float> to an <type Int>, truncating toward zero.
-         Unlike going via Int64, this preserves the full integer part of the
-         float (no 64-bit clamp)."
+        "Converts a <type Float> to an <type Int>, truncating toward zero. "
+        + "Unlike going via Int64, this preserves the full integer part of the "
+        + "float (no 64-bit clamp)."
       fn =
         (function
         // `bigint f` truncates toward zero; `roundedToInt` adds the NaN/Infinity
@@ -364,8 +365,8 @@ let fns () : List<BuiltInFn> =
           FQTypeName.fqPackage (PackageRefs.Type.Stdlib.intParseError ())
         TypeReference.result TInt (TCustomType(NR.ok errorType, []))
       description =
-        "Returns the <type Int> value of a <type String>. Arbitrary precision, so
-         the only failure is a badly-formatted string."
+        "Returns the <type Int> value of a <type String>. Arbitrary precision, "
+        + "so the only failure is a badly-formatted string."
       fn =
         let typeName =
           FQTypeName.fqPackage (PackageRefs.Type.Stdlib.intParseError ())
@@ -686,8 +687,8 @@ let fns () : List<BuiltInFn> =
       parameters = [ Param.make "a" TInt "" ]
       returnType = TypeReference.option TInt64
       description =
-        "Converts an Int to an Int64, returning None if it doesn't fit the
-         64-bit range."
+        "Converts an Int to an Int64, returning None if it doesn't fit the "
+        + "64-bit range."
       fn =
         let someType = KTInt64
         (function

--- a/backend/src/Builtins/Builtins.Pure/Libs/Int128.fs
+++ b/backend/src/Builtins/Builtins.Pure/Libs/Int128.fs
@@ -31,12 +31,10 @@ let fns () : List<BuiltInFn> =
       parameters = [ Param.make "a" TInt128 ""; Param.make "b" TInt128 "" ]
       returnType = TInt128
       description =
-        "Returns the result of wrapping <param a> around so that {{0 <= res < b}}.
-
-        The modulus <param b> must be greater than 0.
-
-        Use <fn Int128.remainder> if you want the remainder after division, which has
-        a different behavior for negative numbers."
+        "Returns the result of wrapping <param a> around so that {{0 <= res < "
+        + "b}}.\n\nThe modulus <param b> must be greater than 0.\n\nUse <fn "
+        + "Int128.remainder> if you want the remainder after division, which has "
+        + "a different behavior for negative numbers."
       fn =
         (function
         | _, vm, _, [| DInt128 v; DInt128 m |] ->
@@ -60,15 +58,12 @@ let fns () : List<BuiltInFn> =
       parameters = [ Param.make "value" TInt128 ""; Param.make "divisor" TInt128 "" ]
       returnType = TypeReference.result TInt128 TString
       description =
-        "Returns the integer remainder left over after dividing <param value> by
-        <param divisor>, as a <type Result>.
-
-        For example, {{Int128.remainder 15 6 == Ok 3}}. The remainder will be
-        negative only if {{<var value> < 0}}.
-
-        The sign of <param divisor> doesn't influence the outcome.
-
-        Returns an {{Error}} if <param divisor> is {{0}}."
+        "Returns the integer remainder left over after dividing <param value> "
+        + "by <param divisor>, as a <type Result>.\n\nFor example, "
+        + "{{Int128.remainder 15 6 == Ok 3}}. The remainder will be negative only "
+        + "if {{<var value> < 0}}.\n\nThe sign of <param divisor> doesn't "
+        + "influence the outcome.\n\nReturns an {{Error}} if <param divisor> is "
+        + "{{0}}."
       fn =
         let resultOk r = Dval.resultOk KTInt128 KTString r |> Ply
         (function

--- a/backend/src/Builtins/Builtins.Pure/Libs/Int16.fs
+++ b/backend/src/Builtins/Builtins.Pure/Libs/Int16.fs
@@ -32,12 +32,10 @@ let fns () : List<BuiltInFn> =
       parameters = [ Param.make "a" TInt16 ""; Param.make "b" TInt16 "" ]
       returnType = TInt16
       description =
-        "Returns the result of wrapping <param a> around so that {{0 <= res < b}}.
-
-        The modulus <param b> must be greater than 0.
-
-        Use <fn Int16.remainder> if you want the remainder after division, which has
-        a different behavior for negative numbers."
+        "Returns the result of wrapping <param a> around so that {{0 <= res < "
+        + "b}}.\n\nThe modulus <param b> must be greater than 0.\n\nUse <fn "
+        + "Int16.remainder> if you want the remainder after division, which has a "
+        + "different behavior for negative numbers."
       fn =
         (function
         | _, vm, _, [| DInt16 v; DInt16 m |] ->
@@ -61,15 +59,12 @@ let fns () : List<BuiltInFn> =
       parameters = [ Param.make "value" TInt16 ""; Param.make "divisor" TInt16 "" ]
       returnType = TypeReference.result TInt16 TString
       description =
-        "Returns the integer remainder left over after dividing <param value> by
-        <param divisor>, as a <type Result>.
-
-        For example, {{Int16.remainder 15 6 == Ok 3}}. The remainder will be
-        negative only if {{<var value> < 0}}.
-
-        The sign of <param divisor> doesn't influence the outcome.
-
-        Returns an {{Error}} if <param divisor> is {{0}}."
+        "Returns the integer remainder left over after dividing <param value> "
+        + "by <param divisor>, as a <type Result>.\n\nFor example, "
+        + "{{Int16.remainder 15 6 == Ok 3}}. The remainder will be negative only "
+        + "if {{<var value> < 0}}.\n\nThe sign of <param divisor> doesn't "
+        + "influence the outcome.\n\nReturns an {{Error}} if <param divisor> is "
+        + "{{0}}."
       fn =
         let resultOk r = Dval.resultOk KTInt16 KTString r |> Ply
         (function
@@ -141,9 +136,8 @@ let fns () : List<BuiltInFn> =
       parameters = [ Param.make "base" TInt16 ""; Param.make "exponent" TInt16 "" ]
       returnType = TInt16
       description =
-        "Raise <param base> to the power of <param exponent>.
-        <param exponent> must to be positive.
-        Overflow wraps around."
+        "Raise <param base> to the power of <param exponent>. <param exponent> "
+        + "must to be positive. Overflow wraps around."
       fn =
         (function
         | _, vm, _, [| DInt16 number; DInt16 exp |] ->

--- a/backend/src/Builtins/Builtins.Pure/Libs/Int32.fs
+++ b/backend/src/Builtins/Builtins.Pure/Libs/Int32.fs
@@ -32,12 +32,10 @@ let fns () : List<BuiltInFn> =
       parameters = [ Param.make "a" TInt32 ""; Param.make "b" TInt32 "" ]
       returnType = TInt32
       description =
-        "Returns the result of wrapping <param a> around so that {{0 <= res < b}}.
-
-         The modulus <param b> must be greater than 0.
-
-         Use <fn Int32.remainder> if you want the remainder after division, which has
-         a different behavior for negative numbers."
+        "Returns the result of wrapping <param a> around so that {{0 <= res < "
+        + "b}}.\n\nThe modulus <param b> must be greater than 0.\n\nUse <fn "
+        + "Int32.remainder> if you want the remainder after division, which has a "
+        + "different behavior for negative numbers."
       fn =
         (function
         | _, vm, _, [| DInt32 v; DInt32 m |] ->
@@ -61,15 +59,12 @@ let fns () : List<BuiltInFn> =
       parameters = [ Param.make "value" TInt32 ""; Param.make "divisor" TInt32 "" ]
       returnType = TypeReference.result TInt32 TString
       description =
-        "Returns the integer remainder left over after dividing <param value> by
-         <param divisor>, as a <type Result>.
-
-         For example, {{Int32.remainder 15 6 == Ok 3}}. The remainder will be
-         negative only if {{<var value> < 0}}.
-
-         The sign of <param divisor> doesn't influence the outcome.
-
-         Returns an {{Error}} if <param divisor> is {{0}}."
+        "Returns the integer remainder left over after dividing <param value> "
+        + "by <param divisor>, as a <type Result>.\n\nFor example, "
+        + "{{Int32.remainder 15 6 == Ok 3}}. The remainder will be negative only "
+        + "if {{<var value> < 0}}.\n\nThe sign of <param divisor> doesn't "
+        + "influence the outcome.\n\nReturns an {{Error}} if <param divisor> is "
+        + "{{0}}."
       fn =
         let resultOk r = Dval.resultOk KTInt32 KTString r |> Ply
         (function
@@ -141,9 +136,8 @@ let fns () : List<BuiltInFn> =
       parameters = [ Param.make "base" TInt32 ""; Param.make "exponent" TInt32 "" ]
       returnType = TInt32
       description =
-        "Raise <param base> to the power of <param exponent>.
-        <param exponent> must to be positive.
-        Overflow wraps around."
+        "Raise <param base> to the power of <param exponent>. <param exponent> "
+        + "must to be positive. Overflow wraps around."
       fn =
         (function
         | _, vm, _, [| DInt32 number; DInt32 exp |] ->

--- a/backend/src/Builtins/Builtins.Pure/Libs/Int64.fs
+++ b/backend/src/Builtins/Builtins.Pure/Libs/Int64.fs
@@ -33,12 +33,10 @@ let fns () : List<BuiltInFn> =
       parameters = [ Param.make "a" TInt64 ""; Param.make "b" TInt64 "" ]
       returnType = TInt64
       description =
-        "Returns the result of wrapping <param a> around so that {{0 <= res < b}}.
-
-         The modulus <param b> must be greater than 0.
-
-         Use <fn Int64.remainder> if you want the remainder after division, which has
-         a different behavior for negative numbers."
+        "Returns the result of wrapping <param a> around so that {{0 <= res < "
+        + "b}}.\n\nThe modulus <param b> must be greater than 0.\n\nUse <fn "
+        + "Int64.remainder> if you want the remainder after division, which has a "
+        + "different behavior for negative numbers."
       fn =
         (function
         | _, vm, _, [| DInt64 v; DInt64 m |] ->
@@ -103,15 +101,12 @@ let fns () : List<BuiltInFn> =
         [ Param.make "dividend" TInt64 ""; Param.make "divisor" TInt64 "" ]
       returnType = TypeReference.result TInt64 TString
       description =
-        "Returns the integer remainder left over after dividing <param dividend> by
-         <param divisor>, as a <type Result>.
-
-         For example, {{Int64.remainder 15 6 == Ok 3}}. The remainder will be
-         negative only if {{<var dividend> < 0}}.
-
-         The sign of <param divisor> doesn't influence the outcome.
-
-         Returns an {{Error}} if <param divisor> is {{0}}."
+        "Returns the integer remainder left over after dividing <param "
+        + "dividend> by <param divisor>, as a <type Result>.\n\nFor example, "
+        + "{{Int64.remainder 15 6 == Ok 3}}. The remainder will be negative only "
+        + "if {{<var dividend> < 0}}.\n\nThe sign of <param divisor> doesn't "
+        + "influence the outcome.\n\nReturns an {{Error}} if <param divisor> is "
+        + "{{0}}."
       fn =
         let resultOk r = Dval.resultOk KTInt64 KTString r |> Ply
         (function
@@ -186,9 +181,8 @@ let fns () : List<BuiltInFn> =
       parameters = [ Param.make "base" TInt64 ""; Param.make "exponent" TInt64 "" ]
       returnType = TInt64
       description =
-        "Raise <param base> to the power of <param exponent>.
-        <param exponent> must to be positive.
-        Overflow wraps around."
+        "Raise <param base> to the power of <param exponent>. <param exponent> "
+        + "must to be positive. Overflow wraps around."
       fn =
         (function
         | _, vm, _, [| DInt64 number; DInt64 exp |] ->

--- a/backend/src/Builtins/Builtins.Pure/Libs/Int8.fs
+++ b/backend/src/Builtins/Builtins.Pure/Libs/Int8.fs
@@ -32,12 +32,10 @@ let fns () : List<BuiltInFn> =
       parameters = [ Param.make "a" TInt8 ""; Param.make "b" TInt8 "" ]
       returnType = TInt8
       description =
-        "Returns the result of wrapping <param a> around so that {{0 <= res < b}}.
-
-        The modulus <param b> must be greater than 0.
-
-        Use <fn Int8.remainder> if you want the remainder after division, which has
-        a different behavior for negative numbers."
+        "Returns the result of wrapping <param a> around so that {{0 <= res < "
+        + "b}}.\n\nThe modulus <param b> must be greater than 0.\n\nUse <fn "
+        + "Int8.remainder> if you want the remainder after division, which has a "
+        + "different behavior for negative numbers."
       fn =
         (function
         | _, vm, _, [| DInt8 v; DInt8 m |] ->
@@ -61,15 +59,12 @@ let fns () : List<BuiltInFn> =
       parameters = [ Param.make "value" TInt8 ""; Param.make "divisor" TInt8 "" ]
       returnType = TypeReference.result TInt8 TString
       description =
-        "Returns the integer remainder left over after dividing <param value> by
-        <param divisor>, as a <type Result>.
-
-        For example, {{Int8.remainder 15 6 == Ok 3}}. The remainder will be
-        negative only if {{<var value> < 0}}.
-
-        The sign of <param divisor> doesn't influence the outcome.
-
-        Returns an {{Error}} if <param divisor> is {{0}}."
+        "Returns the integer remainder left over after dividing <param value> "
+        + "by <param divisor>, as a <type Result>.\n\nFor example, "
+        + "{{Int8.remainder 15 6 == Ok 3}}. The remainder will be negative only "
+        + "if {{<var value> < 0}}.\n\nThe sign of <param divisor> doesn't "
+        + "influence the outcome.\n\nReturns an {{Error}} if <param divisor> is "
+        + "{{0}}."
       fn =
         let resultOk r = Dval.resultOk KTInt8 KTString r |> Ply
         (function
@@ -141,9 +136,8 @@ let fns () : List<BuiltInFn> =
       parameters = [ Param.make "base" TInt8 ""; Param.make "exponent" TInt8 "" ]
       returnType = TInt8
       description =
-        "Raise <param base> to the power of <param exponent>.
-        <param exponent> must to be positive.
-        Overflow wraps around."
+        "Raise <param base> to the power of <param exponent>. <param exponent> "
+        + "must to be positive. Overflow wraps around."
       fn =
         (function
         | _, vm, _, [| DInt8 number; DInt8 exp |] ->

--- a/backend/src/Builtins/Builtins.Pure/Libs/List.fs
+++ b/backend/src/Builtins/Builtins.Pure/Libs/List.fs
@@ -306,9 +306,8 @@ let fns () : List<BuiltInFn> =
       parameters = [ Param.make "list" (TList varA) "" ]
       returnType = TList varA
       description =
-        "Returns the passed list, with only unique values.
-         Only one of each value will be returned, but the
-         order will not be maintained."
+        "Returns the passed list, with only unique values. Only one of each "
+        + "value will be returned, but the order will not be maintained."
       fn =
         (function
         | _, _, _, [| DList(vt, l) |] ->
@@ -328,12 +327,10 @@ let fns () : List<BuiltInFn> =
       parameters = [ Param.make "list" (TList varA) "" ]
       returnType = TList varA
       description =
-        "Returns a copy of <param list> with every value sorted in ascending order.
-
-         Use this if the values have types Dark knows how to sort.
-
-         Consider <fn List.sortBy> or <fn List.sortByComparator> if you need more
-         control over the sorting process."
+        "Returns a copy of <param list> with every value sorted in ascending "
+        + "order.\n\nUse this if the values have types Dark knows how to "
+        + "sort.\n\nConsider <fn List.sortBy> or <fn List.sortByComparator> if "
+        + "you need more control over the sorting process."
       fn =
         (function
         | _, _, _, [| DList(vt, list) |] ->
@@ -354,8 +351,8 @@ let fns () : List<BuiltInFn> =
         [ Param.make "as" (TList varA) ""; Param.make "bs" (TList varA) "" ]
       returnType = TList varA
       description =
-        "Returns a new list with all values in <param as> followed by all values in <param bs>,
-         preserving the order."
+        "Returns a new list with all values in <param as> followed by all "
+        + "values in <param bs>, preserving the order."
       fn =
         (function
         | _, vm, _, [| DList(vt1, l1); DList(vt2, l2) |] ->
@@ -420,8 +417,8 @@ let fns () : List<BuiltInFn> =
       parameters = [ Param.make "list" (TList(TList varA)) "" ]
       returnType = TList varA
       description =
-        "Returns a single list containing the values of every list directly in <param list>
-         (does not recursively flatten nested lists)."
+        "Returns a single list containing the values of every list directly in "
+        + "<param list> (does not recursively flatten nested lists)."
       fn =
         (function
         | _, vm, _, [| DList(_, sublists) |] ->

--- a/backend/src/Builtins/Builtins.Pure/Libs/Math.fs
+++ b/backend/src/Builtins/Builtins.Pure/Libs/Math.fs
@@ -16,11 +16,10 @@ let fns () : List<BuiltInFn> =
       parameters = [ Param.make "angleInRadians" TFloat "" ]
       returnType = TFloat
       description =
-        "Returns the cosine of the given <param angleInRadians>.
-
-         One interpretation of the result relates to a right triangle: the cosine is
-         the ratio of the lengths of the side adjacent to the angle and the
-         hypotenuse."
+        "Returns the cosine of the given <param angleInRadians>.\n\nOne "
+        + "interpretation of the result relates to a right triangle: the cosine "
+        + "is the ratio of the lengths of the side adjacent to the angle and the "
+        + "hypotenuse."
       fn =
         (function
         | _, _, _, [| DFloat a |] -> Ply(DFloat(System.Math.Cos a))
@@ -36,10 +35,10 @@ let fns () : List<BuiltInFn> =
       parameters = [ Param.make "angleInRadians" TFloat "" ]
       returnType = TFloat
       description =
-        "Returns the sine of the given <param angleInRadians>.
-
-         One interpretation of the result relates to a right triangle: the sine is
-         the ratio of the lengths of the side opposite the angle and the hypotenuse"
+        "Returns the sine of the given <param angleInRadians>.\n\nOne "
+        + "interpretation of the result relates to a right triangle: the sine is "
+        + "the ratio of the lengths of the side opposite the angle and the "
+        + "hypotenuse"
       fn =
         (function
         | _, _, _, [| DFloat a |] -> Ply(DFloat(System.Math.Sin a))
@@ -55,11 +54,10 @@ let fns () : List<BuiltInFn> =
       parameters = [ Param.make "angleInRadians" TFloat "" ]
       returnType = TFloat
       description =
-        "Returns the tangent of the given <param angleInRadians>.
-
-         One interpretation of the result relates to a right triangle: the tangent is
-         the ratio of the lengths of the side opposite the angle and the side
-         adjacent to the angle."
+        "Returns the tangent of the given <param angleInRadians>.\n\nOne "
+        + "interpretation of the result relates to a right triangle: the tangent "
+        + "is the ratio of the lengths of the side opposite the angle and the "
+        + "side adjacent to the angle."
       fn =
         (function
         | _, _, _, [| DFloat a |] -> Ply(DFloat(System.Math.Tan a))
@@ -75,13 +73,11 @@ let fns () : List<BuiltInFn> =
       parameters = [ Param.make "ratio" TFloat "" ]
       returnType = TypeReference.option TFloat
       description =
-        "Returns the arc cosine of <param ratio>, as an <type Option>.
-
-         If <param ratio> is in the inclusive range {{[-1.0, 1.0]}}, returns {{Some
-         result}} where <var result> is in radians and is between {{0.0}} and <fn
-         Math.pi>. Otherwise, returns {{None}}.
-
-         This function is the inverse of <fn Math.cos>."
+        "Returns the arc cosine of <param ratio>, as an <type Option>.\n\nIf "
+        + "<param ratio> is in the inclusive range {{[-1.0, 1.0]}}, returns "
+        + "{{Some result}} where <var result> is in radians and is between "
+        + "{{0.0}} and <fn Math.pi>. Otherwise, returns {{None}}.\n\nThis "
+        + "function is the inverse of <fn Math.cos>."
       fn =
         (function
         | _, _, _, [| DFloat r |] ->
@@ -103,13 +99,11 @@ let fns () : List<BuiltInFn> =
       parameters = [ Param.make "ratio" TFloat "" ]
       returnType = TypeReference.option TFloat
       description =
-        "Returns the arc sine of <param ratio>, as an <type Option>.
-
-         If <param ratio> is in the inclusive range {{[-1.0, 1.0]}}, returns {{Some
-         result}} where <var result> is in radians and is between {{-Math.pi/2}} and
-         {{Math.pi/2}}. Otherwise, returns {{None}}.
-
-         This function is the inverse of <fn Math.sin>."
+        "Returns the arc sine of <param ratio>, as an <type Option>.\n\nIf "
+        + "<param ratio> is in the inclusive range {{[-1.0, 1.0]}}, returns "
+        + "{{Some result}} where <var result> is in radians and is between "
+        + "{{-Math.pi/2}} and {{Math.pi/2}}. Otherwise, returns {{None}}.\n\nThis "
+        + "function is the inverse of <fn Math.sin>."
       fn =
         (function
         | _, _, _, [| DFloat r |] ->
@@ -131,11 +125,10 @@ let fns () : List<BuiltInFn> =
       parameters = [ Param.make "ratio" TFloat "" ]
       returnType = TFloat
       description =
-        "Returns the arc tangent of <param ratio>. The result is in radians and is between
-         {{-Math.pi/2}} and {{Math.pi/2}}.
-
-         This function is the inverse of <fn Math.tan>. Use <fn Math.atan2> to expand the
-         output range, if you know the numerator and denominator of <param ratio>."
+        "Returns the arc tangent of <param ratio>. The result is in radians and "
+        + "is between {{-Math.pi/2}} and {{Math.pi/2}}.\n\nThis function is the "
+        + "inverse of <fn Math.tan>. Use <fn Math.atan2> to expand the output "
+        + "range, if you know the numerator and denominator of <param ratio>."
       fn =
         (function
         | _, _, _, [| DFloat a |] -> Ply(DFloat(System.Math.Atan a))
@@ -151,13 +144,11 @@ let fns () : List<BuiltInFn> =
       parameters = [ Param.make "y" TFloat ""; Param.make "x" TFloat "" ]
       returnType = TFloat
       description =
-        "Returns the arc tangent of {{y / x}}, using the signs of <param y> and
-         <param x> to determine the quadrant of the result.
-
-         The result is in radians and is between {{-Math.pi}} and {{Math.pi}}.
-
-         Consider <fn Math.atan> if you know the value of {{y / x}} but not the
-         individual values <param x> and <param y>."
+        "Returns the arc tangent of {{y / x}}, using the signs of <param y> and "
+        + "<param x> to determine the quadrant of the result.\n\nThe result is in "
+        + "radians and is between {{-Math.pi}} and {{Math.pi}}.\n\nConsider <fn "
+        + "Math.atan> if you know the value of {{y / x}} but not the individual "
+        + "values <param x> and <param y>."
       fn =
         (function
         | _, _, _, [| DFloat y; DFloat x |] -> Ply(DFloat(System.Math.Atan2(y, x)))

--- a/backend/src/Builtins/Builtins.Pure/Libs/NoModule.fs
+++ b/backend/src/Builtins/Builtins.Pure/Libs/NoModule.fs
@@ -255,10 +255,9 @@ let fns () : List<BuiltInFn> =
       parameters = [ Param.make "a" varA ""; Param.make "b" varB "" ]
       returnType = varA
       description =
-        "Adds two numbers of the same numeric type. Fixed-width integer overflow
-         wraps around; the arbitrary-precision Int grows
-         instead of overflowing; float arithmetic follows IEEE (overflow to
-         infinity)."
+        "Adds two numbers of the same numeric type. Fixed-width integer "
+        + "overflow wraps around; the arbitrary-precision Int grows instead of "
+        + "overflowing; float arithmetic follows IEEE (overflow to infinity)."
       fn =
         (function
         | _, _, _, [| DInt8 a; DInt8 b |] -> Ply(DInt8(a + b))
@@ -290,10 +289,9 @@ let fns () : List<BuiltInFn> =
       parameters = [ Param.make "a" varA ""; Param.make "b" varB "" ]
       returnType = varA
       description =
-        "Subtracts two numbers of the same numeric type. Fixed-width integer
-         overflow wraps around; the arbitrary-precision Int
-         grows instead of overflowing; float arithmetic follows IEEE (overflow
-         to infinity)."
+        "Subtracts two numbers of the same numeric type. Fixed-width integer "
+        + "overflow wraps around; the arbitrary-precision Int grows instead of "
+        + "overflowing; float arithmetic follows IEEE (overflow to infinity)."
       fn =
         (function
         | _, _, _, [| DInt8 a; DInt8 b |] -> Ply(DInt8(a - b))
@@ -321,10 +319,9 @@ let fns () : List<BuiltInFn> =
       parameters = [ Param.make "a" varA ""; Param.make "b" varB "" ]
       returnType = varA
       description =
-        "Multiplies two numbers of the same numeric type. Fixed-width integer
-         overflow wraps around; the arbitrary-precision Int
-         grows instead of overflowing; float arithmetic follows IEEE (overflow
-         to infinity)."
+        "Multiplies two numbers of the same numeric type. Fixed-width integer "
+        + "overflow wraps around; the arbitrary-precision Int grows instead of "
+        + "overflowing; float arithmetic follows IEEE (overflow to infinity)."
       fn =
         (function
         | _, _, _, [| DInt8 a; DInt8 b |] -> Ply(DInt8(a * b))
@@ -352,10 +349,10 @@ let fns () : List<BuiltInFn> =
       parameters = [ Param.make "a" varA ""; Param.make "b" varB "" ]
       returnType = varA
       description =
-        "Divides two numbers of the same numeric type. Integer types use integer
-         division; dividing an integer by zero raises a runtime error. Signed
-         integer overflow (e.g. {{Int64.MinValue / -1}}) wraps around to
-         {{MinValue}}."
+        "Divides two numbers of the same numeric type. Integer types use "
+        + "integer division; dividing an integer by zero raises a runtime error. "
+        + "Signed integer overflow (e.g. {{Int64.MinValue / -1}}) wraps around to "
+        + "{{MinValue}}."
       fn =
         // Unsigned division can't overflow. Signed division overflows only on
         // `MinValue / -1`, whose wrapped result is `MinValue` itself. For the
@@ -418,8 +415,8 @@ let fns () : List<BuiltInFn> =
       parameters = [ Param.make "a" varA ""; Param.make "b" varB "" ]
       returnType = varA
       description =
-        "Wraps <param a> around so that {{0 <= res < b}}, for two numbers of the
-         same numeric type. The modulus <param b> must be greater than 0."
+        "Wraps <param a> around so that {{0 <= res < b}}, for two numbers of "
+        + "the same numeric type. The modulus <param b> must be greater than 0."
       fn =
         (function
         | _, vm, _, [| DInt8 v; DInt8 m |] ->
@@ -502,11 +499,10 @@ let fns () : List<BuiltInFn> =
       parameters = [ Param.make "base" varA ""; Param.make "exponent" varA "" ]
       returnType = varA
       description =
-        "Raises a number to the power of another number of the same type.
-         Supported for every integer type and Float (not Int128/UInt128).
-         Integer exponents must be non-negative. Fixed-width integer overflow
-         wraps around; the arbitrary-precision Int grows
-         instead."
+        "Raises a number to the power of another number of the same type. "
+        + "Supported for every integer type and Float (not Int128/UInt128). "
+        + "Integer exponents must be non-negative. Fixed-width integer overflow "
+        + "wraps around; the arbitrary-precision Int grows instead."
       fn =
         // Fixed-width powers wrap, so they use modular exponentiation
         // (`powSigned`/`powUnsigned`) — this stays cheap even for huge

--- a/backend/src/Builtins/Builtins.Pure/Libs/Stream.fs
+++ b/backend/src/Builtins/Builtins.Pure/Libs/Stream.fs
@@ -113,11 +113,11 @@ let fns () : List<BuiltInFn> =
             [ "state" ] ]
       returnType = TStream(TVariable "a")
       description =
-        "Constructs a stream from a seed state and a step function. The step is
-         called once per pull — return Some of a (value, nextState) tuple to
-         yield an element, or None to end the stream. Useful for writing custom
-         lazy producers in Dark: file line readers, paginated API iterators,
-         protocol parsers like SSE, etc."
+        "Constructs a stream from a seed state and a step function. The step is "
+        + "called once per pull — return Some of a (value, nextState) tuple to "
+        + "yield an element, or None to end the stream. Useful for writing custom "
+        + "lazy producers in Dark: file line readers, paginated API iterators, "
+        + "protocol parsers like SSE, etc."
       fn =
         (function
         | state, vm, [ _; outputType ], [| initialState; DApplicable app |] ->
@@ -244,10 +244,10 @@ let fns () : List<BuiltInFn> =
       parameters = [ Param.make "stream" (TStream varA) "" ]
       returnType = TUnit
       description =
-        "Marks <param stream> as fully consumed. Idempotent — calling on an
-         already-closed stream is a no-op. Not strictly required (streams are
-         GC-closed via their .NET finalizer), but useful when you want to release
-         an IO source promptly."
+        "Marks <param stream> as fully consumed. Idempotent — calling on an "
+        + "already-closed stream is a no-op. Not strictly required (streams are "
+        + "GC-closed via their .NET finalizer), but useful when you want to "
+        + "release an IO source promptly."
       fn =
         (function
         | _, _, _, [| DStream(impl, disposed, _lockObj) |] ->
@@ -286,9 +286,9 @@ let fns () : List<BuiltInFn> =
             [ "elem" ] ]
       returnType = TStream(TVariable "b")
       description =
-        "Returns a new stream whose elements are <param fn> applied to each
-         element of <param stream>. Lazy — <param fn> runs only when the
-         returned stream is drained."
+        "Returns a new stream whose elements are <param fn> applied to each "
+        + "element of <param stream>. Lazy — <param fn> runs only when the "
+        + "returned stream is drained."
       fn =
         (function
         | state, vm, [ _; outputType ], [| DStream(src, _, _); DApplicable app |] ->
@@ -321,9 +321,9 @@ let fns () : List<BuiltInFn> =
             [ "elem" ] ]
       returnType = TStream varA
       description =
-        "Returns a new stream that yields only the elements of <param stream>
-         for which <param pred> returns true. Lazy — <param pred> runs as the
-         result is drained, skipping rejected elements without buffering."
+        "Returns a new stream that yields only the elements of <param stream> "
+        + "for which <param pred> returns true. Lazy — <param pred> runs as the "
+        + "result is drained, skipping rejected elements without buffering."
       fn =
         (function
         | state, vm, _, [| DStream(src, _, _); DApplicable app |] ->
@@ -354,9 +354,9 @@ let fns () : List<BuiltInFn> =
           Param.make "n" TInt "Maximum number of elements to yield." ]
       returnType = TStream varA
       description =
-        "Returns a new stream that yields at most the first <param n> elements
-         of <param stream>. If the source has fewer elements, yields them all.
-         Terminates early without pulling the source past the limit."
+        "Returns a new stream that yields at most the first <param n> elements "
+        + "of <param stream>. If the source has fewer elements, yields them all. "
+        + "Terminates early without pulling the source past the limit."
       fn =
         (function
         | _, _, _, [| DStream(src, _, _); DInt n |] ->
@@ -382,8 +382,8 @@ let fns () : List<BuiltInFn> =
         [ Param.make "streams" (TList(TStream varA)) "Streams to concatenate." ]
       returnType = TStream varA
       description =
-        "Returns a new stream that drains <param streams> in list order,
-         advancing to the next sub-stream when the current one is exhausted."
+        "Returns a new stream that drains <param streams> in list order, "
+        + "advancing to the next sub-stream when the current one is exhausted."
       fn =
         (function
         | _, _, _, [| DList(_, items) |] ->

--- a/backend/src/Builtins/Builtins.Pure/Libs/String.fs
+++ b/backend/src/Builtins/Builtins.Pure/Libs/String.fs
@@ -60,8 +60,8 @@ let fns () : List<BuiltInFn> =
           Param.make "replaceWith" TString "" ]
       returnType = TString
       description =
-        "Replace all instances on <param searchFor> in <param s> with <param
-         replaceWith>"
+        "Replace all instances on <param searchFor> in <param s> with <param "
+        + "replaceWith>"
       fn =
         (function
         | _, _, _, [| DString s; DString search; DString replace |] ->
@@ -167,8 +167,8 @@ let fns () : List<BuiltInFn> =
       parameters = [ Param.make "s1" TString ""; Param.make "s2" TString "" ]
       returnType = TString
       description =
-        "Concatenates the two strings by appending <param s2> to <param s1> and
-         returns the joined string."
+        "Concatenates the two strings by appending <param s2> to <param s1> and "
+        + "returns the joined string."
       fn =
         (function
         // TODO add fuzzer to ensure all strings are normalized no matter what we do to them.
@@ -188,8 +188,8 @@ let fns () : List<BuiltInFn> =
       parameters = [ Param.make "string" TString "" ]
       returnType = TString
       description =
-        "Turns a string into a prettified slug, including only lowercased
-         alphanumeric characters, joined by hyphens"
+        "Turns a string into a prettified slug, including only lowercased "
+        + "alphanumeric characters, joined by hyphens"
       fn =
         (function
         | _, _, _, [| DString s |] ->
@@ -236,8 +236,9 @@ let fns () : List<BuiltInFn> =
       parameters = [ Param.make "s" TString ""; Param.make "separator" TString "" ]
       returnType = TList TString
       description =
-        "Splits a string at the separator, returning a list of strings without the separator.
-        If the separator is not present, returns a list containing only the initial string."
+        "Splits a string at the separator, returning a list of strings without "
+        + "the separator. If the separator is not present, returns a list "
+        + "containing only the initial string."
       fn =
         (function
         | _, _, _, [| DString s; DString sep |] ->
@@ -316,8 +317,9 @@ let fns () : List<BuiltInFn> =
           Param.make "to" TInt "" ]
       returnType = TString
       description =
-        "Returns the substring of <param string> between the <param from> and <param to> indices.
-         Negative indices start counting from the end of <param string>."
+        "Returns the substring of <param string> between the <param from> and "
+        + "<param to> indices. Negative indices start counting from the end of "
+        + "<param string>."
       fn =
         (function
         | _, vm, _, [| DString s; DInt firstD; DInt lastD |] ->
@@ -365,10 +367,10 @@ let fns () : List<BuiltInFn> =
       parameters = [ Param.make "str" TString "" ]
       returnType = TString
       description =
-        "Returns a copy of <param str> with all leading and trailing whitespace
-         removed. 'whitespace' here means all Unicode characters with the
-         {{White_Space}} property, which includes {{\" \"}}, {{\"\\t\"}} and
-         {{\"\\n\"}}"
+        "Returns a copy of <param str> with all leading and trailing whitespace "
+        + "removed. 'whitespace' here means all Unicode characters with the "
+        + "{{White_Space}} property, which includes {{\" \"}}, {{\"\\t\"}} and "
+        + "{{\"\\n\"}}"
       fn =
         (function
         | _, _, _, [| DString toTrim |] -> toTrim.Trim() |> DString |> Ply
@@ -384,9 +386,10 @@ let fns () : List<BuiltInFn> =
       parameters = [ Param.make "str" TString "" ]
       returnType = TString
       description =
-        "Returns a copy of <param str> with all leading whitespace removed. 'whitespace'
-         here means all Unicode characters with the {{White_Space}} property, which
-         includes {{\" \"}}, {{\"\\t\"}} and {{\"\\n\"}}"
+        "Returns a copy of <param str> with all leading whitespace removed. "
+        + "'whitespace' here means all Unicode characters with the "
+        + "{{White_Space}} property, which includes {{\" \"}}, {{\"\\t\"}} and "
+        + "{{\"\\n\"}}"
       fn =
         (function
         | _, _, _, [| DString toTrim |] -> Ply(DString(toTrim.TrimStart()))
@@ -402,9 +405,10 @@ let fns () : List<BuiltInFn> =
       parameters = [ Param.make "str" TString "" ]
       returnType = TString
       description =
-        "Returns a copy of <param str> with all trailing whitespace removed.
-         'whitespace' here means all Unicode characters with the {{White_Space}}
-         property, which includes {{\" \"}}, {{\"\\t\"}} and {{\"\\n\"}}."
+        "Returns a copy of <param str> with all trailing whitespace removed. "
+        + "'whitespace' here means all Unicode characters with the "
+        + "{{White_Space}} property, which includes {{\" \"}}, {{\"\\t\"}} and "
+        + "{{\"\\n\"}}."
       fn =
         (function
         | _, _, _, [| DString toTrim |] -> Ply(DString(toTrim.TrimEnd()))
@@ -505,10 +509,10 @@ let fns () : List<BuiltInFn> =
           Param.make "searchingFor" TString "The substring to look for" ]
       returnType = TBool
       description =
-        "Returns {{true}} if <param lookingIn> contains <param searchingFor>.
-         SQL-queryable: it only checks found/not-found, which SQLite's INSTR and
-         .NET's Contains agree on (unlike index position, which they count
-         differently for some Unicode text)."
+        "Returns {{true}} if <param lookingIn> contains <param searchingFor>. "
+        + "SQL-queryable: it only checks found/not-found, which SQLite's INSTR "
+        + "and .NET's Contains agree on (unlike index position, which they count "
+        + "differently for some Unicode text)."
       fn =
         (function
         | _, _, _, [| DString lookingIn; DString searchingFor |] ->
@@ -533,20 +537,20 @@ let fns () : List<BuiltInFn> =
             "The string to search for within <param str>" ]
       returnType = TInt
       description =
-        "Returns the index of the first occurrence of <param searchFor> in <param str>,
-         measured in UTF-16 code units (the .NET string representation). Returns -1 if
-         <param searchFor> does not occur. For an index that pairs with {{String.length}},
-         {{String.slice}}, {{String.first}}, and {{String.dropFirst}} (which are all
-         EGC-indexed), use {{stringIndexOfEgc}}.
-
-         Note on SQL: SQLite's INSTR and .NET's IndexOf both tell us whether
-         a substring was found, but they count positions differently for some
-         Unicode text. SQLite counts Unicode characters; .NET IndexOf counts
-         UTF-16 code units. For example, SQLite reports the \"a\" in \"😄a\" at
-         index 1, while .NET reports it at index 2 because the emoji takes two
-         UTF-16 code units. So {{String.contains}} is portable in SQL because it
-         only checks found/not-found, but {{String.indexOf}} may return different
-         numeric indexes outside simple ASCII text."
+        "Returns the index of the first occurrence of <param searchFor> in "
+        + "<param str>, measured in UTF-16 code units (the .NET string "
+        + "representation). Returns -1 if <param searchFor> does not occur. For "
+        + "an index that pairs with {{String.length}}, {{String.slice}}, "
+        + "{{String.first}}, and {{String.dropFirst}} (which are all "
+        + "EGC-indexed), use {{stringIndexOfEgc}}.\n\nNote on SQL: SQLite's INSTR "
+        + "and .NET's IndexOf both tell us whether a substring was found, but "
+        + "they count positions differently for some Unicode text. SQLite counts "
+        + "Unicode characters; .NET IndexOf counts UTF-16 code units. For "
+        + "example, SQLite reports the \"a\" in \"😄a\" at index 1, while .NET "
+        + "reports it at index 2 because the emoji takes two UTF-16 code units. "
+        + "So {{String.contains}} is portable in SQL because it only checks "
+        + "found/not-found, but {{String.indexOf}} may return different numeric "
+        + "indexes outside simple ASCII text."
       fn =
         (function
         | _, _, _, [| DString str; DString search |] ->
@@ -574,14 +578,14 @@ let fns () : List<BuiltInFn> =
             "The string to search for within <param str>" ]
       returnType = TInt
       description =
-        "Returns the index of the first occurrence of <param searchFor> in <param str>,
-         measured in extended grapheme clusters (consistent with {{String.length}},
-         {{String.slice}}, {{String.first}}, and {{String.dropFirst}}). Returns -1 if
-         <param searchFor> does not occur. The match must begin and end on EGC
-         boundaries — partial-grapheme matches (e.g. finding a skin-tone modifier
-         alone inside a full skin-toned emoji) are not reported. Not SQL-queryable
-         because SQLite has no EGC-aware INSTR; use {{stringIndexOf}} inside DB
-         query lambdas."
+        "Returns the index of the first occurrence of <param searchFor> in "
+        + "<param str>, measured in extended grapheme clusters (consistent with "
+        + "{{String.length}}, {{String.slice}}, {{String.first}}, and "
+        + "{{String.dropFirst}}). Returns -1 if <param searchFor> does not occur. "
+        + "The match must begin and end on EGC boundaries — partial-grapheme "
+        + "matches (e.g. finding a skin-tone modifier alone inside a full "
+        + "skin-toned emoji) are not reported. Not SQL-queryable because SQLite "
+        + "has no EGC-aware INSTR; use {{stringIndexOf}} inside DB query lambdas."
       fn =
         (function
         | _, _, _, [| DString str; DString search |] ->
@@ -633,10 +637,10 @@ let fns () : List<BuiltInFn> =
             "The string to search for within <param str>" ]
       returnType = TInt
       description =
-        "Returns the index of the last occurrence of <param searchFor> in <param str>,
-         measured in UTF-16 code units. Returns -1 if <param searchFor> does not occur.
-         For an EGC-indexed result that pairs with {{String.length}} / {{String.slice}},
-         use {{stringLastIndexOfEgc}}."
+        "Returns the index of the last occurrence of <param searchFor> in "
+        + "<param str>, measured in UTF-16 code units. Returns -1 if <param "
+        + "searchFor> does not occur. For an EGC-indexed result that pairs with "
+        + "{{String.length}} / {{String.slice}}, use {{stringLastIndexOfEgc}}."
       fn =
         (function
         | _, _, _, [| DString str; DString search |] ->
@@ -659,11 +663,12 @@ let fns () : List<BuiltInFn> =
             "The string to search for within <param str>" ]
       returnType = TInt
       description =
-        "Returns the index of the last occurrence of <param searchFor> in <param str>,
-         measured in extended grapheme clusters (consistent with {{String.length}},
-         {{String.slice}}, {{String.first}}, and {{String.dropFirst}}). Returns -1 if
-         <param searchFor> does not occur. The match must begin and end on EGC
-         boundaries — partial-grapheme matches are not reported."
+        "Returns the index of the last occurrence of <param searchFor> in "
+        + "<param str>, measured in extended grapheme clusters (consistent with "
+        + "{{String.length}}, {{String.slice}}, {{String.first}}, and "
+        + "{{String.dropFirst}}). Returns -1 if <param searchFor> does not occur. "
+        + "The match must begin and end on EGC boundaries — partial-grapheme "
+        + "matches are not reported."
       fn =
         (function
         | _, _, _, [| DString str; DString search |] ->

--- a/backend/src/Builtins/Builtins.Pure/Libs/UInt128.fs
+++ b/backend/src/Builtins/Builtins.Pure/Libs/UInt128.fs
@@ -32,12 +32,10 @@ let fns () : List<BuiltInFn> =
       parameters = [ Param.make "a" TUInt128 ""; Param.make "b" TUInt128 "" ]
       returnType = TUInt128
       description =
-        "Returns the result of wrapping <param a> around so that {{0 <= res < b}}.
-
-        The modulus <param b> must be greater than 0.
-
-        Use <fn UInt128.remainder> if you want the remainder after division, which has
-        a different behavior for negative numbers."
+        "Returns the result of wrapping <param a> around so that {{0 <= res < "
+        + "b}}.\n\nThe modulus <param b> must be greater than 0.\n\nUse <fn "
+        + "UInt128.remainder> if you want the remainder after division, which has "
+        + "a different behavior for negative numbers."
       fn =
         (function
         | _, vm, _, [| DUInt128 v; DUInt128 m |] ->

--- a/backend/src/Builtins/Builtins.Pure/Libs/UInt16.fs
+++ b/backend/src/Builtins/Builtins.Pure/Libs/UInt16.fs
@@ -33,12 +33,10 @@ let fns () : List<BuiltInFn> =
       parameters = [ Param.make "a" TUInt16 ""; Param.make "b" TUInt16 "" ]
       returnType = TUInt16
       description =
-        "Returns the result of wrapping <param a> around so that {{0 <= res < b}}.
-
-        The modulus <param b> must be greater than 0.
-
-        Use <fn UInt16.remainder> if you want the remainder after division, which has
-        a different behavior for negative numbers."
+        "Returns the result of wrapping <param a> around so that {{0 <= res < "
+        + "b}}.\n\nThe modulus <param b> must be greater than 0.\n\nUse <fn "
+        + "UInt16.remainder> if you want the remainder after division, which has "
+        + "a different behavior for negative numbers."
       fn =
         (function
         | _, vm, _, [| DUInt16 v; DUInt16 m |] ->
@@ -106,9 +104,8 @@ let fns () : List<BuiltInFn> =
       parameters = [ Param.make "base" TUInt16 ""; Param.make "exponent" TUInt16 "" ]
       returnType = TUInt16
       description =
-        "Raise <param base> to the power of <param exponent>.
-        <param exponent> must to be positive.
-        Overflow wraps around."
+        "Raise <param base> to the power of <param exponent>. <param exponent> "
+        + "must to be positive. Overflow wraps around."
       fn =
         (function
         | _, _, _, [| DUInt16 number; DUInt16 exp |] ->

--- a/backend/src/Builtins/Builtins.Pure/Libs/UInt32.fs
+++ b/backend/src/Builtins/Builtins.Pure/Libs/UInt32.fs
@@ -33,12 +33,10 @@ let fns () : List<BuiltInFn> =
       parameters = [ Param.make "a" TUInt32 ""; Param.make "b" TUInt32 "" ]
       returnType = TUInt32
       description =
-        "Returns the result of wrapping <param a> around so that {{0 <= res < b}}.
-
-        The modulus <param b> must be greater than 0.
-
-        Use <fn UInt32.remainder> if you want the remainder after division, which has
-        a different behavior for negative numbers."
+        "Returns the result of wrapping <param a> around so that {{0 <= res < "
+        + "b}}.\n\nThe modulus <param b> must be greater than 0.\n\nUse <fn "
+        + "UInt32.remainder> if you want the remainder after division, which has "
+        + "a different behavior for negative numbers."
       fn =
         (function
         | _, vm, _, [| DUInt32 v; DUInt32 m |] ->
@@ -106,9 +104,8 @@ let fns () : List<BuiltInFn> =
       parameters = [ Param.make "base" TUInt32 ""; Param.make "exponent" TUInt32 "" ]
       returnType = TUInt32
       description =
-        "Raise <param base> to the power of <param exponent>.
-        <param exponent> must to be positive.
-        Overflow wraps around."
+        "Raise <param base> to the power of <param exponent>. <param exponent> "
+        + "must to be positive. Overflow wraps around."
       fn =
         (function
         | _, _, _, [| DUInt32 number; DUInt32 exp |] ->
@@ -286,8 +283,8 @@ let fns () : List<BuiltInFn> =
       parameters = [ Param.make "a" TInt8 "" ]
       returnType = TypeReference.option TUInt32
       description =
-        "Converts an Int8 to a 32-bit unsigned integer.
-        Returns {{None}} if the value is less than 0."
+        "Converts an Int8 to a 32-bit unsigned integer. Returns {{None}} if the "
+        + "value is less than 0."
       fn =
         (function
         | _, _, _, [| DInt8 a |] ->
@@ -322,8 +319,8 @@ let fns () : List<BuiltInFn> =
       parameters = [ Param.make "a" TInt16 "" ]
       returnType = TypeReference.option TUInt32
       description =
-        "Converts an Int16 to a 32-bit unsigned integer.
-        Returns {{None}} if the value is less than 0."
+        "Converts an Int16 to a 32-bit unsigned integer. Returns {{None}} if "
+        + "the value is less than 0."
       fn =
         (function
         | _, _, _, [| DInt16 a |] ->
@@ -358,8 +355,8 @@ let fns () : List<BuiltInFn> =
       parameters = [ Param.make "a" TInt32 "" ]
       returnType = TypeReference.option TUInt32
       description =
-        "Converts an Int32 to a 32-bit unsigned integer.
-        Returns {{None}} if the value is less than 0"
+        "Converts an Int32 to a 32-bit unsigned integer. Returns {{None}} if "
+        + "the value is less than 0"
       fn =
         (function
         | _, _, _, [| DInt32 a |] ->
@@ -379,8 +376,8 @@ let fns () : List<BuiltInFn> =
       parameters = [ Param.make "a" TInt64 "" ]
       returnType = TypeReference.option TUInt32
       description =
-        "Converts an Int64 to a 32-bit unsigned integer.
-        Returns {{None}} if the value is less than 0 or greater than 4294967295."
+        "Converts an Int64 to a 32-bit unsigned integer. Returns {{None}} if "
+        + "the value is less than 0 or greater than 4294967295."
       fn =
         (function
         | _, _, _, [| DInt64 a |] ->
@@ -402,8 +399,8 @@ let fns () : List<BuiltInFn> =
       parameters = [ Param.make "a" TUInt64 "" ]
       returnType = TypeReference.option TUInt32
       description =
-        "Converts a UInt64 to a 32-bit unsigned integer.
-        Returns {{None}} if the value is greater than 4294967295."
+        "Converts a UInt64 to a 32-bit unsigned integer. Returns {{None}} if "
+        + "the value is greater than 4294967295."
       fn =
         (function
         | _, _, _, [| DUInt64 a |] ->
@@ -446,8 +443,8 @@ let fns () : List<BuiltInFn> =
       parameters = [ Param.make "a" TUInt128 "" ]
       returnType = TypeReference.option TUInt32
       description =
-        "Converts a UInt128 to a 32-bit unsigned integer.
-        Returns {{None}} if the value is greater than 4294967295."
+        "Converts a UInt128 to a 32-bit unsigned integer. Returns {{None}} if "
+        + "the value is greater than 4294967295."
       fn =
         (function
         | _, _, _, [| DUInt128 a |] ->

--- a/backend/src/Builtins/Builtins.Pure/Libs/UInt64.fs
+++ b/backend/src/Builtins/Builtins.Pure/Libs/UInt64.fs
@@ -32,12 +32,10 @@ let fns () : List<BuiltInFn> =
       parameters = [ Param.make "a" TUInt64 ""; Param.make "b" TUInt64 "" ]
       returnType = TUInt64
       description =
-        "Returns the result of wrapping <param a> around so that {{0 <= res < b}}.
-
-         The modulus <param b> must be greater than 0.
-
-         Use <fn UInt64.remainder> if you want the remainder after division, which has
-         a different behavior for negative numbers."
+        "Returns the result of wrapping <param a> around so that {{0 <= res < "
+        + "b}}.\n\nThe modulus <param b> must be greater than 0.\n\nUse <fn "
+        + "UInt64.remainder> if you want the remainder after division, which has "
+        + "a different behavior for negative numbers."
       fn =
         (function
         | _, vm, _, [| DUInt64 v; DUInt64 m |] ->
@@ -104,9 +102,8 @@ let fns () : List<BuiltInFn> =
       parameters = [ Param.make "base" TUInt64 ""; Param.make "exponent" TUInt64 "" ]
       returnType = TUInt64
       description =
-        "Raise <param base> to the power of <param exponent>.
-        <param exponent> must to be positive.
-        Overflow wraps around."
+        "Raise <param base> to the power of <param exponent>. <param exponent> "
+        + "must to be positive. Overflow wraps around."
       fn =
         (function
         | _, _, _, [| DUInt64 number; DUInt64 exp |] ->

--- a/backend/src/Builtins/Builtins.Pure/Libs/UInt8.fs
+++ b/backend/src/Builtins/Builtins.Pure/Libs/UInt8.fs
@@ -33,12 +33,10 @@ let fns () : List<BuiltInFn> =
       parameters = [ Param.make "a" TUInt8 ""; Param.make "b" TUInt8 "" ]
       returnType = TUInt8
       description =
-        "Returns the result of wrapping <param a> around so that {{0 <= res < b}}.
-
-        The modulus <param b> must be greater than 0.
-
-        Use <fn UInt8.remainder> if you want the remainder after division, which has
-        a different behavior for negative numbers."
+        "Returns the result of wrapping <param a> around so that {{0 <= res < "
+        + "b}}.\n\nThe modulus <param b> must be greater than 0.\n\nUse <fn "
+        + "UInt8.remainder> if you want the remainder after division, which has a "
+        + "different behavior for negative numbers."
       fn =
         (function
         | _, vm, _, [| DUInt8 v; DUInt8 m |] ->
@@ -105,9 +103,8 @@ let fns () : List<BuiltInFn> =
       parameters = [ Param.make "base" TUInt8 ""; Param.make "exponent" TUInt8 "" ]
       returnType = TUInt8
       description =
-        "Raise <param base> to the power of <param exponent>.
-        <param exponent> must to be positive.
-        Overflow wraps around."
+        "Raise <param base> to the power of <param exponent>. <param exponent> "
+        + "must to be positive. Overflow wraps around."
       fn =
         (function
         | _, _, _, [| DUInt8 number; DUInt8 exp |] ->

--- a/backend/src/Builtins/Builtins.Random/Libs/Random.fs
+++ b/backend/src/Builtins/Builtins.Random/Libs/Random.fs
@@ -226,9 +226,9 @@ let fns () : List<BuiltInFn> =
       parameters = [ Param.make "list" (TList(TVariable "a")) "" ]
       returnType = TypeReference.option (TVariable "a")
       description =
-        "Returns {{Some <var randomValue>}}, where <var randomValue> is a randomly
-         selected value in <param list>. Returns {{None}} if <param list> is
-         empty."
+        "Returns {{Some <var randomValue>}}, where <var randomValue> is a "
+        + "randomly selected value in <param list>. Returns {{None}} if <param "
+        + "list> is empty."
       fn =
         let optType = VT.unknownTODO
         (function

--- a/backend/src/LibExecution/Builtin.fs
+++ b/backend/src/LibExecution/Builtin.fs
@@ -69,44 +69,7 @@ let combine (libs : List<Builtins>) (fnRenames : FnRenames) : Builtins =
     fns = byName (fns |> renameFunctions fnRenames) _.name }
 
 
-/// Join a description that was written as an indented multi-line F# string literal.
-///
-/// The compiler keeps both the newline and the source indentation, so `"one\n         two"` is what
-/// a wrapped description actually holds, and anything rendering it on one line shows those nine
-/// spaces as a gap mid-sentence. Continuation lines join with a single space; a blank line is a
-/// deliberate paragraph break and survives as one.
-let private joinDescriptionLines (description : string) : string =
-  if not (description.Contains '\n') then
-    description
-  else
-    description.Split "\n\n"
-    |> Array.map (fun paragraph ->
-      paragraph.Split '\n'
-      |> Array.map (fun line -> line.Trim())
-      |> Array.filter (fun line -> line <> "")
-      |> String.concat " ")
-    |> Array.filter (fun paragraph -> paragraph <> "")
-    |> String.concat "\n\n"
-
-
 let make (values : List<BuiltInValue>) (fns : List<BuiltInFn>) : Builtins =
-  // Every library builds its `Builtins` here, and `combine` merges what this produced, so this is
-  // the one place a description has to be cleaned for every consumer of it.
-  let values =
-    values
-    |> List.map (fun v ->
-      { v with description = joinDescriptionLines v.description })
-
-  let fns =
-    fns
-    |> List.map (fun f ->
-      { f with
-          description = joinDescriptionLines f.description
-          parameters =
-            f.parameters
-            |> List.map (fun p ->
-              { p with description = joinDescriptionLines p.description }) })
-
   { values = byName values _.name; fns = byName fns _.name }
 
 

--- a/backend/src/LibExecution/Builtin.fs
+++ b/backend/src/LibExecution/Builtin.fs
@@ -69,7 +69,44 @@ let combine (libs : List<Builtins>) (fnRenames : FnRenames) : Builtins =
     fns = byName (fns |> renameFunctions fnRenames) _.name }
 
 
+/// Join a description that was written as an indented multi-line F# string literal.
+///
+/// The compiler keeps both the newline and the source indentation, so `"one\n         two"` is what
+/// a wrapped description actually holds, and anything rendering it on one line shows those nine
+/// spaces as a gap mid-sentence. Continuation lines join with a single space; a blank line is a
+/// deliberate paragraph break and survives as one.
+let private joinDescriptionLines (description : string) : string =
+  if not (description.Contains '\n') then
+    description
+  else
+    description.Split "\n\n"
+    |> Array.map (fun paragraph ->
+      paragraph.Split '\n'
+      |> Array.map (fun line -> line.Trim())
+      |> Array.filter (fun line -> line <> "")
+      |> String.concat " ")
+    |> Array.filter (fun paragraph -> paragraph <> "")
+    |> String.concat "\n\n"
+
+
 let make (values : List<BuiltInValue>) (fns : List<BuiltInFn>) : Builtins =
+  // Every library builds its `Builtins` here, and `combine` merges what this produced, so this is
+  // the one place a description has to be cleaned for every consumer of it.
+  let values =
+    values
+    |> List.map (fun v ->
+      { v with description = joinDescriptionLines v.description })
+
+  let fns =
+    fns
+    |> List.map (fun f ->
+      { f with
+          description = joinDescriptionLines f.description
+          parameters =
+            f.parameters
+            |> List.map (fun p ->
+              { p with description = joinDescriptionLines p.description }) })
+
   { values = byName values _.name; fns = byName fns _.name }
 
 

--- a/backend/tests/Tests/Builtin.Tests.fs
+++ b/backend/tests/Tests/Builtin.Tests.fs
@@ -255,9 +255,47 @@ let everyBuiltinIsReferenced =
   }
 
 
+/// A description written across several source lines has to read as one sentence, since most
+/// things that show it (the workbench signature pane, `dark help`, LSP hover) have one line to
+/// show it on.
+let descriptionsAreJoined =
+  let builtins =
+    allBuiltinSets () |> List.collect (fun b -> b.fns.Values |> List.ofSeq)
+
+  testList
+    "descriptions"
+    [ test "no builtin description carries source indentation" {
+        let ragged =
+          builtins
+          |> List.filter (fun fn -> Regex.IsMatch(fn.description, @"\n[ \t]"))
+          |> List.map (fun fn -> string fn.name)
+
+        Expect.isEmpty
+          ragged
+          ("These descriptions keep the indentation of the F# literal they were written in, which "
+           + "renders as a gap mid-sentence:\n"
+           + String.concat "\n" ragged)
+      }
+      test "a wrapped description reads as one sentence" {
+        // `add` is written across four indented source lines.
+        let add =
+          builtins
+          |> List.tryFind (fun fn -> fn.name.name = "add" && fn.name.version = 0)
+
+        match add with
+        | None -> failtest "no `add` builtin"
+        | Some fn ->
+          Expect.stringContains
+            fn.description
+            "integer overflow wraps around"
+            "the line break should have become a single space"
+      } ]
+
+
 let tests =
   testList
     "builtin"
     [ oldFunctionsAreDeprecated
       builtinAccessInPackageMatter
-      everyBuiltinIsReferenced ]
+      everyBuiltinIsReferenced
+      descriptionsAreJoined ]


### PR DESCRIPTION
A description written as a multi-line F# literal keeps the newline *and* the source indentation. Anything showing it on one line drops the newline as a control character and keeps the spaces, so the sentence comes out with a gap in the middle of it.

`add`, as rendered in the workbench signature pane:

```
Adds two numbers of the same numeric type. Fixed-width integer overflow         wraps around; the arbitrary-precision Int grows         instead of overflowing; float arithmetic follows IEEE (overflow to         infinity).
```

```
Adds two numbers of the same numeric type. Fixed-width integer overflow wraps around; the arbitrary-precision Int grows instead of overflowing; float arithmetic follows IEEE (overflow to infinity).
```

Three continuation lines in the source, three gaps on screen. 109 builtin descriptions have an embedded newline, so this is wrong everywhere a description is shown: the workbench, `dark help`, LSP hover.

Fixed in `LibExecution.Builtin.make`, which every library's `Builtins` is built through, rather than in the 109 strings: nothing stops the next author from indenting a continuation line. Continuations join with a single space, and the 28 descriptions with a real blank line keep their paragraph break. Parameter descriptions go through the same cleanup.

A test asserts no builtin description carries source indentation, so a new one can't reintroduce it.