### PR TITLE
Only skip the SSRF guards for origins you named

### DIFF
--- a/backend/src/Builtins/Builtins.Http.Client/Libs/HttpClient.fs
+++ b/backend/src/Builtins/Builtins.Http.Client/Libs/HttpClient.fs
@@ -817,12 +817,14 @@ let fns (config : Configuration) : List<BuiltInFn> =
     // runs the same disposer chain when the DStream becomes
     // unreachable.
     // ——————————————————————————————————————————————————————————
-    // GET with SSRF guards OFF, returning raw BYTES — for pulling a peer's op wire over the tailnet.
-    // (The safe `httpClientRequest` bans loopback/RFC-1918/tailnet, which a peer's sync server sits behind;
-    // the Blob variant hands the body back as bytes for the caller to decode — `Stdlib.Blob.toString` for the
-    // JSON wire.) TRUSTED-CLI use: the caller IS the code author; used by `Sync.pull` / `dark sync fetch <url>`.
-    // TODO(sync-ssrf): this is registered in the general builtin set, so it's reachable from any CLI-run Dark
-    // (incl. packages pulled from a peer). Gate it to the sync surface (its own library or a sync capability).
+    // GET with SSRF guards OFF, returning raw BYTES: the server wanted sits behind
+    // loopback/RFC-1918/tailnet, which the safe path bans. The body comes as bytes
+    // for the caller to decode -- `Stdlib.Blob.toString` for the JSON wire.
+    //
+    // Registered in the general builtin set, so any CLI-run Dark can reach it,
+    // including code that arrived from elsewhere. `LibExecution.UnguardedOrigins`
+    // keeps that from meaning "can read your loopback": the guards come off only
+    // towards origins this machine was pointed at.
     { name = fn "httpGetUnsafeBytes" 0
       typeParams = []
       parameters =
@@ -841,23 +843,36 @@ let fns (config : Configuration) : List<BuiltInFn> =
         (function
         | _, _, _, [| DString uri |] ->
           uply {
-            let request : Request =
-              { url = uri; method = HttpMethod "GET"; headers = []; body = [||] }
-
-            let! response = makeRequest syncConfig syncClient request
-
-            match response with
-            | Ok r -> return Dval.resultOk KTBlob KTString (Blob.newEphemeral r.body)
-            | Error err ->
-              let reason =
-                match err with
-                | RequestError.BadUrl _ -> "bad url"
-                | RequestError.Timeout -> "timeout"
-                | RequestError.BadHeader _ -> "bad header"
-                | RequestError.NetworkError -> "network error"
-                | RequestError.BadMethod -> "bad method"
+            // Before the request is built, so a refused origin is never dialled.
+            if not (LibExecution.UnguardedOrigins.isAllowed uri) then
               return
-                Dval.resultError KTBlob KTString (DString $"fetch failed: {reason}")
+                Dval.resultError
+                  KTBlob
+                  KTString
+                  (DString(LibExecution.UnguardedOrigins.refusalMessage uri))
+            else
+
+              let request : Request =
+                { url = uri; method = HttpMethod "GET"; headers = []; body = [||] }
+
+              let! response = makeRequest syncConfig syncClient request
+
+              match response with
+              | Ok r ->
+                return Dval.resultOk KTBlob KTString (Blob.newEphemeral r.body)
+              | Error err ->
+                let reason =
+                  match err with
+                  | RequestError.BadUrl _ -> "bad url"
+                  | RequestError.Timeout -> "timeout"
+                  | RequestError.BadHeader _ -> "bad header"
+                  | RequestError.NetworkError -> "network error"
+                  | RequestError.BadMethod -> "bad method"
+                return
+                  Dval.resultError
+                    KTBlob
+                    KTString
+                    (DString $"fetch failed: {reason}")
           }
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable

--- a/backend/src/Cli/Cli.fs
+++ b/backend/src/Cli/Cli.fs
@@ -205,6 +205,24 @@ let main (args : string[]) =
     // to themselves rather than to whichever query happened to run first.
     Telemetry.time "cli.dbConnect" [] LibDB.Sqlite.Sql.warm
 
+    // Where the unguarded HTTP transport may be pointed. Two sources, both of them
+    // local intent: a URL on this command line, and the peers this instance has
+    // connected. Anywhere else it refuses, which is the position a package pulled
+    // from a peer is in.
+    //
+    // The stored side is a lookup rather than a snapshot because `dark sync connect`
+    // adds a peer and probes it inside one process, so a value read here would be a
+    // command too late. `sync_peers_v0` is created by the Dark side on first use, so
+    // an instance that has never synced has no such table, and nothing to allow.
+    LibExecution.UnguardedOrigins.setFromArgv args
+    LibExecution.UnguardedOrigins.setStoredLookup (fun () ->
+      try
+        (LibDB.Sqlite.Sql.query "SELECT url FROM sync_peers_v0"
+         |> LibDB.Sqlite.Sql.executeAsync (fun read -> read.string "url"))
+          .Result
+      with _ ->
+        [])
+
     // Grow the database: apply any unapplied ops and evaluate values.
     let cliPackageManager =
       Telemetry.time "cli.createPM" [] (fun () -> LibDB.PackageManager.rt)

--- a/backend/src/LibExecution/LibExecution.fsproj
+++ b/backend/src/LibExecution/LibExecution.fsproj
@@ -25,6 +25,7 @@
     <Compile Include="PackageRefs.fs" />
     <!-- Capabilities (resource-domain gating model — RT-independent) /-->
     <Compile Include="Capabilities.fs" />
+    <Compile Include="UnguardedOrigins.fs" />
     <!-- Runtime /-->
     <Compile Include="RuntimeTypes.fs" />
     <Compile Include="CapabilityCheck.fs" />

--- a/backend/src/LibExecution/UnguardedOrigins.fs
+++ b/backend/src/LibExecution/UnguardedOrigins.fs
@@ -1,0 +1,65 @@
+/// The origins this instance may reach with the SSRF guards OFF.
+///
+/// `httpGetUnsafeBytes` turns the guards off so a server behind loopback, RFC-1918
+/// or a tailnet is reachable at all, which the guarded client bans. It sits in the
+/// GENERAL builtin set, so any Dark the CLI runs can call it, including code that
+/// arrived from somewhere else. That is a real hole rather than a theoretical
+/// one: a function someone else wrote, run here, can read services on this machine's
+/// own loopback.
+///
+/// So the guards come off only towards origins this machine was pointed at, and a
+/// url anywhere else is refused outright rather than fetched. Ordinary HTTP is
+/// unaffected: `httpClientRequest` is a different builtin, and still guards all of
+/// its own traffic.
+///
+/// What counts as pointed at:
+///
+///   - the peers stored locally, which is what `dark sync connect` writes, and
+///   - a URL typed on the command line of the running process.
+///
+/// Neither is something fetched code can influence: it cannot rewrite argv, and
+/// storing a peer is a local act. The stored side is read through a hook rather than
+/// a snapshot, so an origin added DURING this process counts immediately -- which is
+/// what `dark sync connect <url>` does before it probes that url.
+module LibExecution.UnguardedOrigins
+
+/// scheme://host:port, lowercased, with the default port made explicit so `http://h`
+/// and `http://h:80` compare equal. None when the string is not a URL we can reason
+/// about, which is a refusal, not a pass.
+let originOf (url : string) : string option =
+  match System.Uri.TryCreate(url, System.UriKind.Absolute) with
+  | true, uri ->
+    let scheme = uri.Scheme.ToLowerInvariant()
+    let host = uri.Host.ToLowerInvariant()
+    if host = "" then None else Some $"{scheme}://{host}:{uri.Port}"
+  | _ -> None
+
+/// URLs named on the command line of this process. Set once at startup.
+let mutable private fromArgv : Set<string> = Set.empty
+
+/// Where the stored origins come from. A hook because this module sits below `LibDB`
+/// and must not depend on it, and because the answer can change within one process.
+let mutable private stored : unit -> string list = fun () -> []
+
+let setFromArgv (urls : string seq) : unit =
+  fromArgv <- urls |> Seq.choose originOf |> Set.ofSeq
+
+let setStoredLookup (lookup : unit -> string list) : unit = stored <- lookup
+
+/// May the guards be skipped for this URL?
+let isAllowed (url : string) : bool =
+  match originOf url with
+  | None -> false
+  | Some origin ->
+    Set.contains origin fromArgv
+    || (stored () |> List.choose originOf |> List.contains origin)
+
+/// What a refusal should say. Names the origin asked for, since the caller may not
+/// have built the URL itself, and then both of the things that would change the
+/// answer. No "refused:" prefix: every caller here wraps errors in its own words, and
+/// two prefixes read like two failures.
+let refusalMessage (url : string) : string =
+  let where = originOf url |> Option.defaultValue url
+  $"{where} is not a peer you sync with, so it cannot be fetched with the network "
+  + "protections off. Add it with `dark sync connect`, or pass its URL on the "
+  + "command line."

--- a/backend/tests/Tests/Tests.fs
+++ b/backend/tests/Tests/Tests.fs
@@ -40,6 +40,7 @@ let main (args : string array) : int =
 
         // package manager
         Tests.Propagation.tests
+        Tests.UnguardedOrigins.tests
         Tests.Hashing.tests
         Tests.BranchOps.tests
 

--- a/backend/tests/Tests/Tests.fsproj
+++ b/backend/tests/Tests/Tests.fsproj
@@ -38,6 +38,7 @@
     <Compile Include="Terminal.Tests.fs" />
     <Compile Include="LibExecution.Tests.fs" />
     <Compile Include="Propagation.Tests.fs" />
+    <Compile Include="UnguardedOrigins.Tests.fs" />
     <Compile Include="Hashing.Tests.fs" />
     <Compile Include="BranchOps.Tests.fs" />
 

--- a/backend/tests/Tests/UnguardedOrigins.Tests.fs
+++ b/backend/tests/Tests/UnguardedOrigins.Tests.fs
@@ -1,0 +1,257 @@
+/// Which requests `httpGetUnsafeBytes` will make, against a real HTTP server.
+///
+/// It is the one builtin that turns the SSRF guards off, so it is the one place
+/// where getting the scope wrong means arbitrary Dark can read services on the
+/// machine running it.
+///
+/// The server here is a bare `HttpListener`: the thing under test is the CLIENT's
+/// decision, so the server should be as dumb and as predictable as possible.
+module Tests.UnguardedOrigins
+
+open Expecto
+
+open System.Net
+open System.Threading
+open System.Threading.Tasks
+open FSharp.Control.Tasks
+
+open Prelude
+
+module RT = LibExecution.RuntimeTypes
+module Exe = LibExecution.Execution
+module PT2RT = LibExecution.ProgramTypesToRuntimeTypes
+module UnguardedOrigins = LibExecution.UnguardedOrigins
+
+open TestUtils.TestUtils
+
+
+/// A free loopback port. Same brief race as `HttpServer.Tests`: another process
+/// could take it between Stop() and use, which in practice doesn't happen on
+/// loopback.
+let private allocateFreePort () : int =
+  let listener = new Sockets.TcpListener(IPAddress.Loopback, 0)
+  listener.Start()
+  let port = (listener.LocalEndpoint :?> IPEndPoint).Port
+  listener.Stop()
+  port
+
+
+/// Serve until cancelled: every path answers 200 with a body.
+let private runServer (port : int) (token : CancellationToken) : Task<unit> =
+  task {
+    let listener = new HttpListener()
+    listener.Prefixes.Add($"http://127.0.0.1:{port}/")
+    listener.Start()
+
+    use _ = token.Register(fun () -> listener.Stop())
+
+    try
+      while not token.IsCancellationRequested do
+        let! ctx = listener.GetContextAsync()
+        let bytes = System.Text.Encoding.UTF8.GetBytes "pong"
+        ctx.Response.StatusCode <- 200
+        ctx.Response.ContentLength64 <- int64 bytes.Length
+        do! ctx.Response.OutputStream.WriteAsync(bytes, 0, bytes.Length)
+        ctx.Response.Close()
+    with _ ->
+      // Stopping the listener is how this loop ends; GetContextAsync throws on the
+      // way out.
+      ()
+  }
+
+
+/// Evaluate a Dark expression with the CLI's builtin set and hand back the Dval.
+let private eval (code : string) : Task<RT.Dval> =
+  task {
+    let! state = executionStateFor pmPT true Map.empty
+    let! ptExpr = parsePTExpr code
+    let rtInstrs = PT2RT.Expr.toRT Map.empty 0 None ptExpr
+
+    match! Exe.executeExpr state rtInstrs with
+    | Ok dval -> return dval
+    | Error(rte, _) ->
+      return Exception.raiseInternal "eval failed" [ "rte", string rte ]
+  }
+
+/// Is this `Result.Ok`? The shape is what the test is about, so it's read
+/// positionally rather than reconstructed.
+let private isOk (dval : RT.Dval) : bool =
+  match dval with
+  | RT.DEnum(_, _, _, "Ok", _) -> true
+  | _ -> false
+
+let private errorMessage (dval : RT.Dval) : string =
+  match dval with
+  | RT.DEnum(_, _, _, "Error", [ RT.DString s ]) -> s
+  | other -> $"not an Error: {other}"
+
+
+/// Run <param f> against a server this instance has been pointed at.
+///
+/// Naming it is the part that matters. In the CLI that comes from argv or the stored
+/// peers; here it is this line, and without it every request below would be refused
+/// before it left, which is correct behaviour that would read as a network failure.
+let private withServer (f : int -> Task<unit>) : Task<unit> =
+  task {
+    let port = allocateFreePort ()
+    use cts = new CancellationTokenSource()
+    let serving = runServer port cts.Token
+
+    // Give the listener a moment to bind; a request that races the bind reads as a
+    // network failure, which is exactly the thing under test and would make this
+    // lie.
+    do! Task.Delay 250
+
+    UnguardedOrigins.setFromArgv [ $"http://127.0.0.1:{port}" ]
+
+    try
+      do! f port
+    finally
+      UnguardedOrigins.setFromArgv []
+      cts.Cancel()
+      try
+        serving.Wait 1000 |> ignore<bool>
+      with _ ->
+        ()
+  }
+
+
+let namedOriginIsReachable =
+  testTask "the unguarded transport reaches an origin this instance named" {
+    do!
+      withServer (fun port ->
+        task {
+          let! ok =
+            eval $"Builtin.httpGetUnsafeBytes \"http://127.0.0.1:{port}/ok\""
+          Expect.isTrue (isOk ok) "a named origin is fetched"
+
+          // Every path of a named origin, not just the one that was named: an
+          // origin is the unit of trust here, and a peer serves several routes.
+          let! other =
+            eval
+              $"Builtin.httpGetUnsafeBytes \"http://127.0.0.1:{port}/sync/health\""
+          Expect.isTrue (isOk other) "and so is another path on it"
+        })
+  }
+
+let unnamedOriginIsRefused =
+  testTask "an origin nobody named is refused, and nothing is fetched" {
+    do!
+      withServer (fun port ->
+        task {
+          // A second listener on loopback, which is exactly what pulled code would
+          // go looking for: reachable, and not this instance's business.
+          let other = allocateFreePort ()
+          use cts = new CancellationTokenSource()
+          let serving = runServer other cts.Token
+          do! Task.Delay 250
+
+          try
+            let! refused =
+              eval $"Builtin.httpGetUnsafeBytes \"http://127.0.0.1:{other}/ok\""
+            Expect.isFalse (isOk refused) "an unnamed origin is not fetched"
+
+            let msg = errorMessage refused
+            Expect.stringContains
+              msg
+              $"http://127.0.0.1:{other}"
+              "the refusal names the origin asked for"
+            Expect.stringContains
+              msg
+              "not a peer you sync with"
+              "and says why it was refused"
+            Expect.isFalse
+              (msg.Contains "pong")
+              "and the body never reached the caller"
+
+            // The named one still works, so this is a scope, not an outage.
+            let! ok =
+              eval $"Builtin.httpGetUnsafeBytes \"http://127.0.0.1:{port}/ok\""
+            Expect.isTrue (isOk ok) "the named origin is unaffected"
+          finally
+            cts.Cancel()
+            try
+              serving.Wait 1000 |> ignore<bool>
+            with _ ->
+              ()
+        })
+  }
+
+let unparseableUrlIsRefused =
+  testTask
+    "a url that cannot be read as an origin is refused rather than passed through" {
+    // Fails CLOSED. Anything that cannot be reduced to scheme://host:port cannot be
+    // compared against the named ones, so there is no answer to "is this one of them"
+    // other than no.
+    UnguardedOrigins.setFromArgv [ "http://127.0.0.1:1" ]
+
+    try
+      for url in [ "not a url"; ""; "/sync/health"; "file:///etc/passwd" ] do
+        let! refused = eval $"Builtin.httpGetUnsafeBytes \"{url}\""
+        Expect.isFalse (isOk refused) $"`{url}` is refused"
+        // Refused by the origin check, specifically. Several of these would also
+        // fail further down as a bad url or a banned scheme, so a test that only
+        // asked for "not Ok" would pass with the check gone.
+        Expect.stringContains
+          (errorMessage refused)
+          "not a peer you sync with"
+          $"`{url}` is refused for not being a peer, not for some later reason"
+    finally
+      UnguardedOrigins.setFromArgv []
+  }
+
+let defaultPortIsExplicit =
+  testTask "an origin named without a port covers the same one written with a port" {
+    // `http://host` and `http://host:80` are the same place, and a peer url gets
+    // written both ways -- typed one way, stored the other. Comparing the strings
+    // would make the guard depend on spelling.
+    UnguardedOrigins.setFromArgv [ "http://sync.example.com" ]
+
+    try
+      Expect.isTrue
+        (UnguardedOrigins.isAllowed "http://sync.example.com:80/sync/health")
+        "the default port is explicit on both sides"
+      Expect.isTrue
+        (UnguardedOrigins.isAllowed "http://SYNC.EXAMPLE.COM/sync/health")
+        "and the host is compared case-insensitively"
+      Expect.isFalse
+        (UnguardedOrigins.isAllowed "https://sync.example.com/sync/health")
+        "but a different scheme is a different origin"
+      Expect.isFalse
+        (UnguardedOrigins.isAllowed "http://sync.example.com:9000/sync/health")
+        "and so is a different port"
+    finally
+      UnguardedOrigins.setFromArgv []
+  }
+
+let storedOriginsAreReadPerRequest =
+  testTask "an origin stored during this process counts immediately" {
+    // `dark sync connect <url>` adds a peer and probes it in one process, so the
+    // stored side is a lookup rather than a value read at startup.
+    let mutable stored = []
+    UnguardedOrigins.setStoredLookup (fun () -> stored)
+
+    try
+      Expect.isFalse
+        (UnguardedOrigins.isAllowed "http://later.example.com/sync/health")
+        "not allowed yet"
+
+      stored <- [ "http://later.example.com" ]
+
+      Expect.isTrue
+        (UnguardedOrigins.isAllowed "http://later.example.com/sync/health")
+        "and allowed the moment it is stored"
+    finally
+      UnguardedOrigins.setStoredLookup (fun () -> [])
+  }
+
+
+let tests =
+  testSequencedGroup "UnguardedOrigins"
+  <| testList
+    "UnguardedOrigins"
+    [ namedOriginIsReachable
+      unnamedOriginIsRefused
+      unparseableUrlIsRefused
+      defaultPortIsExplicit
+      storedOriginsAreReadPerRequest ]


### PR DESCRIPTION
`Builtin.httpGetUnsafeBytes` fetches with the SSRF guards off, which is what makes a server behind loopback, RFC-1918 or a tailnet reachable at all. It sits in the general builtin set, so any Dark the CLI runs can call it, including code that arrived from somewhere else.

With a service on the machine's own loopback, that reads it:

```
$ dark eval 'match Builtin.httpGetUnsafeBytes "http://127.0.0.1:9091/secret.txt" with
             | Ok b -> Stdlib.Blob.toString b |> Stdlib.Result.withDefault ""
             | Error e -> e'
internal-only: deploy key hunter2
```

Now:

```
http://127.0.0.1:9091 is not a peer you sync with, so it cannot be fetched with the network
protections off. Add it with `dark sync connect`, or pass its URL on the command line.
```

Two things take the guards off, and both need a local act: a peer in `sync_peers_v0`, and a URL on the command line of the running process. Anywhere else the fetch is refused rather than attempted, and a url that will not reduce to `scheme://host:port` is refused too, so anything unparseable fails closed. `httpClientRequest` is untouched and still guards all of its own traffic.

`UnguardedOrigins` is its own module in `LibExecution` because the builtin reads it and `Cli.fs` writes to it, and that is the only project both of those name directly. The stored side is a callback rather than a value read at startup, because `dark sync connect <url>` stores a peer and then fetches from it inside one process.

Code you fetched can still reach the origin you did name. Closing that wants caller identity, which the builtin has no way to ask for.

Changes:

- `backend/src/LibExecution/UnguardedOrigins.fs`: the allowed set, the stored-origin hook, and the refusal. An origin is `scheme://host:port` with the default port made explicit, so `http://h` and `http://h:80` are one place however the url was spelled.
- `backend/src/Builtins/Builtins.Http.Client/Libs/HttpClient.fs`: `httpGetUnsafeBytes` checks it before it builds a request.
- `backend/src/Cli/Cli.fs`: seeds argv and installs the stored-origin lookup.
- `backend/tests/Tests/UnguardedOrigins.Tests.fs`: against real `HttpListener`s on loopback. A named origin is fetched; a second listener on another port is refused, with its origin named and its body never reaching the caller; the named one still works alongside it.