### PR TITLE
Add `dark edit`, and `view --raw` to feed it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -279,6 +279,22 @@ The interactive CLI (`run-cli` with no args) needs a real TTY. Use `expect`:
 
 Telemetry lands in `rundir/logs/telemetry.jsonl`. Full guide: `docs interactive-testing`.
 
+For poking at it by hand, or driving something `expect` would be awkward for -- an editor,
+a pager, anything that takes over the screen -- `tmux` is more reliable:
+
+    tmux new-session -d -s work -x 200 -y 50
+    tmux send-keys -t work:0 'scripts/run-in-docker bash' Enter
+    tmux send-keys -t work:0 './scripts/run-cli ...' Enter
+    tmux capture-pane -t work:0 -p          # read the screen
+    tmux kill-session -t work
+
+Inside a pane, stdin IS a terminal, so `run-in-docker` allocates a TTY and everything that
+needs one works: `dark edit` really opens `$EDITOR`, and you drive it with more `send-keys`
+(`:%s/a/b/` then `:wq`, or `:cq` to exit non-zero and test the cancel path).
+
+Poll `capture-pane` in a loop rather than sleeping between steps; a command that shells out
+per invocation takes a second or more, and the pane is the only thing that tells you it is done.
+
 ## Debugging
 
     Builtin.debug "label" value   # prints DEBUG: label: <repr> to stdout

--- a/backend/src/Builtins/Builtins.Cli/Libs/Posix.fs
+++ b/backend/src/Builtins/Builtins.Cli/Libs/Posix.fs
@@ -514,6 +514,33 @@ module Libc =
     with e ->
       Error(-1, e.Message)
 
+  /// Run a child process on THIS terminal: stdin, stdout and stderr are inherited
+  /// rather than redirected, and only the exit code comes back.
+  ///
+  /// That is the whole point. `spawnAndWait` captures the streams, which is right for
+  /// a tool whose output you want, and useless for one that draws: an editor with a
+  /// redirected stdout paints into a pipe and reads keys from nowhere. Nothing to
+  /// capture, nothing to deadlock on.
+  let spawnInheritingStdio
+    (program : string)
+    (args : List<string>)
+    : Result<int, int * string> =
+    try
+      let psi = System.Diagnostics.ProcessStartInfo()
+      psi.FileName <- program
+      for arg in args do
+        psi.ArgumentList.Add(arg)
+      psi.UseShellExecute <- false
+      psi.RedirectStandardOutput <- false
+      psi.RedirectStandardError <- false
+      psi.RedirectStandardInput <- false
+
+      use p = System.Diagnostics.Process.Start(psi)
+      p.WaitForExit()
+      Ok p.ExitCode
+    with e ->
+      Error(-1, e.Message)
+
   /// Like spawnAndWait but kills the process if it exceeds timeoutMs.
   let spawnAndWaitWithTimeout
     (program : string)
@@ -978,6 +1005,38 @@ let fns () : List<BuiltInFn> =
               DTuple(Dval.int (bigint exitCode), DString stdout, [ DString stderr ])
             )
             |> Ply
+          | Error e -> resultError (dPosixError e) |> Ply
+        | _ -> incorrectArgs ())
+      sqlSpec = NotQueryable
+      previewable = Impure
+      capabilities = LibExecution.Capabilities.Needs.exec
+      deprecated = NotDeprecated }
+
+
+    { name = fn "posixSpawnInteractive" 0
+      typeParams = []
+      parameters =
+        [ Param.make "program" TString "Path to the executable"
+          Param.make "args" (TList TString) "Arguments to pass" ]
+      returnType = TypeReference.result TInt (posixErrorTypeRef ())
+      description =
+        "Runs a child process on this terminal, inheriting stdin/stdout/stderr, and "
+        + "returns its exit code. For programs that DRAW, like an editor: capturing "
+        + "their output would leave them painting into a pipe."
+      fn =
+        (function
+        | state, _, _, [| DString program; DList(_, args) |] ->
+          let resultOk = Dval.resultOk KTInt (posixErrorKT ())
+          let resultError = Dval.resultError KTInt (posixErrorKT ())
+          let argStrs =
+            args
+            |> List.map (fun d ->
+              match d with
+              | DString s -> s
+              | _ -> incorrectArgs ())
+          LibExecution.CapabilityCheck.requireExec state.grantedCaps program argStrs
+          match Libc.spawnInheritingStdio program argStrs with
+          | Ok exitCode -> resultOk (Dval.int (bigint exitCode)) |> Ply
           | Error e -> resultError (dPosixError e) |> Ply
         | _ -> incorrectArgs ())
       sqlSpec = NotQueryable

--- a/backend/testfiles/execution/stdlib/language-tools/pickLocation.dark
+++ b/backend/testfiles/execution/stdlib/language-tools/pickLocation.dark
@@ -13,7 +13,15 @@ let ctx
   (currentModule: List<String>)
   : Darklang.LanguageTools.PackageManager.PickContext =
   Darklang.LanguageTools.PackageManager.PickContext
-    { currentModule = currentModule }
+    { currentModule = currentModule; preferredLocation = Stdlib.Option.Option.None }
+
+let preferCtx
+  (currentModule: List<String>)
+  (preferredLocation: Darklang.LanguageTools.ProgramTypes.PackageLocation)
+  : Darklang.LanguageTools.PackageManager.PickContext =
+  Darklang.LanguageTools.PackageManager.PickContext
+    { currentModule = currentModule
+      preferredLocation = Stdlib.Option.Option.Some preferredLocation }
 
 let pick
   (ctx: Darklang.LanguageTools.PackageManager.PickContext)
@@ -188,3 +196,33 @@ Darklang.LanguageTools.PackageManager.countMatchingPrefix ["A"; "B"] ["A"; "B"; 
     loc "Darklang" ["Stdlib"] "flatten"
     loc "Darklang" ["Stdlib"; "List"] "flatten" ])
   = Stdlib.Option.Option.Some (loc "Darklang" [] "flatten")
+
+
+// ========================================
+// pickLocation: an asked-for name beats scoring
+// ========================================
+
+// Two names sharing a body share a hash, so both come back as candidates. The one the
+// caller asked about wins, whatever the context would have scored higher.
+(pick (preferCtx ["Darklang"; "Stdlib"; "List"] (loc "Darklang" ["SomeOther"] "map"))
+  [ loc "Darklang" ["Stdlib"; "List"] "map"
+    loc "Darklang" ["SomeOther"] "map" ])
+  = Stdlib.Option.Option.Some (loc "Darklang" ["SomeOther"] "map")
+
+// The order it comes back in does not matter either.
+(pick (preferCtx ["Darklang"; "Stdlib"; "List"] (loc "Darklang" ["SomeOther"] "map"))
+  [ loc "Darklang" ["SomeOther"] "map"
+    loc "Darklang" ["Stdlib"; "List"] "map" ])
+  = Stdlib.Option.Option.Some (loc "Darklang" ["SomeOther"] "map")
+
+// A preference for a name this hash is NOT bound to is ignored rather than honoured:
+// scoring is right for every case except the one the caller named.
+(pick (preferCtx ["Darklang"; "Stdlib"; "List"] (loc "Darklang" ["Absent"] "map"))
+  [ loc "Darklang" ["Stdlib"; "List"] "map"
+    loc "Darklang" ["SomeOther"] "map" ])
+  = Stdlib.Option.Option.Some (loc "Darklang" ["Stdlib"; "List"] "map")
+
+// A preference that differs only by name is a different location, so it does not match.
+(pick (preferCtx [] (loc "Darklang" ["Stdlib"] "second"))
+  [ loc "Darklang" ["Stdlib"] "first" ])
+  = Stdlib.Option.Option.Some (loc "Darklang" ["Stdlib"] "first")

