### PR TITLE
Fix argument handling in `fn`, `val`, `type` and `tree`

### DIFF
--- a/packages/darklang/cli/packages/core.dark
+++ b/packages/darklang/cli/packages/core.dark
@@ -38,3 +38,26 @@ let formatLocation (location: PackageLocation) : String =
     $"/{PrettyPrinter.ProgramTypes.PackageLocation.packageLocation loc} (value)"
   | Function loc ->
     $"/{PrettyPrinter.ProgramTypes.PackageLocation.packageLocation loc} (fn)"
+
+
+/// The definition a person typed, from the arguments after the item's name.
+///
+/// The `=` separating name from definition arrives either as its own argument or
+/// attached to the front; both come off, leading ones only, since the `=` in
+/// `(x: Int64) : Int64 = x` is the body's. A lone `-` reads stdin, so the separate
+/// argument has to go first.
+let definitionFromArgs (args: List<String>) : String =
+  let withoutSeparator =
+    match args with
+    | "=" :: rest -> rest
+    | parts -> parts
+
+  match withoutSeparator with
+  | [ "-" ] -> Stdlib.Cli.Stdin.readAll ()
+  | parts ->
+    let joined = Stdlib.String.join parts " " |> Stdlib.String.trim
+
+    if Stdlib.String.startsWith joined "=" then
+      Stdlib.String.dropFirst joined 1 |> Stdlib.String.trim
+    else
+      joined

--- a/packages/darklang/cli/packages/fn.dark
+++ b/packages/darklang/cli/packages/fn.dark
@@ -9,19 +9,7 @@ let execute (state: Cli.AppState) (args: List<String>) : Cli.AppState =
 
   // fn SomeModule.myFn (param: Type): ReturnType = body
   | location :: definitionParts ->
-    // Strip leading "=" if present (since users naturally type "fn foo (x: Int): Int = ...")
-    let cleanedParts =
-      match definitionParts with
-      | "=" :: rest -> rest
-      | parts -> parts
-
-    // Join all remaining args as the inline definition.
-    // Special case: a single "-" arg means "read body from stdin" so callers
-    // can pipe multi-line bodies via heredoc without shell-quoting.
-    let inlineDefinition =
-      match cleanedParts with
-      | [ "-" ] -> Stdlib.Cli.Stdin.readAll ()
-      | parts -> Stdlib.String.join parts " "
+    let inlineDefinition = Packages.definitionFromArgs definitionParts
 
     if Stdlib.String.isEmpty inlineDefinition then
       // No body provided - show error

--- a/packages/darklang/cli/packages/location.dark
+++ b/packages/darklang/cli/packages/location.dark
@@ -31,5 +31,23 @@ let parseRelativeTo
     let name = (Stdlib.List.last rest) |> Builtin.unwrap
     let modules = Stdlib.List.dropLast rest
 
-    Stdlib.Result.Result.Ok
-      (LanguageTools.ProgramTypes.PackageLocation { owner = owner; modules = modules; name = name })
+    // Module segments must be capitalised. A lowercase one is read as the item's NAME,
+    // so `Zz.low.f` authors `Zz.low`, and every later reference fails with "Zz.low not
+    // found" -- far from here. Owners are exempt.
+    let badModule =
+      modules
+      |> Stdlib.List.findFirst (fun m ->
+        match Stdlib.String.toList m with
+        | [] -> true
+        | first :: _ -> Stdlib.Bool.not (Stdlib.Char.isUppercase first))
+
+    match badModule with
+    | Some bad ->
+      Stdlib.Result.Result.Error
+        ($"module names must start with a capital, and \"{bad}\" does not. "
+         ++ "A lowercase segment is read as the item's NAME, so nothing could refer "
+         ++ "to what this would create.")
+    | None ->
+      Stdlib.Result.Result.Ok
+        (LanguageTools.ProgramTypes.PackageLocation
+          { owner = owner; modules = modules; name = name })

