### PR TITLE
Mark truncated list rows, and keep them out from under the scrollbar

### DIFF
--- a/backend/testfiles/execution/stdlib/cli-tui-text.dark
+++ b/backend/testfiles/execution/stdlib/cli-tui-text.dark
@@ -1,0 +1,25 @@
+// Clipping for terminal rows. Widths are DISPLAY CELLS, not characters: a wide glyph occupies two
+// columns, so a row measured by character count goes ragged on the first one.
+
+module ClipMarked =
+  // A line that fits is untouched, marker and all.
+  Stdlib.Cli.Tui.Text.clipMarked "short" 30 = "short"
+  Stdlib.Cli.Tui.Text.clipMarked "exactly ten" 11 = "exactly ten"
+
+  // A line that does not fit ends in an ellipsis, so it reads as truncated rather than as a
+  // shorter label that happens to end there.
+  Stdlib.Cli.Tui.Text.clipMarked "Interactive tree outliner (full)" 30 =
+    "Interactive tree outliner (fu…"
+
+  Stdlib.Cli.Tui.Text.clipMarked "abcdef" 3 = "ab…"
+
+  // Below two columns there is no room to say anything, so it degrades to a plain clip rather than
+  // spending the only column on a marker.
+  Stdlib.Cli.Tui.Text.clipMarked "abcdef" 1 = "a"
+  Stdlib.Cli.Tui.Text.clipMarked "abcdef" 0 = ""
+
+  // Cells, not characters. Three CJK characters are six columns, so they fit exactly in six and
+  // clip to two plus the marker in five.
+  Stdlib.Cli.Tui.Text.styledWidth "日本語" = 6
+  Stdlib.Cli.Tui.Text.clipMarked "日本語" 6 = "日本語"
+  Stdlib.Cli.Tui.Text.clipMarked "日本語のテキスト" 6 = "日本…"

--- a/packages/darklang/stdlib/cli/tui/text.dark
+++ b/packages/darklang/stdlib/cli/tui/text.dark
@@ -32,6 +32,22 @@ let clipToWidth (text: String) (maxWidth: Int) : String =
   Builtin.cliTerminalClipToWidth text maxWidth
 
 
+/// Clip to <param maxWidth>, marking the cut so a truncated line reads as truncated.
+///
+/// `clipToWidth` alone just stops, which is indistinguishable from a line that happened to be that long --
+/// "Interactive tree outliner (ful" looks like the whole label to anyone who has not seen it wider. One
+/// character of ellipsis is the difference between "there is more" and "that is all".
+///
+/// Below two columns there is no room to say anything, so it degrades to a plain clip.
+let clipMarked (text: String) (maxWidth: Int) : String =
+  if styledWidth text <= maxWidth then
+    text
+  else if maxWidth <= 1 then
+    clipToWidth text maxWidth
+  else
+    (clipToWidth text (maxWidth - 1)) ++ "…"
+
+
 /// Break a row at the column, restating styling that spans the wrap. To break at spaces where it
 /// can, use `wrapAtWords`.
 let wrapAtColumn (text: String) (maxWidth: Int) : List<String> =

--- a/packages/darklang/stdlib/cli/ui/listview.dark
+++ b/packages/darklang/stdlib/cli/ui/listview.dark
@@ -12,6 +12,15 @@ let render (region: Layout.Region) (displayLines: List<String>) (selected: Int) 
     // Bottom-anchored viewport: once the selection passes the last visible row, scroll so it stays on screen.
     let visible = region.rows
     let scrollOffset = Stdlib.Int.max 0 (selected - visible + 1)
+
+    // The scrollbar owns the last column when there is one, so a full-width row does not sit under
+    // the thumb.
+    let textWidth =
+      if total > region.rows then
+        Stdlib.Int.max 0 (region.cols - 1)
+      else
+        region.cols
+
     let rows =
       displayLines
       |> Stdlib.List.indexedMap (fun i l -> (i, l))
@@ -19,7 +28,10 @@ let render (region: Layout.Region) (displayLines: List<String>) (selected: Int) 
       |> Stdlib.List.take visible
       |> Stdlib.List.map (fun pair ->
         let (i, l) = pair
-        Layout.at region (i - scrollOffset) 0 l)
+        // Marked, not silently cut. These are names, and a row that just stops reads as the whole
+        // one: "Interactive tree outliner (ful" looks complete to anyone who has not seen the pane
+        // wider.
+        Layout.at region (i - scrollOffset) 0 (Tui.Text.clipMarked l textWidth))
       |> Stdlib.List.flatten
 
     // Scrollbar thumb, only when the list is taller than the pane. It used to be printed directly, because


### PR DESCRIPTION
List rows are cut without a marker, so a truncated name reads as the whole name.

    before  Interactive tree outliner (ful
    after   Interactive tree outliner (fu…

`clipToWidth` just stops, which is indistinguishable from a label that happened to be that long. `clipMarked` spends one column saying otherwise, and below two columns there is no room to say anything so it degrades to a plain clip.

A second, smaller thing in the same place: when a list is taller than its pane, the scrollbar thumb owns the last column, but rows were laid out across the full width and a long one sat underneath it. Rows now get `cols - 1` when there is a thumb.