--- a/packages/darklang/cli/conflicts.dark
+++ b/packages/darklang/cli/conflicts.dark
@@ -70,12 +70,7 @@ let renderContent
   (hashStr: String)
   : String =
   let hash = LanguageTools.ProgramTypes.Hash.Hash hashStr
-  let ctx =
-    PrettyPrinter.ProgramTypes.Context
-      { branchId = branchId
-        currentModule = []
-        currentFunction = Stdlib.Option.Option.None
-        width = 80 }
+  let ctx = PrettyPrinter.ProgramTypes.Context.forBranch branchId
   // Resolve the hash across kinds rather than by the conflict's stored `itemKind`. A hash is
   // content-addressed and kind-agnostic, and a CROSS-KIND conflict (one side bound the name to a value, the
   // other to a fn — reachable since a name holds ONE item regardless of kind, post one-name-one-item) stores

--- a/packages/darklang/cli/packages/edit.dark
+++ b/packages/darklang/cli/packages/edit.dark
@@ -1,0 +1,228 @@
+module Darklang.Cli.Packages.Edit
+
+/// Change an item that already exists, without retyping it.
+///
+///   dark edit <name>           opens $EDITOR on the declaration, applies it on save
+///   dark edit <name> <file>    applies that file, no editor and no terminal
+///
+/// Two shapes because the callers want opposite things: a person wants an editor, a
+/// script wants none. The file shape pairs with `dark view <name> --raw`, which
+/// prints exactly what this accepts.
+///
+/// Both land through `dark module`, so the source is validated the same way and the
+/// whole declaration is added atomically. Siblings in the module are untouched.
+
+/// $EDITOR, then $VISUAL, then `vi`. In that order, so a per-invocation `EDITOR=`
+/// beats a shell-wide `VISUAL`.
+let editorCommand () : String =
+  match Stdlib.Env.get "EDITOR" with
+  | Some e when e != "" -> e
+  | _ ->
+    match Stdlib.Env.get "VISUAL" with
+    | Some v when v != "" -> v
+    | _ -> "vi"
+
+
+/// The `/Owner.Mod` form `dark module` takes, built from the item's own location.
+let moduleArgFor (loc: LanguageTools.ProgramTypes.PackageLocation) : String =
+  let parts = Stdlib.List.append [ loc.owner ] loc.modules
+  "/" ++ (Stdlib.String.join parts ".")
+
+
+/// The PT location inside whatever the traversal resolved, or None for a module.
+let itemLocation
+  (location: Packages.PackageLocation)
+  : Stdlib.Option.Option<LanguageTools.ProgramTypes.PackageLocation> =
+  match location with
+  | Module _ -> Stdlib.Option.Option.None
+  | Type loc -> Stdlib.Option.Option.Some loc
+  | Value loc -> Stdlib.Option.Option.Some loc
+  | Function loc -> Stdlib.Option.Option.Some loc
+
+
+/// Hand the file to `dark module`, which validates and applies it.
+let applyFile
+  (state: AppState)
+  (loc: LanguageTools.ProgramTypes.PackageLocation)
+  (path: String)
+  : AppState =
+  Packages.ModuleCommand.execute state [ moduleArgFor loc; path ]
+
+
+let execute (state: AppState) (args: List<String>) : AppState =
+  let branchId = state.currentBranchId
+
+  let named =
+    match args with
+    | [ name ] -> Stdlib.Result.Result.Ok((name, Stdlib.Option.Option.None))
+    | [ name; file ] ->
+      Stdlib.Result.Result.Ok((name, Stdlib.Option.Option.Some file))
+    | _ -> Stdlib.Result.Result.Error "usage: dark edit <name> [file]"
+
+  match named with
+  | Error e ->
+    Stdlib.printLine (Stdlib.Cli.UI.Colors.error e)
+
+    Stdlib.printLine
+      (Stdlib.Cli.UI.Colors.dimText
+        "  `dark edit <name>` opens $EDITOR; with a <file> it applies that.")
+
+    state
+  | Ok((name, fileArg)) ->
+
+  match Traversal.traverse branchId state.packageData.currentLocation name with
+  | Error e ->
+    Stdlib.printLine (Stdlib.Cli.UI.Colors.error $"Cannot edit {name}: {e}")
+    state
+  | Ok location ->
+
+  match itemLocation location with
+  | None ->
+    Stdlib.printLine
+      (Stdlib.Cli.UI.Colors.error
+        $"{name} is a module. `dark edit` takes one fn, type or value.")
+
+    Stdlib.printLine
+      (Stdlib.Cli.UI.Colors.dimText
+        "  `dark module /Some.Module <file>` edits a whole module at once.")
+
+    state
+  | Some loc ->
+
+  match fileArg with
+  // No editor and no terminal: the shape a script or an agent uses.
+  | Some file -> applyFile state loc file
+  | None ->
+
+  // An editor needs a terminal on both ends. Without one it starts anyway, paints
+  // control sequences into whatever it was piped to and reads keys from nowhere, so
+  // ask before spawning rather than after. The file form needs no terminal at all,
+  // which is what to point at.
+  match Stdlib.Cli.Tui.TerminalSupport.current () with
+  | Unavailable reason ->
+    Stdlib.printLine
+      (Stdlib.Cli.UI.Colors.error $"Cannot open an editor: {reason}.")
+
+    Stdlib.printLine
+      (Stdlib.Cli.UI.Colors.dimText
+        $"  `dark view {name} --raw > f`, change f, then `dark edit {name} f`.")
+
+    state
+  | Available ->
+
+  match Packages.View.rawSource branchId location with
+  | Error e ->
+    Stdlib.printLine (Stdlib.Cli.UI.Colors.error $"Cannot edit {name}: {e}")
+    state
+  | Ok before ->
+
+  match Stdlib.Cli.Dir.createTemp () with
+  | Error e ->
+    Stdlib.printLine
+      (Stdlib.Cli.UI.Colors.error
+        $"Cannot edit {name}: no temp directory ({e.message})")
+
+    state
+  | Ok dir ->
+    let path = $"{dir}/{loc.name}.dark"
+
+    match Stdlib.Cli.File.writeText path before with
+    | Error e ->
+      Stdlib.printLine
+        (Stdlib.Cli.UI.Colors.error
+          $"Cannot edit {name}: could not write {path} ({e.message})")
+
+      state
+    | Ok _ ->
+      let editor = editorCommand ()
+
+      match Stdlib.Cli.Process.runInteractive editor [ path ] with
+      | Error e ->
+        Stdlib.printLine
+          (Stdlib.Cli.UI.Colors.error $"Could not run `{editor}`: {e.message}")
+
+        Stdlib.printLine
+          (Stdlib.Cli.UI.Colors.dimText
+            $"  Set $EDITOR, or edit {path} and run `dark edit {name} {path}`.")
+
+        state
+      | Ok code when code != 0 ->
+        // A non-zero editor is how you say "forget it" in most of them. The store
+        // is left alone and so is the file, so a long edit is not thrown away on a
+        // stray exit code.
+        Stdlib.printLine
+          $"`{editor}` exited {Stdlib.Int.toString code}; nothing applied."
+
+        Stdlib.printLine
+          (Stdlib.Cli.UI.Colors.dimText $"  Your edit is still at {path}.")
+
+        state
+      | Ok _ ->
+        match Stdlib.Cli.File.readText path with
+        | Error e ->
+          Stdlib.printLine
+            (Stdlib.Cli.UI.Colors.error $"Could not read back {path}: {e.message}")
+
+          state
+        | Ok after ->
+          if (Stdlib.String.trim after) == (Stdlib.String.trim before) then
+            let _ = Stdlib.Cli.Dir.deleteRecursive dir
+            Stdlib.printLine (Stdlib.Cli.UI.Colors.success "no change.")
+            state
+          else
+            let result = applyFile state loc path
+
+            // Whether the apply LANDED, asked by comparing against what the item was
+            // BEFORE. Comparing against what you typed would be wrong nearly always,
+            // since the store pretty-prints; comparing against the old source is
+            // robust, because anything landing changes it.
+            //
+            // The temp file is the only copy of an interactive edit, so it survives
+            // a rejection and the path is printed. On success it goes: a temp path
+            // after every edit is clutter you learn to skip, and clutter you skip is
+            // where a real warning goes to hide.
+            let landed =
+              match Packages.View.rawSource branchId location with
+              | Ok now -> (Stdlib.String.trim now) != (Stdlib.String.trim before)
+              | Error _ -> false
+
+            let _ =
+              if landed then
+                Stdlib.Cli.Dir.deleteRecursive dir |> Stdlib.Result.toOption
+              else
+                Stdlib.printLine
+                  (Stdlib.Cli.UI.Colors.dimText
+                    $"  nothing landed; your edit is still at {path}")
+
+                Stdlib.Option.Option.None
+
+            result
+
+
+let help (_state: AppState) : String =
+  [ "dark edit -- change an item without retyping it"
+    ""
+    "  dark edit <name>           open $EDITOR on the declaration, apply on save"
+    "  dark edit <name> <file>    apply that file instead (no editor, for scripts)"
+    ""
+    "  The file holds one declaration, the same form `dark module` takes."
+    "  `dark view <name> --raw` prints exactly that form, so reading an item,"
+    "  changing it and writing it back is a pipe:"
+    ""
+    "    dark view Foo.bar --raw > /tmp/bar.dark"
+    "    ...edit it..."
+    "    dark edit Foo.bar /tmp/bar.dark"
+    ""
+    "  Editing is live: the change takes effect immediately and shows up in"
+    "  `dark status` as a draft item, like any other edit."
+    ""
+    "  The first form needs a terminal on both ends, since it hands one to your"
+    "  editor. Without one, use the second." ]
+  |> Stdlib.String.join "\n"
+
+
+let complete
+  (state: AppState)
+  (args: List<String>)
+  : List<Completion.CompletionItem> =
+  Packages.View.complete state args

