### PR TITLE
Let a published binary use the store it was pointed at

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -222,8 +222,9 @@ jobs:
           name: Run backend tests
           command: timeout 20m scripts/run-backend-tests --published
 
-      # Allocation for a fixed workload repeats to a tenth of a percent and doesn't care how loaded
-      # the box is, so it's the one performance number that can be asserted on here. Time isn't.
+      # Allocation for a fixed workload is steady enough to assert on and doesn't care how loaded
+      # the box is, which is more than can be said for time. The store is freshly loaded above, and
+      # that matters: the same binary on a working store allocates a couple of percent more.
       - run:
           name: Check the reference workload is within its allocation budget
           command: scripts/perf/gate --published

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,8 +116,10 @@ Everything perf lives in `scripts/perf/` (tools) and `docs/perf/` (writing):
 The playbook is the one to read cold. Its recurring lesson: nearly all wasted effort came from
 trusting a measurement nobody had checked.
 
-Decide with allocation, not time. Allocation for a fixed workload repeats to a tenth of a percent
-and doesn't care how loaded the box is; time drifts by more than most individual wins are worth. So
+Decide with allocation, not time. Allocation for a fixed workload is far steadier than time and
+doesn't care how loaded the box is; time drifts by more than most individual wins are worth. It is
+not byte-identical though, and the store it runs against matters as much as the binary --
+`docs/perf/playbook.md` has the measured noise floor. So
 `gate` asserts allocation and only allocation, against `scripts/perf/budget.json`, and CI runs it
 after the backend tests. When a change earns a lower number, lower the budget in the same commit
 with `scripts/perf/gate --update`, or it stops being a gate and becomes a ceiling to drift up to.

--- a/backend/src/Cli/EmbeddedResources.fs
+++ b/backend/src/Cli/EmbeddedResources.fs
@@ -24,8 +24,8 @@ let private isInstalledMode () : bool =
   let dir = exeDirectory ()
   dir.EndsWith("/.darklang/bin") || dir.EndsWith("\\.darklang\\bin")
 
-/// Gets the appropriate .darklang directory path
-let private getDarklangDirectory () : string =
+/// The .darklang directory to use when nothing says otherwise.
+let private getDefaultDarklangDirectory () : string =
   if isInstalledMode () then
     // Installed mode: use the central ~/.darklang directory
     let home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)
@@ -33,6 +33,18 @@ let private getDarklangDirectory () : string =
   else
     // Portable mode: use adjacent .darklang directory
     Path.Combine(exeDirectory (), ".darklang")
+
+/// Where this instance keeps its store, logs and local config.
+///
+/// An explicit `DARK_CONFIG_RUNDIR` wins over the default. Overwriting it instead would
+/// mean every process on a machine shares one store, so a second instance -- a throwaway
+/// store to try something in, or two binaries measured against the same data -- could not
+/// be asked for at all.
+let private getDarklangDirectory () : string =
+  match Environment.GetEnvironmentVariable "DARK_CONFIG_RUNDIR" with
+  | null
+  | "" -> getDefaultDarklangDirectory ()
+  | explicit -> explicit
 
 let private extractResource (resourceName : string) (targetPath : string) : unit =
   let assembly = Assembly.GetExecutingAssembly()

--- a/docs/perf/playbook.md
+++ b/docs/perf/playbook.md
@@ -13,9 +13,23 @@ checked.** Everything below is a way of not doing that.
 
 ## 1. Measure allocation, not time
 
-Allocation for a fixed workload repeats **to the byte** and doesn't care how loaded the machine is.
-Time on this box drifts about 12 ms, enough to hide or invent most individual wins; eleven runs
+Allocation for a fixed workload is far steadier than time and doesn't care how loaded the machine
+is. Time on this box drifts about 12 ms, enough to hide or invent most individual wins; eleven runs
 cannot reliably resolve a 10 ms difference.
+
+It is not, however, byte-identical. `steady.dark` in debug, ten runs back to back:
+
+    mean    7,343,612 bytes
+    stdev      15,969   = 0.22%
+    spread     56,504   = 0.77%
+
+So treat ~0.8% as the noise floor for a single run of this workload, and do not believe a win
+smaller than that from one measurement each side.
+
+**The store counts as part of the workload.** The same binary on a working rundir allocates about
+2.5% more than on a freshly loaded one, measured both ways: enough to swamp the noise floor and
+enough to fail the gate. `scripts/perf/gate` prints which store it measured for this reason. A
+number is only comparable to another taken against the same store.
 
 Decide with allocation, report time, never gate on time. A change that looks flat in allocation and
 good in time is flat.

