### PR TITLE
Report a read-only or full store as advice, not a stack trace

### DIFF
--- a/backend/src/Cli/Cli.fs
+++ b/backend/src/Cli/Cli.fs
@@ -98,7 +98,14 @@ let state (packageManager : RT.PackageManager) =
     (metadata : Metadata)
     (exn : exn)
     =
-    uply { printException "Internal error" metadata exn }
+    uply {
+      // A store condition already carries a sentence written for whoever ran the command, and
+      // `printException` buries it under a stack trace. The exception still surfaces as a runtime
+      // error, which prints that sentence once.
+      match exn with
+      | :? Exception.StoreConditionException -> ()
+      | _ -> printException "Internal error" metadata exn
+    }
 
   Exe.createState
     (builtinsLazy.Force())
@@ -371,17 +378,36 @@ let main (args : string[]) =
 
 
   with e ->
-    let rec describe (depth : int) (ex : exn) : unit =
-      let indent = String.replicate depth "  "
-      System.Console.Error.WriteLine $"{indent}{ex.GetType().FullName}: {ex.Message}"
+    // A store that cannot be used is an ENVIRONMENT, not a bug: a read-only mount, a store owned by
+    // another user, a full disk. `LibDB.Sqlite` raises a `StoreConditionException` carrying a
+    // sentence written for whoever ran the command, so all that is left is to print it.
+    let rec storeCondition (ex : exn) : Exception.StoreConditionException option =
       match ex with
+      | :? Exception.StoreConditionException as s -> Some s
       | :? System.AggregateException as agg ->
-        for inner in agg.InnerExceptions do
-          describe (depth + 1) inner
+        agg.InnerExceptions |> Seq.tryPick storeCondition
       | _ ->
-        if not (isNull ex.InnerException) then describe (depth + 1) ex.InnerException
-      if depth = 0 && not (isNull ex.StackTrace) then
-        System.Console.Error.WriteLine $"Stack trace:\n{ex.StackTrace}"
-    System.Console.Error.WriteLine "Error starting Darklang CLI:"
-    describe 0 e
-    1
+        if isNull ex.InnerException then None else storeCondition ex.InnerException
+
+    match storeCondition e with
+    | Some s ->
+      System.Console.Error.WriteLine s.Message
+      1
+    | None ->
+
+      let rec describe (depth : int) (ex : exn) : unit =
+        let indent = String.replicate depth "  "
+        System.Console.Error.WriteLine
+          $"{indent}{ex.GetType().FullName}: {ex.Message}"
+        match ex with
+        | :? System.AggregateException as agg ->
+          for inner in agg.InnerExceptions do
+            describe (depth + 1) inner
+        | _ ->
+          if not (isNull ex.InnerException) then
+            describe (depth + 1) ex.InnerException
+        if depth = 0 && not (isNull ex.StackTrace) then
+          System.Console.Error.WriteLine $"Stack trace:\n{ex.StackTrace}"
+      System.Console.Error.WriteLine "Error starting Darklang CLI:"
+      describe 0 e
+      1

--- a/backend/src/LibDB/Sqlite.fs
+++ b/backend/src/LibDB/Sqlite.fs
@@ -101,11 +101,56 @@ module Sql =
 
   let query (sql : string) : Sql.SqlProps = connect |> Sql.query sql
 
+  /// A store that can't be read or written is an ENVIRONMENT, not a bug: a read-only mount, a store owned
+  /// by another user, a disk with nothing left on it. SQLite says exactly which, then .NET buries it under
+  /// an AggregateException and the callers below stringify it into a message, so the cause reached the
+  /// user as a stack trace that named neither the store nor the problem. Worse, writes went through
+  /// `Result.unwrap`, which prints the raw exception to stdout and raises "TODO: failed to unwrap".
+  ///
+  /// So: every query path funnels through here first. Only these three codes are translated, because only
+  /// these three are things the person running the command can act on. Anything else keeps its own
+  /// exception, stack and all, and is a bug worth seeing in full.
+  let private storeCondition (e : exn) : string option =
+    // The SqliteException arrives wrapped -- an AggregateException from the async boundary, sometimes an
+    // InnerException under that -- so this looks through the chain rather than testing the top of it.
+    let rec sqliteCause (ex : exn) : SqliteException option =
+      match ex with
+      | :? SqliteException as s -> Some s
+      | :? System.AggregateException as agg ->
+        agg.InnerExceptions |> Seq.tryPick sqliteCause
+      | _ -> if isNull ex.InnerException then None else sqliteCause ex.InnerException
+
+    match sqliteCause e with
+    // 8 = SQLITE_READONLY, 13 = SQLITE_FULL, 14 = SQLITE_CANTOPEN.
+    | Some s ->
+      match s.SqliteErrorCode with
+      | 8 -> Some "the package store is read-only, so nothing can be written to it"
+      | 13 -> Some "the disk holding the package store is full"
+      | 14 ->
+        Some
+          "the package store could not be opened -- it may be missing, or owned by another user"
+      | _ -> None
+    | None -> None
+
+  /// Raises the store condition if this is one, and does nothing at all if it isn't -- so callers keep
+  /// their own error handling for everything else.
+  let internal raiseIfStoreCondition (e : exn) : unit =
+    match storeCondition e with
+    | Some what ->
+      Exception.raiseStoreCondition
+        $"Can't use the package store: {what}. Nothing was lost -- fix it and run the same command again."
+        [ "dbPath", LibConfig.Config.dbPath ]
+    | None -> ()
+
   let executeNonQueryAsync props =
     timedTask "nonQuery" (fun () ->
       Sql.executeNonQueryAsync props
       |> Async.StartImmediateAsTask
-      |> Task.map Result.unwrap)
+      |> Task.map (function
+        | Ok n -> n
+        | Error(e : exn) ->
+          raiseIfStoreCondition e
+          raise e))
 
   let executeRowAsync (reader : RowReader -> 't) (props : Sql.SqlProps) : Task<'t> =
     task {
@@ -119,6 +164,7 @@ module Sql =
         return
           Exception.raiseInternal $"Too many results, expected 1" [ "actual", list ]
       | Error err ->
+        raiseIfStoreCondition err
         return
           Exception.raiseInternal
             $"SQL query failed in executeRowAsync: {err.Message}"
@@ -142,6 +188,7 @@ module Sql =
             $"Too many results, expected 0 or 1"
             [ "actual", list ]
       | Error err ->
+        raiseIfStoreCondition err
         return
           Exception.raiseInternal
             $"SQL query failed in executeRowOptionAsync: {err.Message}"
@@ -155,6 +202,7 @@ module Sql =
       match r with
       | Ok v -> v
       | Error err ->
+        raiseIfStoreCondition err
         Exception.raiseInternal $"SQL query failed: {err}" [ "error", err ])
 
   let executeExistsSync (props : Sql.SqlProps) : bool =
@@ -166,6 +214,7 @@ module Sql =
     | Ok result ->
       Exception.raiseInternal "Too many results, expected 1" [ "actual", result ]
     | Error err ->
+      raiseIfStoreCondition err
       Exception.raiseInternal
         $"Database query failed in executeExistsSync: {err}"
         [ "err", err ]
@@ -177,6 +226,7 @@ module Sql =
           Sql.executeNonQueryAsync props |> Async.StartImmediateAsTask)
       with
       | Error err ->