--- a/packages/darklang/cli/packages/module.dark
+++ b/packages/darklang/cli/packages/module.dark
@@ -216,10 +216,28 @@ let execute (state: Cli.AppState) (args: List<String>) : Cli.AppState =
                 |> Stdlib.List.map (fun update ->
                   (update.location, update.hash, update.kind))
               Propagate.autoPropagateUpdates branchId propagationUpdates
-              let count = Stdlib.List.length declarations
+
+              // Counted from the ops that were recorded, not from the declarations
+              // that were parsed, so the number is what happened rather than what
+              // was asked for.
+              let definedNames =
+                ops
+                |> Stdlib.List.filterMap (fun op ->
+                  match op with
+                  | SetName(location, _) -> Stdlib.Option.Option.Some location.name
+                  | _ -> Stdlib.Option.Option.None)
+
+              let count = Stdlib.List.length definedNames
+
+              // "1 declarations" is the sort of thing you stop reading, and `edit`
+              // routes through here for a single item, so the singular is a common
+              // case rather than an edge one.
+              let what = if count == 1 then "declaration" else "declarations"
+
               Stdlib.printLine
                 (Stdlib.Cli.UI.Colors.success
-                  $"✓ Defined {Stdlib.Int.toString count} declarations in {modulePath}")
+                  $"✓ Defined {Stdlib.Int.toString count} {what} in {modulePath}")
+
               state
 
 

--- a/packages/darklang/cli/packages/view.dark
+++ b/packages/darklang/cli/packages/view.dark
@@ -27,6 +27,54 @@ let resolveReplacementName
     $"<hash:{LanguageTools.ProgramTypes.hashToShort hash}>"
 
 
+/// The declaration alone: no deprecation header, no capabilities line, no colour.
+/// Feed it to `dark module` or `dark edit` and it round-trips.
+///
+/// Reading an item and writing it back should be a pipe. Stripping a trailer and a
+/// prefix with `sed` is a screen-scrape: it works until the display changes.
+let rawSource
+  (branchId: Uuid)
+  (location: PackageLocation)
+  : Stdlib.Result.Result<String, String> =
+  let sourceOf
+    (loc: LanguageTools.ProgramTypes.PackageLocation)
+    : Stdlib.Result.Result<String, String> =
+    // `preferredLocation`, so a shared body is headed with the name asked for.
+    let ctx =
+      { terminalContext branchId (Stdlib.List.push loc.modules loc.owner) with
+          preferredLocation = Stdlib.Option.Option.Some loc }
+    let modulePath = Stdlib.List.append [ loc.owner ] loc.modules
+    let results = Query.searchExactMatch branchId modulePath loc.name
+
+    match (results.fns, results.types, results.values) with
+    | (item :: _, _, _) ->
+      Stdlib.Result.Result.Ok(PrettyPrinter.ProgramTypes.packageFn ctx item.entity)
+    | (_, item :: _, _) ->
+      Stdlib.Result.Result.Ok(PrettyPrinter.ProgramTypes.packageType ctx item.entity)
+    | (_, _, item :: _) ->
+      Stdlib.Result.Result.Ok(
+        PrettyPrinter.ProgramTypes.packageValue ctx item.entity
+      )
+    | _ ->
+      let where = PrettyPrinter.ProgramTypes.PackageLocation.packageLocation loc
+      Stdlib.Result.Result.Error $"nothing at {where}"
+
+  match location with
+  | Module _ ->
+    Stdlib.Result.Result.Error
+      "--raw prints ONE declaration. Name a fn, type or value, not a module."
+  | Type loc -> sourceOf loc
+  | Value loc -> sourceOf loc
+  | Function loc -> sourceOf loc
+
+
+/// Print `rawSource`, or say why there is none.
+let printRaw (branchId: Uuid) (location: PackageLocation) : Unit =
+  match rawSource branchId location with
+  | Ok src -> Stdlib.printLine src
+  | Error e -> Stdlib.printLine (Stdlib.Cli.UI.Colors.error e)
+
+
 /// Build a deprecation header for an item, if any.
 let deprecationHeaderRowsFor
   (branchId: Uuid)
@@ -152,7 +200,10 @@ let entityRows (branchId: Uuid) (location: PackageLocation) : List<String> =
       let locationStr = Packages.formatLocation location
       [ $"Type '{locationStr}' not found." ]
     | item :: _ ->
