### PR TITLE
Fix `view --instructions` on lambdas, and three stale CLI test assertions

### DIFF
--- a/packages/darklang/cli/packages/view.dark
+++ b/packages/darklang/cli/packages/view.dark
@@ -341,7 +341,7 @@ let instructionRows
         PrettyPrinter.RuntimeTypes.Instructions.header l.instructions
       Stdlib.List.flatten
         [ [ ""
-            Stdlib.Cli.UI.Colors.hint $"lambda#{Stdlib.Int64.toString l.exprId}"
+            Stdlib.Cli.UI.Colors.hint $"lambda#{Stdlib.UInt64.toString l.exprId}"
             Stdlib.Cli.UI.Colors.dimText $"  {header}"
             "" ]
           renderBody l.instructions ])

--- a/packages/darklang/cli/tests/tests-tui.dark
+++ b/packages/darklang/cli/tests/tests-tui.dark
@@ -671,8 +671,11 @@ let testReplCapturesRealValues (): TestResult =
     [ (Darklang.Cli.Repl.captureValue branch 42, "ok:42")
       (Darklang.Cli.Repl.captureValue branch [ 1L; 2L ], "ok:[1L; 2L]")
       (Darklang.Cli.Repl.captureValue branch "hi", "ok:\"hi\"")
+      // An enum renders under a shortened package name, so `Option.Some(1)`. That and the
+      // fully-qualified spelling both parse back to the same value, which is what matters here: the
+      // property is that the output is source you could paste in, not that it is spelled one way.
       (Darklang.Cli.Repl.captureValue branch (Stdlib.Option.Option.Some 1),
-       "ok:Stdlib.Option.Option.Some(1)") ]
+       "ok:Option.Some(1)") ]
   let wrong =
     cases
     |> Stdlib.List.filter (fun c -> let (got, want) = c in got != want)

--- a/packages/darklang/cli/tests/tests.dark
+++ b/packages/darklang/cli/tests/tests.dark
@@ -117,6 +117,12 @@ let testEvalListLength (): TestResult =
     TestResult.Fail $"Expected '3', got '{output}'"
 
 
+/// Create, update, and what happens to a module that does not type-check.
+///
+/// A declaration that fails the at-rest check is SAVED AS WIP and refused at `commit`, not rejected
+/// at author time: a draft may be broken because you write the caller before the callee, a commit may
+/// not, because a commit is what other machines pull. So after an invalid module the item EXISTS, the
+/// message says it is WIP, and the definitions that were already there are untouched.
 let testModuleCommand (): TestResult =
   let suffix = Stdlib.Int.toString (Stdlib.Int.random 100000 999999)
   let branchName = "cli-module-test-" ++ suffix
@@ -204,8 +210,9 @@ let testModuleCommand (): TestResult =
     && initialEval == "12"
     && Stdlib.String.contains updateOutput "Defined 4 declarations"
     && updatedEval == "27"
-    && Stdlib.String.contains invalidOutput "expects 1 field(s)"
-    && Stdlib.String.contains searchOutput "No results found"
+    && Stdlib.String.contains invalidOutput "expects 1 field"
+    && Stdlib.String.contains invalidOutput "saved as WIP"
+    && Stdlib.String.contains searchOutput "shouldNotExist"
     && afterInvalidEval == "27"
   then
     TestResult.Pass
@@ -525,8 +532,23 @@ let testViewInstructions (): TestResult =
 
 
 let testViewInstructionsShowsLambdas (): TestResult =
-  // `filter` is `fold` plus a lambda, and a listing that stopped at `CreateLambda` would be a dead end.
-  let output = runWithCommand ["view"; "Stdlib.List.filter"; "--instructions"]
+  // A listing that stopped at `CreateLambda` would be a dead end, so a lambda gets its own section
+  // below the function that creates it.
+  //
+  // The subject is authored here rather than borrowed from the stdlib. Whether a given stdlib function
+  // compiles to a lambda is an implementation detail: it can become a direct builtin call, and then a
+  // test pointing at it still runs, still fails, and covers nothing.
+  let suffix = Stdlib.Int.toString (Stdlib.Int.random 100000 999999)
+  let name = "Tests.CliLambda.keepBig" ++ suffix
+
+  let _ =
+    runWithCommand
+      [ "fn"
+        "/" ++ name
+        "(xs: List<Int64>) : List<Int64> = Stdlib.List.filter xs (fun x -> if x > 2L then true else false)" ]
+
+  let output = runWithCommand ["view"; name; "--instructions"]
+  let _ = runWithCommand [ "delete"; "fn"; name; "--yes" ]
 
   if Stdlib.String.contains output "CreateLambda"
     && Stdlib.String.contains output "lambda#"
