### PR TITLE
Decode query strings, and fix two ways `queryParams` mangled a URL

### DIFF
--- a/backend/testfiles/execution/stdlib/http.dark
+++ b/backend/testfiles/execution/stdlib/http.dark
@@ -98,6 +98,58 @@ module ParseQueryString =
   Stdlib.Http.parseQueryString "https://x?token=a=b" =
     Stdlib.Dict.fromListOverwritingDuplicates [ ("token", "a=b") ]
 
+  // Keys and values are both decoded.
+  Stdlib.Http.parseQueryString "https://x?q=List+map&n=A%2FB" =
+    Stdlib.Dict.fromListOverwritingDuplicates [ ("q", "List map"); ("n", "A/B") ]
+
+
+module UrlDecode =
+  // What an HTML form sends for a space in a GET.
+  Stdlib.Http.urlDecode "List+map" = "List map"
+
+  Stdlib.Http.urlDecode "A%2FB" = "A/B"
+  Stdlib.Http.urlDecode "a%3Db" = "a=b"
+
+  // Decoding is byte-level, so a multi-byte character survives. Per character it would be two.
+  Stdlib.Http.urlDecode "caf%C3%A9" = "café"
+
+  // Double-encoded: the user typed a percent sign and the form encoded it.
+  Stdlib.Http.urlDecode "%2541" = "%41"
+
+  // A literal `+` travels as `%2B`, and survives the `+`-means-space substitution because that
+  // runs over the raw text, where an escape holds no `+` of its own. Searching for `C++` is the
+  // case that notices if those two steps are ever reordered.
+  Stdlib.Http.urlDecode "a%2Bb" = "a+b"
+  Stdlib.Http.urlDecode "C%2B%2B" = "C++"
+  Stdlib.Http.urlDecode "a%2Bb+c" = "a+b c"
+
+  // A `%` that starts no escape is itself. A search box may contain one, including at the end,
+  // where decoding an empty hex string succeeds and would otherwise contribute no bytes.
+  Stdlib.Http.urlDecode "100%" = "100%"
+  Stdlib.Http.urlDecode "%" = "%"
+  Stdlib.Http.urlDecode "a%2" = "a%2"
+  Stdlib.Http.urlDecode "50%zz" = "50%zz"
+
+  Stdlib.Http.urlDecode "" = ""
+
+
+module QueryParams =
+  (Stdlib.Http.Request.queryParams (
+    Stdlib.Http.Request
+      { url = "/s?q=List+map&n=A%2FB"; headers = []; body = Stdlib.Blob.empty })) =
+    [ ("q", "List map"); ("n", "A/B") ]
+
+  // A field splits at its FIRST `=` only, so a value may hold one: base64 padding and a nested
+  // query string both do.
+  (Stdlib.Http.Request.queryParam
+    (Stdlib.Http.Request { url = "/s?q=a=b"; headers = []; body = Stdlib.Blob.empty })
+    "q") = Stdlib.Option.Option.Some "a=b"
+
+  // Only the first `?` separates the query string; a later one is part of a value.
+  (Stdlib.Http.Request.queryParams (
+    Stdlib.Http.Request
+      { url = "/s?a=1?b=2"; headers = []; body = Stdlib.Blob.empty })) = [ ("a", "1?b=2") ]
+
 
 module ParseHeaders =
   Stdlib.Http.parseHeaders "x: y" = Stdlib.Dict.fromListOverwritingDuplicates [ ("x", "y") ]

--- a/packages/darklang/stdlib/http.dark
+++ b/packages/darklang/stdlib/http.dark
@@ -21,14 +21,15 @@ let parseQueryString (url: String) : Dict<String> =
       if param == "" then
         Stdlib.Option.Option.None
       else
+        // Decoded, like `Request.queryParams`: a caller reading `?q=List+map`
+        // wants the two words, not the plus sign that carried the space.
         match Stdlib.String.split param "=" with
-        | [ key; value ] -> Stdlib.Option.Option.Some((key, value))
-        | [ key ] -> Stdlib.Option.Option.Some((key, ""))
+        | [] -> Stdlib.Option.Option.None
         | key :: rest ->
-          // `?a=b=c` → key="a", value="b=c"
-          let value = Stdlib.String.join rest "="
-          Stdlib.Option.Option.Some((key, value))
-        | [] -> Stdlib.Option.Option.None)
+          // `?a=b=c` gives key="a", value="b=c"
+          Stdlib.Option.Option.Some(
+            (Stdlib.Http.urlDecode key,
+             Stdlib.Http.urlDecode (Stdlib.String.join rest "="))))
     |> Stdlib.Dict.fromListOverwritingDuplicates
 
 