-      let ctx = terminalContext branchId (Stdlib.List.push name.modules name.owner)
+      // `preferredLocation`, so a shared body is headed with the name asked for.
+      let ctx =
+        { terminalContext branchId (Stdlib.List.push name.modules name.owner) with
+            preferredLocation = Stdlib.Option.Option.Some name }
       let prettyPrinted = PrettyPrinter.ProgramTypes.packageType ctx item.entity
       let highlighted = SyntaxHighlighting.highlightCode prettyPrinted
 
@@ -173,7 +224,10 @@ let entityRows (branchId: Uuid) (location: PackageLocation) : List<String> =
       let locationStr = Packages.formatLocation location
       [ $"Function '{locationStr}' not found." ]
     | item :: _ ->
-      let ctx = terminalContext branchId (Stdlib.List.push name.modules name.owner)
+      // `preferredLocation`, so a shared body is headed with the name asked for.
+      let ctx =
+        { terminalContext branchId (Stdlib.List.push name.modules name.owner) with
+            preferredLocation = Stdlib.Option.Option.Some name }
       let prettyPrinted = PrettyPrinter.ProgramTypes.packageFn ctx item.entity
       let highlighted = SyntaxHighlighting.highlightCode prettyPrinted
       let capsBadge =
@@ -198,7 +252,10 @@ let entityRows (branchId: Uuid) (location: PackageLocation) : List<String> =
       let locationStr = Packages.formatLocation location
       [ $"Value '{locationStr}' not found." ]
     | item :: _ ->
-      let ctx = terminalContext branchId (Stdlib.List.push name.modules name.owner)
+      // `preferredLocation`, so a shared body is headed with the name asked for.
+      let ctx =
+        { terminalContext branchId (Stdlib.List.push name.modules name.owner) with
+            preferredLocation = Stdlib.Option.Option.Some name }
       let prettyPrinted = PrettyPrinter.ProgramTypes.packageValue ctx item.entity
       let highlighted = SyntaxHighlighting.highlightCode prettyPrinted
 
@@ -219,6 +276,11 @@ let viewEntity (branchId: Uuid) (location: PackageLocation) : Unit =
 /// other two are compiler views of a function.
 type ViewMode =
   | Source
+  /// The declaration alone: no highlighting, no deprecation header, no capabilities
+  /// line. What you get back is what `dark module` and `dark edit` accept, so
+  /// reading an item and writing it back is a pipe rather than a screen-scrape. The
+  /// default view is for a person; this is for whatever reads it next.
+  | Raw
   /// The ProgramTypes tree the parser built, before compilation.
   | Ast
   /// The register-machine instructions the function actually runs.
@@ -228,6 +290,7 @@ type ViewMode =
 let modeName (mode: ViewMode) : String =
   match mode with
   | Source -> "source"
+  | Raw -> "--raw"
   | Ast -> "--ast"
   | Instructions -> "--instructions"
 
@@ -247,6 +310,7 @@ let parseArgs
       | Error e -> Stdlib.Result.Result.Error e
       | Ok _ ->
         match flag with
+        | "--raw" -> Stdlib.Result.Result.Ok ViewMode.Raw
         | "--ast" -> Stdlib.Result.Result.Ok ViewMode.Ast
         | "--instructions" -> Stdlib.Result.Result.Ok ViewMode.Instructions
         | "--instrs" -> Stdlib.Result.Result.Ok ViewMode.Instructions
@@ -382,6 +446,7 @@ let viewCompiled
         Stdlib.printLine
           (Stdlib.Cli.UI.Colors.error "No compiled instructions stored for this function.")
     | Source -> viewEntity branchId location
+    | Raw -> printRaw branchId location
 
 
 // VIEW command - view modules, functions, types, or constants, as source, AST, or instructions
@@ -403,11 +468,21 @@ let execute (state: AppState) (args: List<String>) : AppState =
 
     match locationResult with
     | Error errorMsg ->
-      Stdlib.printLine (Stdlib.Cli.UI.Colors.error $"Cannot view: {errorMsg}")
+      // Names the target you asked for. "Cannot view: Not found: Zzz" says what
+      // failed but not what you typed, which matters when the arg was resolved
+      // relative to your current location.
+      //
+      // Unwrapped, not interpolated raw: `pathArg` is an Option, and interpolating
+      // one raises "Expected String in string interpolation", so the error path
+      // meant to name your target would crash instead of printing it.
+      let asked = pathArg |> Stdlib.Option.withDefault ""
+      let what = if asked == "" then "" else $" {asked}"
+      Stdlib.printLine (Stdlib.Cli.UI.Colors.error $"Cannot view{what}: {errorMsg}")
       state
     | Ok location ->
       match mode with
       | Source -> viewEntity branchId location
+      | Raw -> printRaw branchId location
       | _ -> viewCompiled branchId location mode
 
       state
@@ -417,7 +492,7 @@ let complete (state: AppState) (args: List<String>) : List<Completion.Completion
   // Complete the path as before, and offer the view flags once something is typed. Flags are filtered
   // out of the path completion so `view List.last --a` completes the flag, not a package path.
   let flagCompletions (partial: String) : List<Completion.CompletionItem> =
-    [ "--ast"; "--instructions" ]
+    [ "--raw"; "--ast"; "--instructions" ]
     |> Stdlib.List.filter (fun name -> Stdlib.String.startsWith name partial)
     |> Stdlib.List.map (fun name -> Completion.simple name)
 
@@ -433,11 +508,16 @@ let complete (state: AppState) (args: List<String>) : List<Completion.Completion
 
 let help (_state: AppState) : String =
   [
-    "Usage: view [path] [--ast | --instructions]"
+    "Usage: view [path] [--raw | --ast | --instructions]"
     "View detailed information about functions, types, values, or modules."
     ""
     "With path: View the specified entity with syntax highlighting."
     "Without path: View current location."
+    ""
+    "Options:"
+    "  --raw             The declaration alone, with no header, badge or colour."
+    "                    What `dark module` and `dark edit` accept, so reading an"
+    "                    item and writing it back is a pipe."
     ""
     "Options (functions only):"
     "  --ast             The ProgramTypes tree the parser built, before compilation."
@@ -449,6 +529,7 @@ let help (_state: AppState) : String =
     "  view List.head                  - View the List.head function"
     "  view Option                     - View the Option type"
     "  view Stdlib.List                - View contents of Stdlib.List module"
+    "  view List.head --raw            - Print just the declaration"
     "  view List.last --ast            - View List.last as a syntax tree"
     "  view List.map --instructions    - Disassemble List.map"
   ] |> Stdlib.String.join "\n"

--- a/packages/darklang/cli/registry.dark
+++ b/packages/darklang/cli/registry.dark
@@ -39,6 +39,7 @@ module Registry =
       ("fn", "Create a new function", [ "function" ], Packages.Fn.execute, Packages.Fn.help, Packages.Fn.complete)
       ("type", "Create a new type", [], Packages.Type.execute, Packages.Type.help, Packages.Type.complete)
       ("module", "Define multiple package declarations", [], Packages.ModuleCommand.execute, Packages.ModuleCommand.help, Packages.ModuleCommand.complete)
+      ("edit", "Change an item without retyping it", [], Packages.Edit.execute, Packages.Edit.help, Packages.Edit.complete)
       ("hash", "Show hash of a package item", [], Packages.Hash.execute, Packages.Hash.help, Packages.Hash.complete)
       // SCM commands
       ("status", "Show uncommitted changes", [ "wip"; "changes" ], SCM.Status.execute, SCM.Status.help, SCM.Status.complete)

