### PR TITLE
Run the CLI integration tests again, and give `version` a `--local`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -215,7 +215,12 @@ jobs:
 
       - run: ./scripts/build/_dotnet-wrapper publish -c Release fsdark.sln /p:DebugType=None /p:DebugSymbols=false
 
-      - run: scripts/run-backend-tests --published
+      # Bounded, so a wedged suite dies at a known point with its log intact rather than
+      # running until CircleCI's job cap. The runner emits a heartbeat every 30s, so the
+      # default no-output timeout can no longer fire on a healthy-but-slow run.
+      - run:
+          name: Run backend tests
+          command: timeout 20m scripts/run-backend-tests --published
 
       # Allocation for a fixed workload repeats to a tenth of a percent and doesn't care how loaded
       # the box is, so it's the one performance number that can be asserted on here. Time isn't.
@@ -237,8 +242,12 @@ jobs:
             - backend/Build/obj
             - /home/dark/.nuget
           key: v5-backend-{{ checksum "../checksum" }}
-      - store_artifacts: { path: rundir }
-      - store_test_results: { path: rundir/test_results }
+      - store_artifacts:
+          path: rundir
+          when: always
+      - store_test_results:
+          path: rundir/test_results
+          when: always
 
   # Build cli binaries
   build-cli:
@@ -288,9 +297,13 @@ jobs:
             - backend/Build/obj
             - /home/dark/.nuget
           key: v5-cli-{{ checksum "../checksum" }}
-      - store_artifacts: { path: rundir }
+      - store_artifacts:
+          path: rundir
+          when: always
       - store_artifacts: { path: clis }
-      - store_test_results: { path: rundir/test_results }
+      - store_test_results:
+          path: rundir/test_results
+          when: always
 
   ##########################
   # Release matrix (NativeAOT, fanned out by OS)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -295,6 +295,30 @@ needs one works: `dark edit` really opens `$EDITOR`, and you drive it with more 
 Poll `capture-pane` in a loop rather than sleeping between steps; a command that shells out
 per invocation takes a second or more, and the pane is the only thing that tells you it is done.
 
+## CI has a terminal, and that changes behaviour
+
+`Builtin.stdinIsInteractive ()` is false on a pipe and TRUE on a pty. CircleCI gives each
+step a pty, so anything gated on "is a human here?" answers YES in CI, and a command that
+then reads stdin blocks on a terminal nobody types into. Forever.
+
+It presents as a hang, not a failure: no error, no output, and the step killed for
+silence with nothing in the log naming the culprit.
+
+So anything unattended passes `--yes` explicitly. Never rely on being detected as
+non-interactive, and never test a destructive command without it. Reproducing this class
+needs a real terminal, which `tmux` gives you (see above); the same run from a pipe
+passes, which is why it survives local testing.
+
+Three things make the next one findable, all in place:
+
+    scripts/run-backend-tests        under CI, a heartbeat every 2min, so a live run
+                                     never looks silent to CI's no-output timeout
+    scripts/run-backend-tests --debug   names every test as it starts, which is how you
+                                     find WHICH one is stuck
+    .circleci/config.yml             `when: always` on store_artifacts, so a failing step
+                                     still uploads rundir, and `timeout 20m` on the test
+                                     step so it dies somewhere known
+
 ## Debugging
 
     Builtin.debug "label" value   # prints DEBUG: label: <repr> to stdout

--- a/backend/tests/Tests/CliTraces.Tests.fs
+++ b/backend/tests/Tests/CliTraces.Tests.fs
@@ -150,12 +150,26 @@ let private testHelpCommand =
       Expect.stringContains output "status" "status command"
     })
 
+/// `--local`, so the suite does not depend on reaching GitHub.
+///
+/// Bare `version` checks for a newer release, and against a firewall that drops rather
+/// than refuses it waits ~11s before giving up. What this test is about is the version
+/// the binary reports, which `--local` answers from the binary alone.
 let private testVersionCommand =
   cliTest "version command" (fun state ->
     task {
-      let! output = runCli state [ "version" ]
+      let! output = runCli state [ "version"; "--local" ]
       Expect.stringContains output "Darklang CLI" "CLI banner"
       Expect.stringContains output "alpha-" "version prefix"
+      Expect.isFalse
+        (output.Contains "update available" || output.Contains "unable to check")
+        "and says nothing about updates, since it did not look"
+
+      // A near miss must not silently fall through to the network check, which is the
+      // one thing the caller was trying to avoid.
+      let! typo = runCli state [ "version"; "--locl" ]
+      Expect.stringContains typo "unknown option" "a mistyped flag is named"
+      Expect.isFalse (typo.Contains "update available") "and nothing was fetched"
     })
 
 let private testStatusCommand =