--- a/packages/darklang/cli/packages/traversal.dark
+++ b/packages/darklang/cli/packages/traversal.dark
@@ -117,7 +117,13 @@ let resolveEntity
       | [] ->
         match entityResults.values with
         | item :: _ -> Stdlib.Result.Result.Ok (PackageLocation.Value item.location)
-        | [] -> Stdlib.Result.Result.Error "Not found"
+        | [] ->
+          // The path, not just "Not found": that same sentence otherwise covers a
+          // typo, an unauthored name, and a path resolved from somewhere unexpected.
+          let looked =
+            Stdlib.String.join (Stdlib.List.append basePath [ name ]) "."
+
+          Stdlib.Result.Result.Error $"Not found: {looked}"
 
 
 let applyPath

--- a/packages/darklang/cli/packages/tree.dark
+++ b/packages/darklang/cli/packages/tree.dark
@@ -135,31 +135,61 @@ let execute (state: AppState) (args: List<String>): AppState =
         | Error _ -> 2
       | None -> 2 // Default depth of 2 for concise but useful view
 
-    // Determine starting location
     let branchId = state.currentBranchId
+
+    let pathArgs =
+      args
+      |> Stdlib.List.filter (fun a ->
+        Stdlib.Bool.not (Stdlib.String.startsWith a "--"))
+
+    // An unrecognised flag is dropped by the filter above, making `tree --zzbogus`
+    // indistinguishable from a bare `tree`. Only these three exist.
+    let knownFlag (a: String) : Bool =
+      (a == "--toc")
+      || (a == "--include-deprecated")
+      || (Stdlib.String.startsWith a "--depth=")
+
+    let unknownFlags =
+      args
+      |> Stdlib.List.filter (fun a ->
+        (Stdlib.String.startsWith a "--") && (Stdlib.Bool.not (knownFlag a)))
+
+    match unknownFlags with
+    | bad :: _ ->
+      Stdlib.printLine
+        (Stdlib.Cli.UI.Colors.error $"tree does not understand `{bad}`.")
+
+      Stdlib.printLine
+        (Stdlib.Cli.UI.Colors.hint
+          "  flags: --depth=N, --toc, --include-deprecated")
+
+      state
+    | [] ->
+
+    // Refused, not ignored: falling back to the current location answers a different
+    // question, and says nothing about the path you gave.
     let startLocation =
-      let pathArgs =
-        args
-        |> Stdlib.List.filter (fun arg -> Stdlib.Bool.not (Stdlib.String.startsWith arg "--"))
-
       match pathArgs with
-      | [] -> state.packageData.currentLocation
+      | [] -> Stdlib.Result.Result.Ok state.packageData.currentLocation
       | [ pathStr ] ->
-        match Traversal.traverse branchId state.packageData.currentLocation pathStr with
-        | Ok location -> location
-        | Error _ -> state.packageData.currentLocation
-      | _ -> state.packageData.currentLocation
+        Traversal.traverse branchId state.packageData.currentLocation pathStr
+      | _ ->
+        Stdlib.Result.Result.Error "tree takes at most one path"
 
-    // Load deprecation sets once for the whole tree render.
-    let depSets = Query.loadDeprecationSets branchId
+    match startLocation with
+    | Error e ->
+      Stdlib.printLine (Stdlib.Cli.UI.Colors.error $"Cannot show a tree: {e}")
+      state
+    | Ok startLocation ->
+      // Load deprecation sets once for the whole tree render.
+      let depSets = Query.loadDeprecationSets branchId
 
-    // Display tree
-    let locationStr = Packages.formatLocation startLocation
-    Stdlib.printLine $"Package tree from {locationStr}:"
-    Stdlib.printLine ""
-    displayTree branchId startLocation maxDepth 0 "" depSets includeDeprecated
+      let locationStr = Packages.formatLocation startLocation
+      Stdlib.printLine $"Package tree from {locationStr}:"
+      Stdlib.printLine ""
+      displayTree branchId startLocation maxDepth 0 "" depSets includeDeprecated
 