--- a/packages/darklang/cli/scm/review/app.dark
+++ b/packages/darklang/cli/scm/review/app.dark
@@ -101,12 +101,7 @@ let prettyPrintFromPM (branchId: Uuid) (itemName: String) (kind: String) : Strin
   let loc = LanguageTools.ProgramTypes.parsePackageLocation itemName
   let modulePath = Stdlib.List.append [loc.owner] loc.modules
   let results = Darklang.Cli.Packages.Query.searchExactMatch branchId modulePath loc.name
-  let ctx =
-    PrettyPrinter.ProgramTypes.Context
-      { branchId = branchId
-        currentModule = []
-        currentFunction = Stdlib.Option.Option.None
-        width = 80 }
+  let ctx = PrettyPrinter.ProgramTypes.Context.forBranch branchId
   match kind with
   | "Fn" ->
     match results.fns with
@@ -129,12 +124,7 @@ let prettyPrintFromOps
   (itemName: String)
   (kind: String)
   : Stdlib.Option.Option<String> =
-  let ctx =
-    PrettyPrinter.ProgramTypes.Context
-      { branchId = branchId
-        currentModule = []
-        currentFunction = Stdlib.Option.Option.None
-        width = 80 }
+  let ctx = PrettyPrinter.ProgramTypes.Context.forBranch branchId
   let targetHash =
     (extractSetOps ops)
     |> Stdlib.List.filterMap (fun entry ->

--- a/packages/darklang/cli/tests/tests-runner.dark
+++ b/packages/darklang/cli/tests/tests-runner.dark
@@ -26,6 +26,15 @@ let allTests (): List<String * TestFunction> =
     ("View Instructions Lambdas", fun () -> testViewInstructionsShowsLambdas ())
     ("View Compiler Views Reject Non-Fns", fun () -> testViewCompilerViewsRejectNonFunctions ())
     ("View Flag Before Path", fun () -> testViewFlagBeforePath ())
+    ("View Raw Is Undecorated", fun () -> testViewRawIsUndecorated ())
+    ( "View Heads With The Name You Asked For",
+      fun () -> testViewHeadsWithTheNameYouAskedFor () )
+    ("Edit Round Trips Through Raw", fun () -> testEditRoundTripsThroughRaw ())
+    ( "Edit Round Trips Types And Values",
+      fun () -> testEditRoundTripsTypesAndValues () )
+    ( "Edit Leaves The Item Alone On A Bad File",
+      fun () -> testEditLeavesTheItemAloneOnABadFile () )
+    ("Edit Refuses What It Cannot Edit", fun () -> testEditRefusesWhatItCannotEdit ())
     ("View Unknown Flag", fun () -> testViewUnknownFlag ())
 
     ("Native List Edge Cases", fun () -> testNativeListEdgeCases ())

--- a/packages/darklang/cli/tests/tests.dark
+++ b/packages/darklang/cli/tests/tests.dark
@@ -665,3 +665,276 @@ let testGetAtNoneIsStillNone (): TestResult =
     TestResult.Pass
   else
     TestResult.Fail $"Expected out-of-bounds None to behave as None, got eq: {eq}, default: {dflt}"
+
+
+/// `view --raw` prints the declaration and nothing else.
+///
+/// The point of `--raw` is that another program consumes it, so anything decorative
+/// in there is a bug rather than a cosmetic complaint: a colour code or a badge line
+/// ends up in whatever the output was piped into.
+let testViewRawIsUndecorated (): TestResult =
+  let esc = "\u001b"
+  let raw = runWithCommand [ "view"; "Stdlib.List.head"; "--raw" ]
+  let decorated = runWithCommand [ "view"; "Stdlib.List.head" ]
+
+  if
+    Stdlib.String.contains raw "let head"
+      && Stdlib.Bool.not (Stdlib.String.contains raw esc)
+      && Stdlib.String.contains decorated esc
+  then
+    TestResult.Pass
+  else
+    TestResult.Fail $"Expected an undecorated declaration, got: {raw}"
+
+
+/// Reading an item and writing it straight back changes nothing.
+///
+/// This is the property that makes `view --raw` usable as a pipe: if the printer and
+/// the parser disagree anywhere, a round trip authors a second version of the item
+/// and the op log grows every time someone looks at it.
+let testEditRoundTripsThroughRaw (): TestResult =
+  let suffix = Stdlib.Int.toString (Stdlib.Int.random 100000 999999)
+  let branchName = "cli-edit-test-" ++ suffix
+  let name = "Tests.CliEdit.tripled"
+  let sourcePath = Stdlib.Cli.File.createTemp () |> Builtin.unwrap
+  let changedPath = Stdlib.Cli.File.createTemp () |> Builtin.unwrap
+
+  let _ = runWithCommand [ "branch"; "create"; branchName ]
+
+  let _ =
+    runWithCommand
+      [ "--branch"
+        branchName
+        "fn"
+        "/" ++ name
+        "let tripled (n: Int64) : Int64 = Stdlib.Int64.multiply n 3L" ]
+
+  let before = runWithCommand [ "--branch"; branchName; "view"; name; "--raw" ]
+  // The hash, not the op count: an apply that changes nothing still records that the
+  // name was set, so the log grows either way. What must not change is the item.
+  let hashBefore = runWithCommand [ "--branch"; branchName; "hash"; name ]
+  let _ = (Stdlib.Cli.File.writeAtomic sourcePath before) |> Builtin.unwrap
+  let _ = runWithCommand [ "--branch"; branchName; "edit"; name; sourcePath ]
+  let after = runWithCommand [ "--branch"; branchName; "view"; name; "--raw" ]
+  let hashAfter = runWithCommand [ "--branch"; branchName; "hash"; name ]
+
+  // And a real change still lands, so the assertion above is not passing because
+  // `edit` quietly does nothing.
+  let _ =
+    (Stdlib.Cli.File.writeAtomic
+      changedPath
+      "let tripled (n: Int64) : Int64 = Stdlib.Int64.multiply n 30L")
+    |> Builtin.unwrap
+
+  let _ = runWithCommand [ "--branch"; branchName; "edit"; name; changedPath ]
+  let evaluated = runWithCommand [ "--branch"; branchName; "eval"; name ++ " 2L" ]
+
+  if
+    before == after && hashBefore == hashAfter
+      && Stdlib.String.contains evaluated "60"
+  then
+    TestResult.Pass
+  else
+    TestResult.Fail(
+      $"Expected a no-op round trip then a landed change; before: {before}, "
+      ++ $"after: {after}, eval: {evaluated}"
+    )
+
+
+/// A definition is headed with the name you asked for.
+///
+/// Two items with byte-identical bodies are one stored item, and a stored function
+/// carries no name, so the name in the heading is resolved from the hash. With more
+/// than one candidate that resolution has to prefer the one that was typed;
+/// otherwise `view Zz.alpha` prints a definition headed `Zz.beta`, and `--raw` feeds
+/// that wrong name to whatever writes it back.
+let testViewHeadsWithTheNameYouAskedFor (): TestResult =
+  let suffix = Stdlib.Int.toString (Stdlib.Int.random 100000 999999)
+  let branchName = "cli-sharedbody-test-" ++ suffix
+  let alpha = "Tests.CliShared.alpha"
+  let beta = "Tests.CliShared.beta"
+
+  let _ = runWithCommand [ "branch"; "create"; branchName ]
+
+  // The same body on purpose: that is what makes them one item.
+  let _ =
+    runWithCommand
+      [ "--branch"; branchName; "fn"; "/" ++ alpha; "let alpha () : Int64 = 7L" ]
+
+  let _ =
+    runWithCommand
+      [ "--branch"; branchName; "fn"; "/" ++ beta; "let beta () : Int64 = 7L" ]
+
+  let rawAlpha = runWithCommand [ "--branch"; branchName; "view"; alpha; "--raw" ]
+  let rawBeta = runWithCommand [ "--branch"; branchName; "view"; beta; "--raw" ]
+
+  // The decorated view resolves the name the same way, so it needs the same answer.
+  // Only `--raw` gets written back, but a wrong name on screen is wrong either way.
+  let shownAlpha = runWithCommand [ "--branch"; branchName; "view"; alpha ]
+  let shownBeta = runWithCommand [ "--branch"; branchName; "view"; beta ]
+
+  if
+    Stdlib.String.contains rawAlpha "let alpha"
+      && Stdlib.Bool.not (Stdlib.String.contains rawAlpha "let beta")
+      && Stdlib.String.contains rawBeta "let beta"
+      && Stdlib.Bool.not (Stdlib.String.contains rawBeta "let alpha")
+      && Stdlib.String.contains shownAlpha "alpha"
+      && Stdlib.Bool.not (Stdlib.String.contains shownAlpha "let beta")
+      && Stdlib.String.contains shownBeta "beta"
+      && Stdlib.Bool.not (Stdlib.String.contains shownBeta "let alpha")
+  then
+    TestResult.Pass
+  else
+    TestResult.Fail(
+      $"Expected each name to head its own declaration; alpha: {rawAlpha}, "
+      ++ $"beta: {rawBeta}, shown: {shownAlpha} / {shownBeta}"
+    )
+
+
+/// Every kind `--raw` prints round-trips, not just functions.
+///
+/// The printer and the parser have to agree per kind, and a type's record and enum
+/// layout is where they are likeliest to drift apart. A round trip that changes the
+/// item is worse than one that fails: nothing says so, and the store quietly holds
+/// something you did not write.
+let testEditRoundTripsTypesAndValues (): TestResult =
+  let suffix = Stdlib.Int.toString (Stdlib.Int.random 100000 999999)
+  let branchName = "cli-edit-kinds-" ++ suffix
+  let typeName = "Tests.CliEditKinds.Pair"
+  let valueName = "Tests.CliEditKinds.answer"
+  let typePath = Stdlib.Cli.File.createTemp () |> Builtin.unwrap
+  let valuePath = Stdlib.Cli.File.createTemp () |> Builtin.unwrap
+
+  let _ = runWithCommand [ "branch"; "create"; branchName ]
+
+  let _ =
+    runWithCommand
+      [ "--branch"
+        branchName
+        "type"
+        "/" ++ typeName
+        "{ a: Int64; b: String }" ]
+
+  let _ =
+    runWithCommand [ "--branch"; branchName; "val"; "/" ++ valueName; "42L" ]
+
+  let typeBefore =
+    runWithCommand [ "--branch"; branchName; "view"; typeName; "--raw" ]
+
+  let typeHashBefore = runWithCommand [ "--branch"; branchName; "hash"; typeName ]
+
+  let valueBefore =
+    runWithCommand [ "--branch"; branchName; "view"; valueName; "--raw" ]
+
+  let valueHashBefore = runWithCommand [ "--branch"; branchName; "hash"; valueName ]
+
+  let _ = (Stdlib.Cli.File.writeAtomic typePath typeBefore) |> Builtin.unwrap
+  let _ = (Stdlib.Cli.File.writeAtomic valuePath valueBefore) |> Builtin.unwrap
+  let _ = runWithCommand [ "--branch"; branchName; "edit"; typeName; typePath ]
+  let _ = runWithCommand [ "--branch"; branchName; "edit"; valueName; valuePath ]
+
+  let typeAfter =
+    runWithCommand [ "--branch"; branchName; "view"; typeName; "--raw" ]
+
+  let typeHashAfter = runWithCommand [ "--branch"; branchName; "hash"; typeName ]
+
+  let valueAfter =
+    runWithCommand [ "--branch"; branchName; "view"; valueName; "--raw" ]
+
+  let valueHashAfter = runWithCommand [ "--branch"; branchName; "hash"; valueName ]
+
+  if
+    typeBefore == typeAfter && typeHashBefore == typeHashAfter
+      && valueBefore == valueAfter && valueHashBefore == valueHashAfter
+      && Stdlib.String.contains typeBefore "type Pair"
+      && Stdlib.String.contains valueBefore "val answer"
+  then
+    TestResult.Pass
+  else
+    TestResult.Fail(
+      $"Expected types and values to round-trip; type: {typeBefore} -> {typeAfter}, "
+      ++ $"value: {valueBefore} -> {valueAfter}"
+    )
+
+
+/// A file `edit` cannot use leaves the item exactly as it was.
+///
+/// `edit` hands the file to the same validation `module` does, so a rejection has to
+/// be a rejection: half-applying it, or reporting a failure while the store moved,
+/// would make an editor round trip something you cannot trust.
+let testEditLeavesTheItemAloneOnABadFile (): TestResult =
+  let suffix = Stdlib.Int.toString (Stdlib.Int.random 100000 999999)
+  let branchName = "cli-edit-bad-" ++ suffix
+  let name = "Tests.CliEditBad.kept"
+  let badPath = Stdlib.Cli.File.createTemp () |> Builtin.unwrap
+
+  let _ = runWithCommand [ "branch"; "create"; branchName ]
+
+  let _ =
+    runWithCommand
+      [ "--branch"
+        branchName
+        "fn"
+        "/" ++ name
+        "let kept (n: Int64) : Int64 = n" ]
+
+  let hashBefore = runWithCommand [ "--branch"; branchName; "hash"; name ]
+  let _ = (Stdlib.Cli.File.writeAtomic badPath "this is not dark") |> Builtin.unwrap
+  let refused = runWithCommand [ "--branch"; branchName; "edit"; name; badPath ]
+  let hashAfterBad = runWithCommand [ "--branch"; branchName; "hash"; name ]
+
+  // A path that is not there at all takes the same route, and must also change
+  // nothing.
+  let missing =
+    runWithCommand
+      [ "--branch"; branchName; "edit"; name; "/tmp/cli-edit-no-such-file.dark" ]
+
+  let hashAfterMissing = runWithCommand [ "--branch"; branchName; "hash"; name ]
+
+  if
+    hashBefore == hashAfterBad && hashBefore == hashAfterMissing
+      && Stdlib.String.contains refused "Parse error"
+      && Stdlib.String.contains missing "Could not read"
+  then
+    TestResult.Pass
+  else
+    TestResult.Fail(
+      $"Expected a rejected file to change nothing; hashes {hashBefore} / "
+      ++ $"{hashAfterBad} / {hashAfterMissing}, said: {refused} | {missing}"
+    )
+
+
+/// `edit` and `view --raw` both take exactly one declaration, and say so.
+///
+/// A module is the near miss worth naming: `dark edit Stdlib.List` is a reasonable
+/// thing to type, and the answer has to point at the command that does take one
+/// rather than leaving you to guess.
+let testEditRefusesWhatItCannotEdit (): TestResult =
+  let bare = runWithCommand [ "edit" ]
+  let tooMany = runWithCommand [ "edit"; "a"; "b"; "c" ]
+  let aModule = runWithCommand [ "edit"; "Stdlib.List" ]
+  let unknown = runWithCommand [ "edit"; "Zz.NoSuch.thing" ]
+  let rawModule = runWithCommand [ "view"; "Stdlib.List"; "--raw" ]
+
+  // These tests shell out, so stdin is a pipe, which is exactly the case `edit` with
+  // no file has to refuse. An editor started here paints into that pipe.
+  let noTerminal = runWithCommand [ "edit"; "Stdlib.List.head" ]
+
+  if
+    Stdlib.String.contains noTerminal "Cannot open an editor"
+      && Stdlib.String.contains noTerminal "not a terminal"
+      && Stdlib.String.contains noTerminal "--raw"
+      && Stdlib.String.contains bare "usage: dark edit"
+      && Stdlib.String.contains tooMany "usage: dark edit"
+      && Stdlib.String.contains aModule "is a module"
+      && Stdlib.String.contains aModule "dark module"
+      && Stdlib.String.contains unknown "Cannot edit Zz.NoSuch.thing"
+      && Stdlib.String.contains rawModule "ONE declaration"
+  then
+    TestResult.Pass
+  else
+    TestResult.Fail(
+      $"Expected each refusal to name what to do instead; bare: {bare}, "
+      ++ $"module: {aModule}, unknown: {unknown}, raw module: {rawModule}, "
+      ++ $"no terminal: {noTerminal}"
+    )

--- a/packages/darklang/cli/workbench/authoring.dark
+++ b/packages/darklang/cli/workbench/authoring.dark
@@ -171,12 +171,7 @@ let openEditExisting (state: State) (item: BodyItem) : Step =
   let modules = modulePathOf state.location
   let fullName = Stdlib.String.join (Stdlib.List.append modules [ item.name ]) "."
   let results = Packages.Query.searchExactMatch state.branchId modules item.name
-  let ctx =
-    PrettyPrinter.ProgramTypes.Context
-      { branchId = state.branchId
-        currentModule = []
-        currentFunction = Stdlib.Option.Option.None
-        width = 80 }
+  let ctx = PrettyPrinter.ProgramTypes.Context.forBranch state.branchId
   // Prefill from the item's current source, per kind. `val` items save under the "value" kind (see saveEditing).
   let kindAndSrc =
     if item.kind == "type" then

--- a/packages/darklang/cli/workbench/loaders.dark
+++ b/packages/darklang/cli/workbench/loaders.dark
@@ -211,12 +211,7 @@ let changesSourceText (branchId: Uuid) (selected: Int) : String =
     let leaf = Stdlib.List.last parts |> Stdlib.Option.withDefault name
     let mods = Stdlib.List.take parts (Stdlib.Int.max 0 ((Stdlib.List.length parts) - 1))
     let results = Packages.Query.searchExactMatch branchId mods leaf
-    let ctx =
-      PrettyPrinter.ProgramTypes.Context
-        { branchId = branchId
-          currentModule = []
-          currentFunction = Stdlib.Option.Option.None
-          width = 80 }
+    let ctx = PrettyPrinter.ProgramTypes.Context.forBranch branchId
     let src =
       if kind == "Type" then
         match results.types with

--- a/packages/darklang/languageTools/lsp-server/fileSystemProvider.dark
+++ b/packages/darklang/languageTools/lsp-server/fileSystemProvider.dark
@@ -52,12 +52,7 @@ module ReadFile =
         let pm = LanguageTools.PackageManager.pm ()
         let branchId = state.currentBranchId
 
-        let ctx =
-          PrettyPrinter.ProgramTypes.Context
-            { branchId = branchId
-              currentModule = []
-              currentFunction = Stdlib.Option.Option.None
-              width = 80 }
+        let ctx = PrettyPrinter.ProgramTypes.Context.forBranch branchId
 
         // Try to find as a specific entity (type, function, or value)
         let entityContent =
@@ -97,11 +92,7 @@ module ReadFile =
                 exactMatch = false }
 
           let ctx =