@@ -425,7 +439,7 @@ let private testTracesDeleteSingle =
           let! latestJson = runCli state [ "traces"; "list"; "1"; "--json" ]
           let latestTid = parseTraceID latestJson
 
-          let! delOut = runCli state [ "traces"; "delete"; latestTid ]
+          let! delOut = runCli state [ "traces"; "delete"; latestTid; "--yes" ]
           Expect.stringContains delOut "Deleted trace" "delete confirm"
 
           // Post-delete: the previously-latest trace should be gone (its
@@ -451,7 +465,8 @@ let private testTracesPruneKeep =
           let! latestJson = runCli state [ "traces"; "list"; "1"; "--json" ]
           let latestTid = parseTraceID latestJson
 
-          let! pruneOut = runCli state [ "traces"; "delete"; "--keep"; "1" ]
+          let! pruneOut =
+            runCli state [ "traces"; "delete"; "--keep"; "1"; "--yes" ]
           Expect.stringContains pruneOut "Pruned 2 trace" "prune confirm"
 
           // Post-prune: the previously-latest is the only one left.
@@ -653,10 +668,12 @@ let private testTracesDeleteGrammar =
           let! clearTwo = runCli state [ "traces"; "delete"; "--all"; "--yes" ]
           let! _ = runCli state [ "eval"; "1L + 1L" ]
           let! _ = runCli state [ "eval"; "2L + 2L" ]
-          let! pruneNone = runCli state [ "traces"; "delete"; "--keep"; "0" ]
+          let! pruneNone =
+            runCli state [ "traces"; "delete"; "--keep"; "0"; "--yes" ]
           let! _ = runCli state [ "eval"; "3L + 3L" ]
           let! _ = runCli state [ "eval"; "4L + 4L" ]
-          let! pruneOne = runCli state [ "traces"; "delete"; "--keep"; "1" ]
+          let! pruneOne =
+            runCli state [ "traces"; "delete"; "--keep"; "1"; "--yes" ]
 
           Expect.stringContains clearOne "Cleared 1 trace." "singular"
           Expect.stringContains clearTwo "Cleared 2 traces." "plural"
@@ -708,9 +725,9 @@ let private testTracesPruneIdempotent =
           // "kept" set is consistent. Verifying the result is
           // deterministic across repeated calls is the cheap
           // observable check that doesn't need parallel writers.
-          let! _ = runCli state [ "traces"; "delete"; "--keep"; "2" ]
-          let! _ = runCli state [ "traces"; "delete"; "--keep"; "2" ]
-          let! _ = runCli state [ "traces"; "delete"; "--keep"; "2" ]
+          let! _ = runCli state [ "traces"; "delete"; "--keep"; "2"; "--yes" ]
+          let! _ = runCli state [ "traces"; "delete"; "--keep"; "2"; "--yes" ]
+          let! _ = runCli state [ "traces"; "delete"; "--keep"; "2"; "--yes" ]
 
           let! listOut = runCli state [ "traces"; "list" ]
           // Lines look like "  <timestamp>  <uuid>  <handler>".

--- a/backend/tests/Tests/SyncE2E.Tests.fs
+++ b/backend/tests/Tests/SyncE2E.Tests.fs
@@ -452,7 +452,10 @@ let private realTests =
                  || out.Contains "unreachable")
                 "it surfaces that the peer was unreachable"
               // The store is unharmed: a normal read-only command still works afterward.
-              let ver = darkIn b.dir [ "version" ]
+              // `--local`, because bare `version` checks GitHub for a newer release and
+              // waits ~11s to give up where there is no egress. What is being asked here
+              // is whether the CLI still answers at all.
+              let ver = darkIn b.dir [ "version"; "--local" ]
               Expect.isFalse
                 (ver = "")
                 "the CLI + store are still usable after the failed sync"

--- a/backend/tests/Tests/Tests.fs
+++ b/backend/tests/Tests/Tests.fs
@@ -50,16 +50,13 @@ let main (args : string array) : int =
 
         // http server
         Tests.HttpServer.tests
-        // CliTraces is excluded: it hangs CI, and why is not yet known. The cases
-        // are sequenced (`Console.SetOut` capture forces it) so Expecto prints
-        // nothing until the summary, and `testVersionCommand` runs `dark version`,
-        // which fetches from api.github.com. Request and connect timeouts are
-        // already 30s and 10s, so the fetch alone cannot explain a ten-minute
-        // stall. Re-enabling needs a repro on a runner without egress, not a guess.
+        // Sequenced, because these capture `Console.Out` and that is process-global.
         //