--- a/scripts/perf/_bench.py
+++ b/scripts/perf/_bench.py
@@ -263,13 +263,15 @@ def fixture_save(name=None):
 def rundir_for(binary):
     """Which store a given binary actually uses.
 
-    Not always this repo's `rundir`. A published binary carries an embedded seed, and
-    `EmbeddedResources.extract()` sets DARK_CONFIG_RUNDIR to `<exe dir>/.darklang` unconditionally --
-    it ignores any value already in the environment, so this can't be redirected, only discovered.
-    A Debug build has no embedded resource, skips that branch, and uses the repo rundir.
+    An explicit DARK_CONFIG_RUNDIR wins for every binary, published or Debug, so when it is set that IS
+    the answer. `<exe dir>/.darklang` is only the default a published binary computes for itself when the
+    variable is unset, and a leftover directory next to an exe must not outrank the store we were told
+    to use.
 
     Getting this wrong silently compares two binaries against two different stores, which is how a
     harness ends up lying more convincingly than no harness at all."""
+    if os.environ.get("DARK_CONFIG_RUNDIR"):
+        return os.environ["DARK_CONFIG_RUNDIR"]
     adjacent = os.path.join(os.path.dirname(os.path.abspath(binary)), ".darklang")
     return adjacent if os.path.isdir(adjacent) else RUNDIR
 
@@ -465,7 +467,7 @@ def cmd_run(args):
         # Warmup, discarded: the first runs of a fresh binary pay JIT and page-cache costs that no later run
         # repeats, and folding them into the median makes every batch look worse than the steady state.
         for _ in range(args.warmup):
-            run_once(binary, argv, args.trace, False)
+            run_once(binary, argv, args.trace, False, fixture_path(args.fixture))
 
         samples = []
         for i in range(args.n):

--- a/scripts/perf/_common
+++ b/scripts/perf/_common
@@ -18,13 +18,11 @@ release_exe() {
   ls -t "${RELEASE_EXE_PATHS[@]}" 2>/dev/null | head -1 || true
 }
 