-            PrettyPrinter.ProgramTypes.Context
-              { branchId = state.currentBranchId
-                currentModule = []
-                currentFunction = Stdlib.Option.Option.None
-                width = 80 }
+            PrettyPrinter.ProgramTypes.Context.forBranch state.currentBranchId
 
           let results =
             LanguageTools.PackageManager.Search.search state.currentBranchId searchQuery
@@ -432,11 +423,7 @@ module WriteFile =
                     exactMatch = false }
 
               let ctx =
-                PrettyPrinter.ProgramTypes.Context
-                  { branchId = state.currentBranchId
-                    currentModule = []
-                    currentFunction = Stdlib.Option.Option.None
-                    width = 80 }
+                PrettyPrinter.ProgramTypes.Context.forBranch state.currentBranchId
 
               let results =
                 LanguageTools.PackageManager.Search.search state.currentBranchId searchQuery

--- a/packages/darklang/languageTools/packageManager.dark
+++ b/packages/darklang/languageTools/packageManager.dark
@@ -10,11 +10,23 @@ module Darklang.LanguageTools.PackageManager
 /// When a hash maps to multiple named locations (e.g. Person and Person2 are
 /// structurally identical), we use context to pick the best display name.
 type PickContext =
-  { currentModule: List<String> }
+  { currentModule: List<String>
+
+    /// Which name to pick when the hash has several, if this is one of them.
+    ///
+    /// A hash can be bound to more than one location -- two items with identical
+    /// bodies are one item -- and the scoring below cannot tell those apart. It
+    /// scores by module prefix, which is right for a name appearing inside someone
+    /// else's code and arbitrary for the item a caller is displaying: without this,
+    /// `dark view Zz.alpha` prints a definition headed `Zz.beta`.
+    ///
+    /// Ignored when it is not among the candidates, so a caller can set it whenever
+    /// it knows which location it is displaying, without checking first.
+    preferredLocation: Stdlib.Option.Option<ProgramTypes.PackageLocation> }
 
 module PickContext =
   val empty =