@@ -54,17 +55,61 @@ let parseHeaders (s: String) : Dict<String> =
   |> Stdlib.Dict.fromListOverwritingDuplicates
 
 
+/// Percent-decoding for one query-string field.
+///
+/// Decodes at the BYTE level and only reads the result back as text at the end,
+/// because an escape is a BYTE and a non-ASCII character is several of them:
+/// `%C3%A9` is one `e-acute`, not two characters. Decoding per character produces
+/// mojibake for every name that is not plain ASCII.
+///
+/// `+` is a space. That is not decoration: an HTML form doing a GET encodes a
+/// space that way, so a two-word search from a form field arrives as `a+b`.
+///
+/// A `%` that does not start two hex digits is passed through as itself rather
+/// than dropped. A search box is allowed to contain a percent sign.
+let urlDecode (s: String) : String =
+  match Stdlib.String.split (Stdlib.String.replaceAll s "+" " ") "%" with
+  | [] -> ""
+  | first :: rest ->
+    rest
+    |> Stdlib.List.fold (Stdlib.String.toBytes first) (fun acc piece ->
+      let hex = Stdlib.String.slice piece 0 2
+
+      // The length check is not redundant: `Blob.fromHex ""` succeeds, so a `%`
+      // at the very end of the string decodes to no bytes at all and vanishes.
+      match
+        (if (Stdlib.String.length hex) == 2 then
+           Stdlib.Blob.fromHex hex
+         else
+           Stdlib.Result.Result.Error "not an escape")
+      with
+      | Ok b ->
+        Stdlib.List.append
+          (Stdlib.List.append acc (Stdlib.Blob.toList b))
+          (Stdlib.String.toBytes (Stdlib.String.dropFirst piece 2))
+      | Error _ -> Stdlib.List.append acc (Stdlib.String.toBytes ("%" ++ piece)))
+    |> Stdlib.String.fromBytesWithReplacement
+
+
 module Request =
+  /// The query string, decoded.
+  ///
+  /// Splits each field at its FIRST `=` only. A value is allowed to contain one
+  /// (base64 padding and any nested query string do), and requiring exactly two
+  /// pieces dropped the whole field on the floor: `?q=a=b` read as though `q`
+  /// had never been sent.
   let queryParams (req: Stdlib.Http.Request) : List<String * String> =
     match req.url |> Stdlib.String.split "?" with
     | [] -> []
     | _ :: queryParts ->
-      (Stdlib.String.join queryParts "")
+      (Stdlib.String.join queryParts "?")
       |> Stdlib.String.split "&"
       |> Stdlib.List.map (fun param ->
         match Stdlib.String.split param "=" with
-        | [ key; value ] -> (key, value)
-        | _ -> (param, ""))
+        | [] -> ("", "")
+        | key :: valueParts ->
+          (Stdlib.Http.urlDecode key,
+           Stdlib.Http.urlDecode (Stdlib.String.join valueParts "=")))
 
   let queryParam
     (req: Stdlib.Http.Request)


### PR DESCRIPTION
`Stdlib.Http` doesn't decode query strings, and `Request.queryParams` mangles two shapes of URL.

    ?q=List+map     before  [("q", "List+map")]     after  [("q", "List map")]
    ?q=a=b          before  [("q=a=b", "")]         after  [("q", "a=b")]
    ?q=caf%C3%A9    before  [("q", "caf%C3%A9")]    after  [("q", "café")]
    ?a=1?b=2        before  [("a=1b=2", "")]        after  [("a", "1?b=2")]

The first is what an HTML form GET sends for a space. The second required exactly two pieces after splitting on `=`, so a value containing one turned the whole field into the key. The fourth joined the parts after `?` with the empty string, so a second `?` vanished.

Decoding is byte-level, and only read back as text at the end: an escape is a byte and a non-ASCII character is several, so `%C3%A9` is one `é` rather than two mangled characters. `+` is a space, because that's what a form sends. A `%` that starts no escape passes through as itself, including a trailing one, since a search box may contain a percent sign.

Changes:

- `packages/darklang/stdlib/http.dark`: `urlDecode` is new; `queryParams` and `parseQueryString` split at the first `=` only and decode both halves; `queryParams` keeps a later `?` in the value.
- `backend/testfiles/execution/stdlib/http.dark`: cases for each shape above, multi-byte, double-encoded, and the bare/trailing `%`.