-# Where a given binary writes its telemetry. A published binary resolves its log directory relative
-# to its own location rather than to DARK_CONFIG_RUNDIR, so the two build modes disagree.
-telemetry_for() {
-  case "$1" in
-  backend/Build/out/Cli/Debug/*) echo "${DARK_CONFIG_RUNDIR}/logs/telemetry.jsonl" ;;
-  *) echo "$(dirname "$1")/.darklang/logs/telemetry.jsonl" ;;
-  esac
+# Where a binary writes its telemetry: under the store it is using. Published and Debug builds both
+# honour DARK_CONFIG_RUNDIR, and every perf script re-execs into the container, which sets it, so
+# there is no per-binary case here to get wrong.
+telemetry_path() {
+  echo "${DARK_CONFIG_RUNDIR}/logs/telemetry.jsonl"
 }
 
 # `$1` is the tool's name. Prints where a published CLI was looked for, since an empty path in a
@@ -35,4 +33,21 @@ no_release_exe() {
     printf '  %s\n' "${RELEASE_EXE_PATHS[@]}"
     echo "Build one with scripts/build/build-release-cli-exes.sh, or publish the solution."
   } >&2
+}
+
+# Refuse a published CLI that predates the source it is meant to contain. A stale artifact does not
+# produce a stale-looking number -- it produces a plausible one, for the previous build, and a budget
+# compared against it says nothing. `find -print -quit` stops at the first newer file, so this costs
+# nothing on a warm tree.
+assert_release_exe_fresh() {
+  local exe=$1 tool=$2 newer
+  newer=$(find packages backend/src -type f \( -name '*.dark' -o -name '*.fs' \) \
+    -newer "$exe" -print -quit 2>/dev/null || true)
+  [[ -z "$newer" ]] && return 0
+  {
+    echo "$tool: $(basename "$exe") is older than $newer."
+    echo "  It would be measured instead of your change. Rebuild it:"
+    echo "    scripts/build/build-release-cli-exes.sh"
+  } >&2
+  return 1
 }

--- a/scripts/perf/gate
+++ b/scripts/perf/gate
@@ -8,8 +8,9 @@
 #   scripts/perf/gate --published  against the published one, as CI does
 #   scripts/perf/gate --update     rewrite this mode's budget to what it measures
 #
-# Allocation, not time: it repeats to within a tenth of a percent and doesn't care how loaded the
-# machine is. Debug and published are budgeted separately, since they don't allocate the same amount.
+# Allocation, not time: it doesn't care how loaded the machine is. It is not byte-identical either --
+# see docs/perf/playbook.md for the noise floor. Debug and published are budgeted separately, since
+# they don't allocate the same amount.
 # The budget is in scripts/perf/budget.json -- lower it in the same commit that earns it.
 
 set -euo pipefail
@@ -27,6 +28,7 @@ done
 
 if [[ "$PUBLISHED" == "true" ]]; then
   EXE=$(release_exe)
+  [[ -x "$EXE" ]] && { assert_release_exe_fresh "$EXE" perf/gate || exit 2; }
 else
   EXE="backend/Build/out/Cli/Debug/net10.0/Cli"
 fi
@@ -41,7 +43,7 @@ fi
 BUDGET_FILE="scripts/perf/budget.json"
 WORKLOAD="scripts/perf/workloads/steady.dark"
 
-TELEMETRY=$(telemetry_for "$EXE")
+TELEMETRY=$(telemetry_path)
 
 # Trace detail off: a dev shell sets it on, a user's run has it off, and with it on the interpreter
 # holds every argument and result alive for the whole run.
@@ -54,6 +56,10 @@ rm -f "$TELEMETRY"
 OUTPUT=$(run_workload)
 echo "$OUTPUT" | head -c 200
 echo
+
+# The store is measured too, not just the binary: a working rundir carrying your own ops allocates a
+# couple of percent more than a freshly loaded one, which is enough to read as a regression.
+echo "store    ${DARK_CONFIG_RUNDIR}"
 
 MODE=$([[ "$PUBLISHED" == "true" ]] && echo published || echo debug)
 python3 - "$BUDGET_FILE" "$TELEMETRY" "$UPDATE" "$MODE" <<'PY'
@@ -97,9 +103,10 @@ if measured > ceiling:
     over = (measured / limit - 1) * 100
     print(f"FAIL: {over:.1f}% over budget.")
     print("If the regression is intended, raise the budget in the same commit and say why.")
+    print("If the store above is not a freshly loaded one, that alone accounts for about 2.5%.")
     sys.exit(1)
 
-if measured < limit * 0.97:
+if measured < limit * (1 - tolerance):
     under = (1 - measured / limit) * 100
     print(f"{under:.1f}% under budget -- lower it with `scripts/perf/gate --update`.")
 PY

--- a/scripts/perf/suite
+++ b/scripts/perf/suite
@@ -49,7 +49,7 @@ else
   EXE="backend/Build/out/Cli/Debug/net10.0/Cli"
   MODE=debug
 fi
-TELEMETRY=$(telemetry_for "${EXE:-.}")
+TELEMETRY=$(telemetry_path)
 
 if [[ ! -x "$EXE" ]]; then
   if [[ "$RELEASE" == "true" ]]; then no_release_exe perf/suite

--- a/scripts/testing/validate-cli-artifact
+++ b/scripts/testing/validate-cli-artifact
@@ -25,9 +25,10 @@
 # Both times the tell was output (`ls` printing 5 lines where the other printed
 # 7), not timing or exit status.
 #
-# Each artifact gets its own DARKLANG_HOME. Two binaries sharing one .darklang
-# directory corrupt the store outright ("database disk image is malformed"),
-# which is its own way to produce a confidently wrong result.
+# Each artifact gets its own HOME, which is what decides where an installed-mode
+# binary keeps its store. Two binaries sharing one .darklang directory corrupt
+# the store outright ("database disk image is malformed"), which is its own way
+# to produce a confidently wrong result.
 
 set -euo pipefail
 
@@ -178,6 +179,29 @@ else
   echo "  ok   eval outside the checkout"
 fi
 rm -rf "$OUTSIDE"
+
+echo ""
+echo "The store it was pointed at:"
+
+# A published binary carries an embedded seed and, told nothing, extracts it beside
+# itself. An explicit DARK_CONFIG_RUNDIR has to win over that default, or every
+# process on a machine shares one store and a second instance cannot be asked for.
+NAMED=$(mktemp -d /tmp/dark-artifact-store.XXXXXX)
+cp "$ARTIFACT" "$NAMED/dark"
+named_rc=0
+named_out=$( cd "$NAMED" && HOME="$NAMED" DARK_CONFIG_RUNDIR="$NAMED/named" \
+  ./dark eval "1 + 2" 2>&1 ) || named_rc=$?
+if [[ $named_rc -ne 0 || ! -f "$NAMED/named/data.db" ]]; then
+  echo "  FAIL store follows DARK_CONFIG_RUNDIR (exit $named_rc)"
+  echo "$named_out" | tail -15 | indent
+  failures=$((failures + 1))
+elif [[ -e "$NAMED/.darklang/data.db" ]]; then
+  echo "  FAIL store follows DARK_CONFIG_RUNDIR (seeded .darklang beside the exe too)"
+  failures=$((failures + 1))
+else
+  echo "  ok   store follows DARK_CONFIG_RUNDIR"
+fi
+rm -rf "$NAMED"
 
 echo ""
 echo "Dark CLI test suite:"


### PR DESCRIPTION
A published binary ignored `DARK_CONFIG_RUNDIR`. `EmbeddedResources.extract` computed its own default and overwrote the variable before anything read it, so it worked in a Debug build and did nothing in a shipped one.

```
before   DARK_CONFIG_RUNDIR=/tmp/store dark eval "1 + 2"   ->  store lands in <exe dir>/.darklang
after    same command                                      ->  store lands in /tmp/store
```

The default still applies when it's unset. `validate-cli-artifact` covers it.

The perf scripts had grown around the old behaviour, so `rundir_for` and `telemetry_for` get simpler. Three other bugs in them:

- the warmup run ignored `--fixture`, and could restore a fixture over the store the measured runs used
- `gate` hardcoded `0.97` while reading `tolerance` from `budget.json`
- `gate --published` measured whatever published CLI it found, however old. It refuses a stale one now.

Two doc corrections, both measured: allocation doesn't "repeat to the byte" (0.77% spread over ten runs), and the store counts as part of the workload (~2.5% between a working rundir and a freshly loaded one). `gate` prints the store it measured. Budgets are unchanged.