-    PickContext { currentModule = [] }
+    PickContext { currentModule = []; preferredLocation = Stdlib.Option.Option.None }
 
 /// Count how many leading segments of two lists match.
 let countMatchingPrefix (a: List<String>) (b: List<String>) : Int =
@@ -33,6 +45,21 @@ let pickLocation
   (ctx: PickContext)
   (locations: List<ProgramTypes.PackageLocation>)
   : Stdlib.Option.Option<ProgramTypes.PackageLocation> =
+  // The asked-for name wins outright when it is one of the candidates. Only then: a
+  // preference for a name this hash is not bound to would be a lie, and the scoring
+  // below is right for every other case.
+  let asked =
+    match ctx.preferredLocation with
+    | Some p ->
+      locations
+      |> Stdlib.List.findFirst (fun l ->
+        (l.owner == p.owner) && (l.modules == p.modules) && (l.name == p.name))
+    | None -> Stdlib.Option.Option.None
+
+  match asked with
+  | Some a -> Stdlib.Option.Option.Some a
+  | None ->
+
   match locations with
   | [] -> Stdlib.Option.Option.None
   | [ single ] -> Stdlib.Option.Option.Some single

--- a/packages/darklang/prettyPrinter/programTypes.dark
+++ b/packages/darklang/prettyPrinter/programTypes.dark
@@ -53,7 +53,15 @@ type Context =
 
     /// Columns available. Layout decisions are made against this; it is a field rather than something
     /// looked up so that printing stays reproducible and a caller can print for a pane.