-        // Uncomment the line below to run them; no filter reaches them while it is commented out,
-        // so nothing currently exercises the tracer end to end.
-        // Tests.CliTraces.tests
+        // Every destructive command here passes `--yes`. CI runs with a pty, so the
+        // "is anyone watching?" check says yes and the confirmation prompt blocks on a
+        // terminal nobody types into; a pipe skips the prompt, so the omission is
+        // invisible locally. `packages/darklang/cli/tracing.dark` has the detail.
+        Tests.CliTraces.tests
         Tests.CliScriptLowering.tests
         Tests.Toplevels.tests
 

--- a/packages/darklang/cli/installation/version.dark
+++ b/packages/darklang/cli/installation/version.dark
@@ -2,9 +2,28 @@ module Darklang.Cli.Installation.Version
 
 
 let execute (state: AppState) (args: List<String>) : AppState =
-  // Checks GitHub for a newer release, which dominates the command. Deliberate: knowing you're out of
-  // date is the point of the command, not a side errand.
-  Stdlib.printLine (Helpers.versionInfoWithUpdateCheck ())
+  // Named, not ignored: a mistyped `--locl` would otherwise fall through to the update
+  // check, which is the one thing the caller was trying to skip.
+  let unknown = args |> Stdlib.List.filter (fun a -> a != "--local")
+
+  match unknown with
+  | bad :: _ ->
+    Stdlib.printLine (Stdlib.Cli.UI.Colors.error $"version: unknown option `{bad}`")
+    Stdlib.printLine (help state)
+    state
+  | [] ->
+
+  // The update check is a network round trip and it dominates the command. Deliberate:
+  // knowing you are out of date is the point, not a side errand.
+  //
+  // `--local` answers from the binary alone, for a caller that wants to know WHICH
+  // binary this is rather than whether it is current: a test, a script, a machine with
+  // no egress. Against a firewall that DROPS rather than refuses -- the shape of a CI
+  // runner -- the check takes ~11s to give up and then says nothing useful anyway.
+  if Stdlib.List.member args "--local" then
+    Stdlib.printLine $"Darklang CLI {Helpers.cliVersion ()}"
+  else
+    Stdlib.printLine (Helpers.versionInfoWithUpdateCheck ())
 
   // Store-format coordinate — the on-disk data shape this Dark speaks vs what your local data is stamped at.
   // (This is what the boot-time migrator + sync's wire-version key off; see `dark update`.) It is NOT a product
@@ -41,9 +60,12 @@ let complete (_state: AppState) (_args: List<String>) : List<Completion.Completi
 
 let help (_state: AppState) : String =
   [
-    "Usage: version"
+    "Usage: version [--local]"
     "Display CLI version and store-format information."
     ""
     "Shows the current version, whether a newer release exists, and whether your data"
     "matches this binary's store format."
+    ""
+    "  --local    Skip the check for a newer release, which needs the network."
+    "             Answers immediately, and says nothing about updates."
   ] |> Stdlib.String.join "\n"

--- a/packages/darklang/cli/tracing.dark
+++ b/packages/darklang/cli/tracing.dark
@@ -177,10 +177,13 @@ let parseViewOptions
 
 /// Confirm a destructive op. Returns true to proceed, false to bail.
 ///
-/// `--yes` / `-y` skips the prompt; non-interactive stdin (piped
-/// scripts, test runs, CI) also skips so callers don't hang or
-/// fail on EOF. Only an interactive user without `--yes` sees the
-/// prompt — matching the `rm -i` shape.
+/// `--yes` / `-y` skips the prompt. So does stdin that is not a terminal, which covers a
+/// pipe or a redirect. Everyone else is asked — the `rm -i` shape.
+///
+/// "Not a terminal" is narrower than "nobody is watching", and the gap is where things
+/// hang. A CI runner gets a pty, so this asks, and then blocks on a terminal nobody will
+/// ever type into. Anything unattended has to pass `--yes` rather than rely on being
+/// detected.
 let confirmDestructive (autoConfirm: Bool) (action: String) : Bool =
   if autoConfirm then
     true

--- a/scripts/run-backend-tests
+++ b/scripts/run-backend-tests
@@ -58,6 +58,7 @@ echo $$ > "$LOCK"
 
 # shellcheck disable=SC2317  # reached via trap
 cleanup() {
+  kill "${HEARTBEAT_PID:-}" 2>/dev/null || true
   killall -9 Tests 2>/dev/null || true
   rm -f "$LOCK"
 }