-    state
+      state
 
 
 // Display tree recursively from a given location.

--- a/packages/darklang/cli/packages/type.dark
+++ b/packages/darklang/cli/packages/type.dark
@@ -9,19 +9,7 @@ let execute (state: Cli.AppState) (args: List<String>) : Cli.AppState =
 
   // type SomeModule.myType = definition
   | location :: definitionParts ->
-    // Strip leading "=" if present (since users naturally type "type Foo = ...")
-    let cleanedParts =
-      match definitionParts with
-      | "=" :: rest -> rest
-      | parts -> parts
-
-    // Join all remaining args as the inline definition.
-    // Special case: a single "-" arg means "read body from stdin" so callers
-    // can pipe multi-line definitions via heredoc without shell-quoting.
-    let inlineDefinition =
-      match cleanedParts with
-      | [ "-" ] -> Stdlib.Cli.Stdin.readAll ()
-      | parts -> Stdlib.String.join parts " "
+    let inlineDefinition = Packages.definitionFromArgs definitionParts
 
     if Stdlib.String.isEmpty inlineDefinition then
       // No inline definition provided - show error

--- a/packages/darklang/cli/packages/value.dark
+++ b/packages/darklang/cli/packages/value.dark
@@ -9,19 +9,7 @@ let execute (state: Cli.AppState) (args: List<String>) : Cli.AppState =
 
   // val SomeModule.myValue = expression
   | location :: definitionParts ->
-    // Strip leading "=" if present (since users naturally type "val x = ...")
-    let cleanedParts =
-      match definitionParts with
-      | "=" :: rest -> rest
-      | parts -> parts
-
-    // Join all remaining args as the inline definition.
-    // Special case: a single "-" arg means "read body from stdin" so callers
-    // can pipe multi-line expressions via heredoc without shell-quoting.
-    let inlineDefinition =
-      match cleanedParts with
-      | [ "-" ] -> Stdlib.Cli.Stdin.readAll ()
-      | parts -> Stdlib.String.join parts " "
+    let inlineDefinition = Packages.definitionFromArgs definitionParts
 
     if Stdlib.String.isEmpty inlineDefinition then
       // No inline definition provided - show error

--- a/packages/darklang/cli/packages/view.dark
+++ b/packages/darklang/cli/packages/view.dark
@@ -468,16 +468,8 @@ let execute (state: AppState) (args: List<String>) : AppState =
 
     match locationResult with
     | Error errorMsg ->
-      // Names the target you asked for. "Cannot view: Not found: Zzz" says what
-      // failed but not what you typed, which matters when the arg was resolved
-      // relative to your current location.
-      //
-      // Unwrapped, not interpolated raw: `pathArg` is an Option, and interpolating
-      // one raises "Expected String in string interpolation", so the error path
-      // meant to name your target would crash instead of printing it.
-      let asked = pathArg |> Stdlib.Option.withDefault ""
-      let what = if asked == "" then "" else $" {asked}"
-      Stdlib.printLine (Stdlib.Cli.UI.Colors.error $"Cannot view{what}: {errorMsg}")
+      // The traversal names the path it looked for, so this does not repeat it.
+      Stdlib.printLine (Stdlib.Cli.UI.Colors.error $"Cannot view: {errorMsg}")
       state
     | Ok location ->
       match mode with

--- a/packages/darklang/cli/tests/tests-runner.dark
+++ b/packages/darklang/cli/tests/tests-runner.dark
@@ -35,6 +35,13 @@ let allTests (): List<String * TestFunction> =
     ( "Edit Leaves The Item Alone On A Bad File",
       fun () -> testEditLeavesTheItemAloneOnABadFile () )
     ("Edit Refuses What It Cannot Edit", fun () -> testEditRefusesWhatItCannotEdit ())