@@ -534,7 +556,7 @@ let testViewInstructionsShowsLambdas (): TestResult =
   then
     TestResult.Pass
   else
-    TestResult.Fail $"Expected the lambda's own listing under filter's, got: {output}"
+    TestResult.Fail $"Expected the lambda's own listing under {name}'s, got: {output}"
 
 
 let testViewCompilerViewsRejectNonFunctions (): TestResult =

--- a/packages/darklang/prettyPrinter/instructions.dark
+++ b/packages/darklang/prettyPrinter/instructions.dark
@@ -120,7 +120,7 @@ let inlineDval (branchId: Uuid) (dv: LanguageTools.RuntimeTypes.Dval) : String =
   | DApplicable app ->
     match app with
     | AppNamedFn fn -> "&" ++ (PrettyPrinter.RuntimeTypes.fnName branchId fn.name)
-    | AppLambda l -> $"&lambda#{Stdlib.Int64.toString l.exprId}"
+    | AppLambda l -> $"&lambda#{Stdlib.UInt64.toString l.exprId}"
   | other -> PrettyPrinter.RuntimeTypes.dval branchId other
 
 
@@ -195,7 +195,7 @@ let operands (branchId: Uuid) (index: Int) (i: LanguageTools.RuntimeTypes.Instru
     $"{register t} <- {n}"
   | CreateLambda(t, l) ->
     let n = Stdlib.Int.toString (Stdlib.List.length l.patterns)
-    $"{register t} <- lambda#{Stdlib.Int64.toString l.exprId} ({n} params)"
+    $"{register t} <- lambda#{Stdlib.UInt64.toString l.exprId} ({n} params)"
   | Apply(t, fnReg, _, args) ->
     $"{register t} <- {register fnReg}({registers args})"
   | RaiseNRE(names, _) -> Stdlib.String.join names "."


### PR DESCRIPTION
This takes the Dark CLI test suite from 63/66 to 66/66. Three failures, all pre-existing on main, and one of them was hiding a real bug rather than being a stale assertion.

---

**`dark view <fn> --instructions` crashes on any function containing a lambda.** A lambda's `exprId` is a `UInt64` and three call sites passed it to `Stdlib.Int64.toString`, so the command died with a type error from inside the pretty printer. That is the actual fix here; the rest is assertions catching up.

The test covering it pointed at `Stdlib.List.filter`, which became a direct builtin call with no lambda in it at all. So the test failed for the wrong reason and never reached the crashing path. A test whose subject quietly changes underneath it stops testing anything, and keeps failing in a way that looks explained.

It now authors its own subject, a function with a lambda containing a conditional, so it exercises `CreateLambda`, the lambda's own section, and `JumpByIfFalse`. Verified by reinstating the bug: the suite goes to 65/66.

**Two assertions describe contracts that changed.** `Module Command` expected an invalid declaration to be rejected outright; the at-rest checker saves it as WIP and refuses it at `commit`, which is deliberate (a draft may be broken because you write the caller before the callee, a commit may not). And it looked for the wording "expects 1 field(s)", which is now "expects 1 field, but 2 were provided". `REPL Captures Real Values` pinned the exact spelling `Stdlib.Option.Option.Some(1)`, and the printer now shortens a resolved package name to `Option.Some(1)`. I checked that both forms still evaluate, so the round-trip property the test documents is intact and only the spelling moved.

---

Changes made:

- In `packages/darklang/prettyPrinter/instructions.dark` and `packages/darklang/cli/packages/view.dark`: `UInt64.toString` for a lambda's `exprId`, three sites.
- In `packages/darklang/cli/tests/tests.dark`: the lambda test authors its own subject; `Module Command` asserts the WIP contract and the current wording.
- In `packages/darklang/cli/tests/tests-tui.dark`: the capture test expects the shortened spelling, with a note that both parse back.

I have not touched the shape of the at-rest design or the printer's shortening. Both look right to me; only the assertions were behind.