+        raiseIfStoreCondition err
         Exception.raiseInternal
           $"Database statement failed in executeStatementAsync: {err}"
           [ "err", err ]
@@ -187,6 +237,7 @@ module Sql =
     match timedSync "statementSync" (fun () -> Sql.executeNonQuery props) with
     | Ok _count -> ()
     | Error err ->
+      raiseIfStoreCondition err
       Exception.raiseInternal
         $"Database statement failed in executeStatementSync: {err}"
         [ "err", err ]
@@ -199,6 +250,7 @@ module Sql =
     match connect |> Sql.executeTransaction statements with
     | Ok counts -> counts
     | Error err ->
+      raiseIfStoreCondition err
       Exception.raiseInternal
         $"Database transaction failed in executeTransactionSync: {err}"
         [ "err", err ]

--- a/backend/src/Prelude/Exception.fs
+++ b/backend/src/Prelude/Exception.fs
@@ -22,6 +22,19 @@ type InternalException(message : string, metadata : Metadata, inner : exn) =
   new(msg : string, inner : exn) = InternalException(msg, [], inner)
 
 
+/// A condition of the MACHINE rather than of the program: the store is read-only, the disk is full, the
+/// store belongs to another user. Distinguished from `InternalException` because the response is opposite
+/// -- there is nothing to fix in the code, nothing to report, and the person running the command can
+/// resolve it themselves once told which of those it is. Carries a sentence written for them, so a caller
+/// that catches this can print it and nothing else.
+type StoreConditionException(message : string, metadata : Metadata, inner : exn) =
+  inherit System.Exception(message, inner)
+  member _.metadata = metadata
+  new(msg : string) = StoreConditionException(msg, [], null)
+  new(msg : string, metadata : Metadata) =
+    StoreConditionException(msg, metadata, null)
+
+
 // A pageable exception will cause the pager to go off! This is something that should
 // never happen and is an indicator that the service is broken in some way.  The
 // pager goes off because a pageable exception sets the `{ is_pageable: true }`
@@ -81,6 +94,10 @@ let raiseInternal (msg : string) (tags : Metadata) =
   let e = InternalException(msg, tags)
   callExceptionCallback e
   raise e
+
+/// See `StoreConditionException`. Not reported anywhere: this is the machine's state, not a defect.
+let raiseStoreCondition (msg : string) (tags : Metadata) =
+  raise (StoreConditionException(msg, tags))
 
 let unwrapOptionInternal (msg : string) (tags : Metadata) (o : Option<'a>) : 'a =
   match o with


### PR DESCRIPTION
A read-only store, a full disk, or a store owned by another user are conditions of the machine, not bugs in the program. They arrive as a stack trace.

    before  ✗ Failed to add function: Database transaction failed in executeTransactionSync:
            Microsoft.Data.Sqlite.SqliteException (0x80004005): SQLite Error 8: 'attempt to
            write a readonly database'.
               at Microsoft.Data.Sqlite.SqliteException.ThrowExceptionForRC(Int32 rc, sqlite3 db)
               at Microsoft.Data.Sqlite.SqliteDataReader.NextResult()
               ... six more frames

    after   ✗ Failed to add function: Can't use the package store: the package store is
            read-only, so nothing can be written to it. Nothing was lost -- fix it and run the
            same command again.

Three SQLite codes are translated and nothing else: 8 (read-only), 13 (disk full), 14 (cannot open). Those are the ones the person running the command can act on. Anything else keeps its exception, stack and all, because that is a bug worth seeing in full.

`StoreConditionException` is a separate type rather than a flag, so a caller can print its message and print nothing else. The exception arrives wrapped, an `AggregateException` from the async boundary and sometimes an `InnerException` under that, so the check looks through the chain rather than at the top of it.

Changes:

- `backend/src/Prelude/Exception.fs`: `StoreConditionException`, carrying a sentence written for a person.
- `backend/src/LibDB/Sqlite.fs`: every query path funnels through one translator first.
- `backend/src/Cli/Cli.fs`: two places that print it and stop, rather than adding a stack trace under it.