### PR TITLE
Escape HTML attribute values

### DIFF
--- a/backend/testfiles/execution/stdlib/html.dark
+++ b/backend/testfiles/execution/stdlib/html.dark
@@ -51,6 +51,30 @@ Stdlib.Html.escapeHtml "\"quoted\"" = "&quot;quoted&quot;"
 (Stdlib.Html.stringNode "<script>trusted</script>")
 |> nodeToString = "<script>trusted</script>"
 
+// -- attribute values are escaped, like text is
+//
+// The quote is the one that matters: an unescaped `"` closes the attribute, and everything
+// after it is parsed as markup rather than as part of the value.
+(htmlTag "a" [ ("href", Stdlib.Option.Option.Some "\" onmouseover=\"alert(1)") ] [])
+|> nodeToString = "<a href=\"&quot; onmouseover=&quot;alert(1)\"></a>"
+
+(htmlTag "div" [ ("title", Stdlib.Option.Option.Some "a & b") ] []) |> nodeToString =
+  "<div title=\"a &amp; b\"></div>"
+
+(htmlTag "div" [ ("title", Stdlib.Option.Option.Some "<script>") ] []) |> nodeToString =
+  "<div title=\"&lt;script&gt;\"></div>"
+
+(htmlTag "div" [ ("title", Stdlib.Option.Option.Some "it's") ] []) |> nodeToString =
+  "<div title=\"it&#x27;s\"></div>"
+
+// A boolean attribute has no value to escape. `input` is a void element, so no closing tag.
+(htmlTag "input" [ ("disabled", Stdlib.Option.Option.None) ] []) |> nodeToString =
+  "<input disabled>"
+
+// The attribute helpers feed the same path, so they are covered too.
+(Stdlib.Html.div [ Stdlib.Html.dataAttr "note" "a \"quoted\" one" ] [])
+|> nodeToString = "<div data-note=\"a &quot;quoted&quot; one\"></div>"
+
 // Using text() with div to prevent XSS
 (Stdlib.Html.div
   []

--- a/packages/darklang/stdlib/html.dark
+++ b/packages/darklang/stdlib/html.dark
@@ -139,7 +139,7 @@ let htmlTagNode
 /// Converts a Node to its HTML string representation.
 ///
 /// Handles both text nodes and HTML tags, properly rendering:
-/// - Attributes with values as `name="value"`
+/// - Attributes with values as `name="value"`, with the value escaped
 /// - Boolean attributes (None value) as just `name`
 /// - Void elements without closing tags
 /// - Regular elements with proper opening and closing tags
@@ -152,7 +152,10 @@ let nodeToString (node: Node) : String =
       tag.attrs
       |> List.map (fun (key, valueOpt) ->
         match valueOpt with
-        | Some value -> $"{key}=\"{value}\""
+        // Escaped like text is. An attribute value is the easier injection: a `"` in an
+        // unescaped one closes the attribute and everything after it is markup. Callers
+        // pass raw values -- a url, a name, a class -- and do not pre-escape.
+        | Some value -> $"{key}=\"{escapeHtml value}\""
         | None -> key)
       |> String.join " "
 


### PR DESCRIPTION
`Stdlib.Html.escapeHtml` exists and `Html.text` already uses it, so text nodes are safe. Attribute values are not:

```
| Some value -> $"{key}=\"{value}\""
```

A `"` in the value closes the attribute, and everything after it is markup rather than part of the value:

```
value = `" onmouseover="alert(1)`

before   href="" onmouseover="alert(1)"
after    <a href="&quot; onmouseover=&quot;alert(1)"></a>
```

The asymmetry is the bug: a caller passing a url, a name or a class has no reason to think attributes need pre-escaping when text does not.

Changes:

- `packages/darklang/stdlib/html.dark`: attribute values go through `escapeHtml`.
- `backend/testfiles/execution/stdlib/html.dark`: a quote, `&`, `<` and `'` in attribute values; a boolean attribute, which has no value to escape; and one through the `dataAttr` helper, since the helpers feed the same path.