+    ( "Authoring Accepts A Quoted Separator",
+      fun () -> testAuthoringAcceptsAQuotedSeparator () )
+    ( "Authoring Refuses A Lowercase Module",
+      fun () -> testAuthoringRefusesALowercaseModule () )
+    ("Not Found Names The Path", fun () -> testNotFoundNamesThePath ())
+    ( "Tree Refuses What It Cannot Show",
+      fun () -> testTreeRefusesWhatItCannotShow () )
     ("View Unknown Flag", fun () -> testViewUnknownFlag ())
 
     ("Native List Edge Cases", fun () -> testNativeListEdgeCases ())

--- a/packages/darklang/cli/tests/tests.dark
+++ b/packages/darklang/cli/tests/tests.dark
@@ -938,3 +938,103 @@ let testEditRefusesWhatItCannotEdit (): TestResult =
       ++ $"module: {aModule}, unknown: {unknown}, raw module: {rawModule}, "
       ++ $"no terminal: {noTerminal}"
     )
+
+
+/// Every way of passing a definition authors the same item. The `=` is a separator:
+/// unquoted the shell splits it off, quoted it arrives attached, and both come off.
+let testAuthoringAcceptsAQuotedSeparator (): TestResult =
+  let branch = "cli-quoted-eq-" ++ (Stdlib.Int.toString (Stdlib.Int.random 1 999999))
+  let run (args: List<String>) : String =
+    runWithCommand (Stdlib.List.append [ "--branch"; branch ] args)
+
+  let body = "(x: Int64) : Int64 = Stdlib.Int64.multiply x 2L"
+  let _ = runWithCommand [ "branch"; "create"; branch ]
+  let _ = run [ "fn"; "/Tests.QuotedEq.quoted"; "= " ++ body ]
+  let _ = run [ "fn"; "/Tests.QuotedEq.split"; "="; body ]
+  let typed = run [ "type"; "/Tests.QuotedEq.T"; "= { x: Int64 }" ]
+  let valued = run [ "val"; "/Tests.QuotedEq.v"; "= 42L" ]
+
+  // The hash is the assertion: the same item, not merely both accepted. Evaluating it
+  // shows the `=` inside the body survived.
+  let quotedHash = run [ "hash"; "Tests.QuotedEq.quoted" ]
+  let splitHash = run [ "hash"; "Tests.QuotedEq.split" ]
+  let evaluated = run [ "eval"; "Tests.QuotedEq.quoted 21L" ]
+
+  if
+    quotedHash == splitHash
+      && Stdlib.String.contains evaluated "42"
+      && Stdlib.String.contains typed "Created type"
+      && Stdlib.String.contains valued "Created value"
+  then
+    TestResult.Pass
+  else
+    TestResult.Fail(
+      $"hashes {quotedHash} / {splitHash}, eval {evaluated}, {typed}, {valued}"
+    )
+
+
+/// A lowercase module segment is refused. It would be read as the item's NAME, so
+/// `Tests.lower.f` authors `Tests.lower` and nothing can refer to it afterwards.
+let testAuthoringRefusesALowercaseModule (): TestResult =
+  let branch = "cli-lowercase-" ++ (Stdlib.Int.toString (Stdlib.Int.random 1 999999))
+  let run (args: List<String>) : String =
+    runWithCommand (Stdlib.List.append [ "--branch"; branch ] args)
+
+  let _ = runWithCommand [ "branch"; "create"; branch ]
+  let refused = run [ "fn"; "/Tests.lower.f"; "() : Int64 = 1L" ]
+  let listed = run [ "ls"; "Tests.lower" ]
+
+  if
+    Stdlib.String.contains refused "must start with a capital"
+      && Stdlib.Bool.not (Stdlib.String.contains refused "Created")
+      && Stdlib.String.contains listed "Not found"
+  then
+    TestResult.Pass
+  else
+    TestResult.Fail $"refusal: {refused}, and listing said: {listed}"
+
+
+/// "Not found" names the path, once. Naming it at the traversal covers every caller,
+/// which is why none of them adds it again.
+let testNotFoundNamesThePath (): TestResult =
+  // A real prefix, so the traversal gets past it: it reports the FIRST missing segment,
+  // and a wholly unknown path would only ever report its first.
+  let missing = "Darklang.Stdlib.NoSuchModule.thing"
+  let expected = "Not found: Darklang.Stdlib.NoSuchModule"
+  let viewed = runWithCommand [ "view"; missing ]
+  let listed = runWithCommand [ "ls"; missing ]
+  let navigated = runWithCommand [ "nav"; missing ]
+
+  let names (s: String) : Bool = Stdlib.String.contains s expected
+  let twice = (Stdlib.List.length (Stdlib.String.split viewed "NoSuchModule")) > 2
+
+  if names viewed && names listed && names navigated && Stdlib.Bool.not twice then
+    TestResult.Pass
+  else
+    TestResult.Fail $"view: {viewed}, ls: {listed}, nav: {navigated}"
+
+
+/// `tree` refuses what it cannot show. Both arms used to answer instead: an unknown flag
+/// was dropped with the real ones, and an unresolvable path fell back to where you stood.
+let testTreeRefusesWhatItCannotShow (): TestResult =
+  let badFlag = runWithCommand [ "tree"; "--zzbogus" ]
+  let badPath = runWithCommand [ "tree"; "Zz.NoSuchThing" ]
+  let twoPaths = runWithCommand [ "tree"; "Darklang.Stdlib"; "Darklang.Cli" ]
+  let withDepth = runWithCommand [ "tree"; "Darklang.Stdlib.Option"; "--depth=1" ]
+
+  // The header the render prints. Seeing it in a refusal means it showed a tree anyway.
+  let shown (s: String) : Bool = Stdlib.String.contains s "Package tree from"
+
+  if
+    Stdlib.String.contains badFlag "does not understand"
+      && Stdlib.Bool.not (shown badFlag)
+      && Stdlib.String.contains badPath "Not found"
+      && Stdlib.Bool.not (shown badPath)
+      && Stdlib.String.contains twoPaths "at most one path"
+      && shown withDepth
+  then
+    TestResult.Pass
+  else
+    TestResult.Fail(
+      $"flag: {badFlag}, path: {badPath}, two: {twoPaths}, depth shown: {shown withDepth}"
+    )