-    width: Int }
+    width: Int
+
+    /// The location this definition is being shown under, when the caller knows it.
+    ///
+    /// Only `FQ*.Package.atDefinition` can use it: that is the one lookup whose hash
+    /// is the subject's own. A name inside the body resolves against its own
+    /// candidates, where this location does not appear.
+    preferredLocation:
+      Stdlib.Option.Option<LanguageTools.ProgramTypes.PackageLocation> }
 
 module Context =
   let forBranch (branchId: Uuid) : Context =
@@ -61,7 +69,8 @@ module Context =
       { branchId = branchId
         currentModule = []
         currentFunction = Stdlib.Option.Option.None
-        width = 80 }
+        width = 80
+        preferredLocation = Stdlib.Option.Option.None }
 
   val forMain = forBranch SCM.Branch.mainBranchId
 
@@ -75,10 +84,13 @@ module Context =
       { branchId = branchId
         currentModule = path
         currentFunction = Stdlib.Option.Option.None
-        width = 80 }
+        width = 80
+        preferredLocation = Stdlib.Option.Option.None }
 
   let toPickContext (ctx: Context) : LanguageTools.PackageManager.PickContext =
-    LanguageTools.PackageManager.PickContext { currentModule = ctx.currentModule }
+    LanguageTools.PackageManager.PickContext
+      { currentModule = ctx.currentModule
+        preferredLocation = ctx.preferredLocation }
 
 let packageNameWithContext
   (ctx: Context)

--- a/packages/darklang/prettyPrinter/runtimeTypes.dark
+++ b/packages/darklang/prettyPrinter/runtimeTypes.dark
@@ -75,7 +75,9 @@ let typeNameWith
     let locations = Darklang.LanguageTools.PackageManager.Type.locations branchId hash
     match
       Darklang.LanguageTools.PackageManager.pickLocation
-        (LanguageTools.PackageManager.PickContext { currentModule = opts.currentModule })
+        (LanguageTools.PackageManager.PickContext
+          { currentModule = opts.currentModule
+            preferredLocation = Stdlib.Option.Option.None })
         locations
     with
     | Some l -> PrettyPrinter.shortenName opts.currentModule l.owner l.modules l.name

--- a/packages/darklang/stdlib/cli/process.dark
+++ b/packages/darklang/stdlib/cli/process.dark
@@ -45,6 +45,19 @@ let run (program: String) (args: List<String>) : Result.Result<Output, Posix.Err
         stderr = Stdlib.Tuple3.third result })
 
 
+/// Run a program ON THIS TERMINAL and return its exit code.
+///
+/// Inherits stdin, stdout and stderr instead of capturing them, which is what
+/// anything that DRAWS needs: an editor with a redirected stdout paints into a pipe
+/// and reads keys from nowhere. Use `run` when you want the output, this when you
+/// want the program to be usable.
+let runInteractive
+  (program: String)
+  (args: List<String>)
+  : Result.Result<Int, Posix.Error> =
+  Builtin.posixSpawnInteractive program args
+
+
 /// Run a program and return stdout as text, or stderr as error.
 /// Returns String errors because it mixes spawn failures with command failures.
 let exec (program: String) (args: List<String>) : Result.Result<String, String> =

--- a/scripts/run-in-docker
+++ b/scripts/run-in-docker
@@ -67,6 +67,15 @@ for var in $(env | sed -n 's/^\(DARK_[A-Z0-9_]*\)=.*/\1/p'); do
   DARK_ENV_FLAGS+=( -e "$var" )
 done
 
+# EDITOR and VISUAL too: `dark edit` spawns the editor INSIDE the container, so without
+# these it falls back to vi no matter what the host is set to. Only forwarded when set,
+# since `-e VAR` on an unset var would export it empty and hide the fallback.
+for var in EDITOR VISUAL; do
+  if [[ -n "${!var:-}" ]]; then
+    DARK_ENV_FLAGS+=( -e "$var" )
+  fi
+done
+
 # The `cat <&0` below reads fd 0 to EOF, so only forward it when something will get there.
 # Pipes and regular files always do. Sockets are ambiguous: agent harnesses hand over one that
 # carries no data and never EOFs, while node/libuv's `stdio: 'pipe'` socketpair does both, so


### PR DESCRIPTION
Every authoring command takes a whole definition. Changing one line of a forty-line function means typing the other thirty-nine.

`dark edit <name>` opens the declaration in `$EDITOR` and applies it on save. `dark edit <name> <file>` applies a file instead, with no editor and no terminal. Both go through `dark module`, so the source is validated the same way and siblings in the module are untouched.

`dark view <name> --raw` prints the declaration on its own -- no deprecation header, no capabilities badge, no colour. That is exactly what `edit` and `module` accept:

```
$ dark view Stdlib.List.head --raw
/// Returns {{Some}} the head (first value) of a list. Returns {{None}} if the list is empty.
let head<'a> (list: List<'a>): Option<'a> =
  match list with
  | [] -> Option.None
  | head :: _ -> Option.Some(head)

$ dark view Foo.bar --raw > /tmp/bar.dark    # ...change it...
$ dark edit Foo.bar /tmp/bar.dark
✓ Defined 1 declaration in /Foo
```

An editor needs the terminal it was started from, so `posixSpawnInteractive` inherits stdin, stdout and stderr instead of capturing them. When there is no terminal, `edit` says so and points at the file form:

```
$ dark edit Stdlib.List.head < /dev/null
Cannot open an editor: standard input is not a terminal.
  `dark view Stdlib.List.head --raw > f`, change f, then `dark edit Stdlib.List.head f`.
```

One thing `--raw` forced: `dark view Zz.alpha` could print a definition headed `let beta`. Two byte-identical bodies are one stored item, and a stored function carries no name, so the printer picks a name by scoring the current module against each candidate location. Nothing separated `alpha` from `beta`, so the tie went to whichever came back first. The location you asked about is now carried into the printer and wins if it is among the candidates. With `--raw` that name gets written straight back, so it had to be right.

Changes:

- `cli/packages/edit.dark`, three lines in `cli/registry.dark`: the command.
- `cli/packages/view.dark`: `--raw`, and `Cannot view <name>: ...` now says which name.
- `languageTools/packageManager.dark`, `prettyPrinter/programTypes.dark`, `prettyPrinter/runtimeTypes.dark`: `preferred` on the pick context.
- `cli/packages/module.dark`: counts the declarations it recorded rather than the ones it parsed, and says "1 declaration". `edit` sends one item through here, so the singular is common now.
- `Builtins.Cli/Libs/Posix.fs`, `stdlib/cli/process.dark`: the interactive spawn and its wrapper.
- Eight places built a printer context field by field; they call `Context.forBranch` instead.
- `AGENTS.md`: how to drive a command that opens an editor, since `expect` is awkward for one.

Tests: `pickLocation.dark` covers the preference, including a preferred name the hash is not bound to, which falls back to scoring. The CLI suite covers `--raw` being undecorated, both views heading a shared body with the name asked for, round trips of a fn, a type and a value leaving the hash alone while a real change still lands, a rejected file changing nothing, and each refusal -- module, unknown name, wrong arity, no terminal.