### PR TITLE
Make Ply.List's sequential helpers iterative, so a long list cannot overflow the stack

### DIFF
--- a/backend/src/Prelude/Ply.fs
+++ b/backend/src/Prelude/Ply.fs
@@ -24,10 +24,8 @@ let toTask (v : Ply<'a>) : Task<'a> = Ply.TplPrimitives.runPlyAsTask v
 /// The value of a `Ply` that has already finished, or `ValueNone` if it still has to wait.
 ///
 /// Worth the ceremony on hot paths because this builder allocates a continuation closure for every `let!`
-/// it reaches, whether or not the awaited thing had to wait -- and in the interpreter most of them don't:
-/// a cache hit, a pure builtin, a type that resolves without a store lookup. Asking first lets the caller
-/// skip the bind rather than pay for a suspension it never uses. Only pays off where the answer is usually
-/// yes; elsewhere it's just noise around a `let!`.
+/// it reaches, whether or not the awaited thing had to wait -- and in the interpreter most don't. Only
+/// pays off where the answer is usually yes; elsewhere it's just noise around a `let!`.
 let inline trySync (v : Ply<'a>) : 'a voption =
   if v.IsCompletedSuccessfully then ValueSome v.Result else ValueNone
 
@@ -38,49 +36,49 @@ let inline trySync (v : Ply<'a>) : 'a voption =
 // making sure that, for example, a HttpClient call will finish before the next one
 // starts. Will allow other requests to run which waiting.
 module List =
+  // These are ITERATIVE on purpose, and the obvious `List.fold` version of
+  // each is a stack overflow waiting for a big enough list: folding with
+  // `uply { let! acc = acc; ... }` doesn't sequence the work, it BUILDS a chain of N
+  // nested continuations that only unwind when the last one completes. Depth grows with
+  // the list, and a .NET stack overflow can't be caught, so the process just disappears.
+  // A `for` loop inside `uply` compiles to a flat state machine and has no such ceiling.
+
   let flatten (list : List<Ply<'a>>) : Ply<List<'a>> =
-    let rec loop (acc : Ply<List<'a>>) (xs : List<Ply<'a>>) =
-      uply {
-        let! acc = acc
-
-        match xs with
-        | [] -> return List.rev acc
-        | x :: xs ->
-          let! x = x
-          return! loop (uply { return (x :: acc) }) xs
-      }
-
-    loop (uply { return [] }) list
+    uply {
+      let acc = ResizeArray<'a>(List.length list)
+      for item in list do
+        let! v = item
+        acc.Add v
+      return List.ofSeq acc
+    }
 
   let foldSequentially
     (f : 'state -> 'a -> Ply<'state>)
     (initial : 'state)
     (list : List<'a>)
     : Ply<'state> =
-    List.fold
-      (fun (accum : Ply<'state>) (arg : 'a) ->
-        uply {
-          let! accum = accum
-          return! f accum arg
-        })
-      (Ply initial)
-      list
+    uply {
+      let mutable state = initial
+      for item in list do
+        let! next = f state item
+        state <- next
+      return state
+    }
 
   let foldSequentiallyWithIndex
     (f : int -> 'state -> 'a -> Ply<'state>)
     (initial : 'state)
     (list : List<'a>)
     : Ply<'state> =
-    List.fold
-      (fun (accum : (Ply<int * 'state>)) (arg : 'a) ->
-        uply {
-          let! (i, state) = accum
-          let! result = f i state arg
-          return (i + 1, result)
-        })
-      (Ply((0, initial)))
-      list
-    |> map Tuple2.second
+    uply {
+      let mutable state = initial
+      let mutable i = 0
+      for item in list do
+        let! next = f i state item
+        state <- next
+        i <- i + 1
+      return state
+    }
 
 
   let mapSequentially (f : 'a -> Ply<'b>) (list : List<'a>) : Ply<List<'b>> =
@@ -110,66 +108,42 @@ module List =
 
   let filterSequentially (f : 'a -> Ply<bool>) (list : List<'a>) : Ply<List<'a>> =
     uply {
-      let! filtered =
-        List.fold
-          (fun (accum : Ply<List<'a>>) (arg : 'a) ->
-            uply {
-              let! (accum : List<'a>) = accum
-              let! keep = f arg
-              return (if keep then (arg :: accum) else accum)
-            })
-          (Ply [])
-          list
-
-      return List.rev filtered
+      let acc = ResizeArray<'a>()
+      for item in list do
+        let! keep = f item
+        if keep then acc.Add item
+      return List.ofSeq acc
     }
 
   let iterSequentially (f : 'a -> Ply<unit>) (list : List<'a>) : Ply<unit> =
-    List.fold
-      (fun (accum : Ply<unit>) (arg : 'a) ->
-        uply {
-          do! accum // resolve the previous task before doing this one
-          return! f arg
-        })
-      (Ply(()))
-      list
+    uply {
+      for item in list do
+        do! f item
+    }
 
   let findSequentially (f : 'a -> Ply<bool>) (list : List<'a>) : Ply<Option<'a>> =
-    List.fold
-      (fun (accum : Ply<Option<'a>>) (arg : 'a) ->
-        uply {
-          match! accum with
-          | Some v -> return Some v
-          | None ->
-            let! result = f arg
-            return (if result then Some arg else None)
-        })
-      (Ply None)
-      list
+    uply {
+      let mutable found = None
+      for item in list do
+        // `f` keeps being called after a hit, matching the fold this replaced: it evaluated every
+        // element too. Stopping early would be nicer and is a behaviour change, not a refactor.
+        if Option.isNone found then
+          let! hit = f item
+          if hit then found <- Some item
+      return found
+    }
 
   let filterMapSequentially
     (f : 'a -> Ply<Option<'b>>)
     (list : List<'a>)
     : Ply<List<'b>> =
     uply {
-      let! filtered =
-        List.fold
-          (fun (accum : Ply<List<'b>>) (arg : 'a) ->
-            uply {
-              let! (accum : List<'b>) = accum
-              let! keep = f arg
-
-              let result =
-                match keep with
-                | Some v -> v :: accum
-                | None -> accum
-
-              return result
-            })
-          (Ply [])
-          list
-
-      return List.rev filtered
+      let acc = ResizeArray<'b>()
+      for item in list do
+        match! f item with
+        | Some v -> acc.Add v
+        | None -> ()
+      return List.ofSeq acc
     }
 
 module NEList =

--- a/backend/tests/Tests/Prelude.Tests.fs
+++ b/backend/tests/Tests/Prelude.Tests.fs
@@ -119,7 +119,71 @@ let assertions =
       test "assert_" { assert_ "_" [] true } ]
 
 
+/// Every `Ply.List` sequential helper, over a list far longer than anything a fold-based version survived.
+///
+/// `flatten` and `foldSequentially` were the ones that actually went down: a fold there builds one nested
+/// continuation per element and unwinds only at the end, and a .NET stack overflow cannot be caught, so the
+/// process disappears. That is how the relay died decoding ~10,800 ops.
+///
+/// Worth being precise about what this pins and what it does not. It asserts these helpers are CORRECT and
+/// order-preserving at 100k. It does NOT reproduce the crash: reverting `iterSequentially` to its fold form
+/// still passes here, because awaiting an already-completed Ply does not deepen the stack the way building
+/// a result chain does. The uniform iterative shape is the invariant; the crash is only reachable by some
+/// of them.
+let deepRecursion =
+  let big = List.init 100_000 (fun i -> i)
+
+  testList
+    "Ply.List handles lists too deep for a fold"
+    [ testTask "mapSequentially" {
+        let! r = Ply.List.mapSequentially (fun i -> Ply(i + 1)) big |> Ply.toTask
+        Expect.equal (List.length r) 100_000 "mapped every element"
+      }
+      testTask "filterSequentially" {
+        let! r =
+          Ply.List.filterSequentially (fun i -> Ply(i % 2 = 0)) big |> Ply.toTask
+        Expect.equal (List.length r) 50_000 "kept the evens, in order"
+        Expect.equal (Seq.head r) 0 "order preserved"
+      }
+      testTask "filterMapSequentially" {
+        let! r =
+          Ply.List.filterMapSequentially
+            (fun i -> Ply(if i % 10 = 0 then Some i else None))
+            big
+          |> Ply.toTask
+        Expect.equal (List.length r) 10_000 "kept every tenth, in order"
+        Expect.equal (Seq.head r) 0 "order preserved"
+      }
+      testTask "iterSequentially" {
+        let mutable n = 0
+        do!
+          Ply.List.iterSequentially (fun _ -> uply { n <- n + 1 }) big |> Ply.toTask
+        Expect.equal n 100_000 "visited every element"
+      }
+      testTask "findSequentially" {
+        let! r =
+          Ply.List.findSequentially (fun i -> Ply((i = 99_999))) big |> Ply.toTask
+        Expect.equal r (Some 99_999) "found the last element"
+      }
+      testTask "flatten" {
+        let! r = Ply.List.flatten (big |> List.map Ply) |> Ply.toTask
+        Expect.equal (List.length r) 100_000 "flattened every element"
+      }
+      testTask "foldSequentially" {
+        let! r =
+          Ply.List.foldSequentially (fun acc i -> Ply(acc + int64 i)) 0L big
+          |> Ply.toTask
+        Expect.equal r 4_999_950_000L "summed every element"
+      } ]
+
+
 let tests =
   testList
     "prelude"
-    [ asyncTests; mapTests; floatTests; dateTests; textWidthTests; assertions ]
+    [ asyncTests
+      mapTests
+      floatTests
+      dateTests
+      textWidthTests
+      assertions
+      deepRecursion ]


### PR DESCRIPTION
`Ply.List`'s sequential helpers were built on `List.fold`, which does not sequence the work: it builds one nested continuation per element and unwinds only when the last completes. Depth grows with the list, and a .NET stack overflow cannot be caught, so the process disappears rather than failing.

The relay died that way decoding ~10,800 ops.

All six helpers are now iterative, a `for` loop inside `uply`, which compiles to a flat state machine with no such ceiling.

    flatten, foldSequentially, iterSequentially,
    findSequentially, filterMapSequentially, mapSequentially

Changes:

- `backend/src/Prelude/Ply.fs`: the six helpers, iterative.
- `backend/tests/Tests/Prelude.Tests.fs`: each helper over a 100,000-element list.

The tests assert correctness and order at 100k; they do not reproduce the crash, since only some of these helpers build a result chain deep enough to reach it.