### PR DESCRIPTION
`fn`, `val` and `type` rejected a quoted `=`. The `=` between the name and the definition is a separator: unquoted the shell splits it into its own argument, quoted it stays attached and reaches the parser. All four forms now author the same item:

| form | before | now |
|---|---|---|
| `dark fn Foo "(x: Int64) : Int64 = x"` | works | works |
| `dark fn Foo = "(x: Int64) : Int64 = x"` | works | works |
| `dark fn Foo "= (x: Int64) : Int64 = x"` | `Parse error at line 1, column 11` | works |
| `dark fn Foo = -`, body on stdin | works | works |

Scripts quote by default, and you have to quote once the definition contains a `|`. The strip runs in two places: on the separate argument before the `-` check, so stdin still works, and on the joined string for the quoted case. Only a leading `=` -- the one inside the body is the body's.

A lowercase module segment created an item nothing could refer to. A dotted name takes capitalised segments as modules and the first lowercase one as the item's name, so `Zz.low.f` is the name `Zz.low` with `.f` applied to it. It authored fine, and later references failed with "Zz.low not found". Refused now:

```
Invalid location: module names must start with a capital, and "low" does not. A lowercase
segment is read as the item's NAME, so nothing could refer to what this would create.
```

"Not found" did not say what was not found: the same message for a typo, an unauthored name, and a path resolved from somewhere other than where you were standing. The traversal names the path now, which covers `view`, `ls` and `nav`:

```
before   Cannot view: Not found
after    Cannot view: Not found: Darklang.Stdlib.NoSuchModule
```

It reports the first segment that is missing. `view` used to add the name itself and no longer does, so it is not said twice.

`tree` ignored bad input twice: an unknown flag was filtered out along with the real ones, so `dark tree --zzbogus` printed the whole root tree, and an unresolvable path fell back to the current location. Both are refused now.