@@ -140,11 +141,36 @@ true > "${TEST_LOG}" # truncate
 
 cd backend
 echo -e "Logging to: ${grey}${TEST_LOG}${reset}"
+
+# CI only, because CI is the only place with nothing else to look at: the spinner is
+# disabled up there, and Expecto prints nothing between "Running tests..." and the
+# summary. A step with no output for ten minutes gets killed, which turns any slowdown
+# into a hang with no evidence of where. Locally the spinner already says it is alive.
+#
+# Two minutes, not thirty seconds: this exists to stay inside a ten-minute limit, not to
+# report progress, so the cheapest interval that does that is the right one. A four
+# minute run costs one line. Use `--debug` when you need to know WHICH test.
+#
+# Goes to this script's stdout rather than through the `tee` below, so it lands in the
+# step output CI keeps rather than in `fsharp-tests.log`. Killed with the runner.
+if [[ -v CI ]]; then
+  (
+    start=$(date +%s)
+    while true; do
+      sleep 120
+      echo "[heartbeat] tests still running, $(( $(date +%s) - start ))s elapsed"
+    done
+  ) &
+  HEARTBEAT_PID=$!
+fi
+
 set +e
 DARK_CONFIG_TELEMETRY_EXPORTER=none \
 "${EXE}" ${SPINNER} --colours "${COLOURS}" --junit-summary "${JUNIT_FILE}" "${EXPECTO_ARGS[@]}" 2>&1 | tee "${TEST_LOG}"
 STATUS=${PIPESTATUS[0]}
 set -e
+
+kill "${HEARTBEAT_PID:-}" 2>/dev/null || true
 
 # Expecto reports a filter that matched nothing as "0 tests run - Success!" and exits
 # 0, which is the worst answer available: you believe you ran a suite you didn't.


### PR DESCRIPTION
`Tests.CliTraces` is commented out of `Tests.fs` -- 45 tests that drive the CLI end to end, over `eval`, `run`, `view`, `ls`, `traces` and the runtime-error surface. The comment says it hangs CI and that why is not known.

It does hang, and here is why. `traces delete` asks for confirmation unless you pass `--yes`, and skips asking when stdin is not a terminal. CI runs each step under a pty, so stdin IS a terminal there, the prompt prints, and the read blocks on a terminal nobody types into. Seven calls in these tests omitted `--yes`; from a pipe they skip the prompt and pass, which is why this survives local testing. With a real terminal the group stops dead on the first of them:

```
[DBG] tests/CliTraces/traces find <pattern> by content passed in 00:00:00.0620000.
[DBG] tests/CliTraces/traces delete <id> preserves siblings starting...
                                                    (nothing, forever)
```

Those seven now pass `--yes`. With that, the group runs in a real terminal in 2.5s, and the suite goes from 10,465 tests to 10,510.

The docstring on `confirmDestructive` claimed piped scripts, test runs and CI were all covered by the non-interactive check. CI is the one case it does not cover, and it now says so.

Three things kept this invisible, and all three are worth fixing regardless:

- The suite prints nothing between "Running tests..." and the summary, so a wedged run and a healthy one look identical for minutes at a time -- and CI kills a step after ten minutes of silence. The runner emits a heartbeat every 30s.
- `store_artifacts` had no `when: always`, so a killed step uploaded nothing. There has never been a log to read.
- Nothing bounded the step, so it ran to CircleCI's job cap. It is `timeout 20m` now.

Also here, because a test shelling out to `dark version` makes a live GitHub request, and against a firewall that drops rather than refuses that takes ~11s to give up: `version --local` answers from the binary alone, and the two tests that called it use that. `version` ignored any argument it was given, so a mistyped `--locl` would silently make the request you were skipping; unknown options are named now.

Changes:

- `backend/tests/Tests/Tests.fs`: the line, uncommented.
- `backend/tests/Tests/CliTraces.Tests.fs`: `--yes` on all seven destructive calls.
- `packages/darklang/cli/tracing.dark`: the docstring, corrected.
- `packages/darklang/cli/installation/version.dark`: `--local`, and unknown options refused.
- `backend/tests/Tests/SyncE2E.Tests.fs`: uses `--local` too.
- `scripts/run-backend-tests`, `.circleci/config.yml`: heartbeat, artifacts on failure, bounded step.
- `AGENTS.md`: that CI has a terminal, and what it means for anything unattended.
