### PR TITLE
Refuse arguments the CLI doesn't understand

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,10 +92,38 @@ tell you the tree has moved on rather than silently running a stale binary.
 Find what you want before guessing at a filter: `--groups` and `--find` need no
 database and no package reload, and print the exact command for what they found.
 
-The one trap worth knowing here: a filter that matches nothing used to be reported as
-`0 tests run - Success!` with exit 0. It fails now. `docs/unittests.md` has the rest,
-including what the three filter flags actually do and why they used to disagree with
-their own help text.
+`run-backend-tests` does NOT compile. It reloads packages and runs the test binary that is
+already there, so an `.fs` change you have not built yet is simply not in the run. It looks
+exactly like a pass, and a red test you "fixed" stays red with its old message, which is the
+tell. Build first:
+
+    scripts/dev/build && ./scripts/run-backend-tests
+
+The other trap: a filter that matches nothing used to be reported as `0 tests run - Success!`
+with exit 0. It fails now. `docs/unittests.md` has the rest, including what the three filter
+flags actually do and why they used to disagree with their own help text.
+
+### Sweeping the CLI after a change
+
+A Dark call site is not type-checked until it executes, so a rename or a type change across
+`packages/` leaves holes a green suite cannot see. The bugs that get found here are found by
+running commands, not by reading them, and always the same four ways:
+
+1. every command BARE
+2. every command with `--help`
+3. every command with valid arguments
+4. every command with arguments a person would get wrong (missing, misspelled, wrong type)
+
+Grep the output for `Encountered a Runtime Error`, `expects .* but got`, `No matching case
+found`, `couldn't be found`. Shape 4 is the one people skip and it finds the most: a
+fall-through arm answers plausibly instead of refusing, so `dark commits zzznope` listed
+main's commits as though nothing had been asked.
+
+Shapes 2 and 4 are automated in `CliTraces.Tests.fs`, driven off the command registry rather
+than a list, so a new command is swept the day it is registered. A command that must not be
+RUN goes in `notSweepable` there, with the reason; a name in that list that is no longer
+registered fails its own test, because an exclusion nobody revisits is how a sweep quietly
+stops covering the thing it was written for.
 
 ### Performance
 

--- a/backend/tests/Tests/CliTraces.Tests.fs
+++ b/backend/tests/Tests/CliTraces.Tests.fs
@@ -93,6 +93,23 @@ let private runCli (state : RT.ExecutionState) (args : string list) : Task<strin
   }
 
 
+/// `runCli`, but a runtime error is a result rather than the end of the test.
+///
+/// For the sweeps below: one command that throws must not stop the other sixty from being
+/// checked, and WHICH command threw is the finding, so it has to come back as a value.
+let private runCliCatching
+  (state : RT.ExecutionState)
+  (args : string list)
+  : Task<Result<string, string>> =
+  task {
+    try
+      let! output = runCli state args
+      return Ok output
+    with e ->
+      return Error(e.Message.Split('\n')[0])
+  }
+
+
 /// Helper: extract the trace ID from a `traces list 1 --json` output.
 let private parseTraceID (json : string) : string =
   let split = json.Split("\"traceId\":\"")
@@ -877,6 +894,242 @@ let private testTracesTruncatedStillShowsRoot =
   }
 
 
+// ─── Command sweeps ───────────────────────────────────────────────────────
+//
+// Every test above names one command. These name none: they ask the registry what exists and
+// hold all of it to one rule, so a command nobody wrote a test for is still covered, and so is
+// the next one somebody adds.
+
+/// Every command the CLI registry knows about, read out of `dark help`.
+let private registeredCommands (state : RT.ExecutionState) : Task<List<string>> =
+  task {
+    let! output = runCli state [ "help" ]
+
+    return
+      output.Split('\n')
+      |> Array.toList
+      |> List.choose (fun line ->
+        if line.StartsWith "  " && line.Contains " - " then
+          let name = line.Trim().Split(' ')[0]
+          if name = "" || name.StartsWith "-" then None else Some name
+        else
+          None)
+      |> List.distinct
+  }
+
+/// Phrases that mean "you used this wrong". A request for HELP must never be answered with one.
+///
+/// Deliberately NOT "usage:" or "required": both appear in good help text, and a check that flags
+/// them flags forty commands and gets switched off.
+let private soundsLikeMisuse (output : string) : bool =
+  let o = output.ToLower()
+  [ "error:"
+    "internal error"
+    "is not a valid"
+    "unknown topic"
+    "unknown command" ]
+  |> List.exists (fun phrase -> o.Contains phrase)
+
+/// Commands the sweeps must not RUN, because running them is the problem: they take over the
+/// screen, rewrite the install, end the session or reach the network.
+///
+/// Asserted to be registered, below. An exclusion for a command that no longer exists is how a
+/// sweep quietly stops covering the thing it was written for.
+let private notSweepable =
+  Set.ofList
+    [ "quit"
+      "install"
+      "uninstall"
+      "update"
+      "install-status"
+      "serve"
+      "outliner"
+      "views"
+      "text-editor"
+      "apps"
+      "login"
+      "logout"
+      "export-seed"
+      "devices"
+      "clear"
+      "agent" ]
+
+let private everyExclusionIsReal =
+  cliTest "every command excluded from the sweeps still exists" (fun state ->
+    task {
+      let! commands = registeredCommands state
+      Expect.isGreaterThan (List.length commands) 20 "the registry was read"
+
+      let registered = Set.ofList commands
+      let stale = Set.difference notSweepable registered
+
+      if not (Set.isEmpty stale) then
+        Tests.failtestf
+          "excluded from the sweeps but no longer registered: %s"
+          (stale |> Set.toList |> String.concat ", ")
+    })
+
+/// `--help`, not a bare `help`: the flag is handled centrally, so every command answers it,
+/// while a bare `help` is an ordinary argument. `dark fn help` authors a function called `help`,
+/// and that is the documented shape rather than an oversight.
+let private everyCommandAnswersHelp =
+  cliTest "every registered command answers `--help` with help" (fun state ->
+    task {
+      let! commands = registeredCommands state
+      let mutable failures : List<string * string> = []
+
+      for cmd in commands do
+        if not (Set.contains cmd notSweepable) then
+          match! runCliCatching state [ cmd; "--help" ] with
+          | Error e -> failures <- (cmd, $"crashed: {e}") :: failures
+          | Ok output ->
+            if output = "" then
+              failures <- (cmd, "printed nothing") :: failures
+            elif soundsLikeMisuse output then
+              failures <- (cmd, output.Split('\n')[0]) :: failures
+
+      // Reported together: when this breaks it breaks for a whole family at once, and finding
+      // that out one re-run at a time is the slow way.
+      if not (List.isEmpty failures) then
+        let detail =
+          failures
+          |> List.rev
+          |> List.map (fun (c, why) -> $"  dark {c} --help -> {why}")
+          |> String.concat "\n"
+
+        Tests.failtestf "commands that don't answer `--help`:\n%s" detail
+    })
+
+let private everyCommandRefusesABogusArgument =
+  cliTest
+    "no registered command ignores an argument that means nothing"
+    (fun state ->
+      task {
+        let! commands = registeredCommands state
+        let mutable failures : List<string * string> = []
+
+        for cmd in commands do
+          if not (Set.contains cmd notSweepable) then
+            // Saying nothing is the failure this catches. A command that silently drops an
+            // argument it did not understand looks exactly like one that did what you asked.
+            match! runCliCatching state [ cmd; "zzz-no-such-thing-zzz" ] with
+            | Error e -> failures <- (cmd, $"crashed: {e}") :: failures
+            | Ok output ->
+              if output.Trim() = "" then
+                failures <- (cmd, "said nothing") :: failures
+
+        if not (List.isEmpty failures) then
+          let detail =
+            failures
+            |> List.rev
+            |> List.map (fun (c, why) ->
+              $"  dark {c} zzz-no-such-thing-zzz -> {why}")
+            |> String.concat "\n"
+
+          Tests.failtestf
+            "commands that ignore an argument they don't understand:\n%s"
+            detail
+      })
+
+/// A dash-led argument is a mistyped flag, never a name.
+///
+/// `create` and `rename` are the two that WRITE the name they are given, so they are the two
+/// where taking it leaves something behind to find and clean up afterwards.
+let private aDashLedArgumentIsNeverAName =
+  cliTest
+    "a dash-led argument is refused as a name rather than taken as one"
+    (fun state ->
+      task {
+        let! created = runCli state [ "branch"; "create"; "--zzz-not-a-branch" ]
+        Expect.stringContains
+          created
+          "starts with a dash"
+          "branch create should refuse it"
+
+        let! renamed =
+          runCli state [ "branch"; "rename"; "main"; "--zzz-not-a-branch" ]
+        Expect.stringContains
+          renamed
+          "starts with a dash"
+          "branch rename should refuse it"
+
+        let! branches = runCli state [ "branch"; "list" ]
+
+        Expect.isFalse
+          (branches.Contains "--zzz-not-a-branch")
+          "and neither may leave a branch behind"
+      })
+
+/// Commands that take a target, given one that does not exist.
+///
+/// The rule: SAY WHICH THING you could not find. "Cannot merge main branch" is what `merge`
+/// answered for any argument at all, so a typo read as a fact about your branch rather than as
+/// a command that never ran.
+///
+/// Rows for commands that do not exist on main yet are kept here, commented, rather than
+/// deleted: they are re-enabled by removing the `//` when the command lands, which is a thing
+/// the next person can do without knowing this list was ever longer.
+///     "conflicts branch", [ "conflicts"; "branch"; "zzznope" ]
+///     "review approve",   [ "review"; "approve"; "zzznope" ]
+///     "review reject",    [ "review"; "reject"; "zzznope" ]
+///     "propagate show",   [ "propagate"; "show"; "Zzz.Nope.nope" ]
+///     "propagate pin",    [ "propagate"; "pin"; "Zzz.Nope.nope" ]
+///     "propagate follow", [ "propagate"; "follow"; "Zzz.Nope.nope" ]
+///     "constraints resolve", [ "constraints"; "resolve"; "zzznope" ]
+///     "ack",              [ "ack"; "zzznope" ]
+let private nonexistentTargets : List<string * List<string>> =
+  [ "view", [ "view"; "Zzz.Nope.nope" ]
+    "deps", [ "deps"; "Zzz.Nope.nope" ]
+    "ls", [ "ls"; "Zzz.Nope.nope" ]
+    "nav", [ "nav"; "Zzz.Nope.nope" ]
+    "tree", [ "tree"; "Zzz.Nope.nope" ]
+    "hash", [ "hash"; "Zzz.Nope.nope" ]
+    "undo", [ "undo"; "Zzz.Nope.nope" ]
+    "deprecate", [ "deprecate"; "Zzz.Nope.nope" ]
+    "delete", [ "delete"; "Zzz.Nope.nope" ]
+    "show", [ "show"; "zzznope" ]
+    "commits", [ "commits"; "zzznope" ]
+    "merge", [ "merge"; "zzznope" ]
+    "rebase", [ "rebase"; "zzznope" ]
+    "review", [ "review"; "zzznope" ]
+    "discard", [ "discard"; "zzznope" ]
+    "conflicts", [ "conflicts"; "zzznope" ]
+    "branch switch", [ "branch"; "switch"; "zzznope" ]
+    "branch archive", [ "branch"; "archive"; "zzznope" ]
+    "branch set-default", [ "branch"; "set-default"; "zzznope" ] ]
+
+let private missingTargetsAreNamed =
+  cliTest "a command that can't find its target says which target" (fun state ->
+    task {
+      let mutable failures : List<string * string> = []
+
+      for (label, args) in nonexistentTargets do
+        let! result = runCliCatching state args
+        let output = result |> Result.defaultValue ""
+        let target = args |> List.last |> Option.defaultValue ""
+
+        // The first segment, not the whole target: a traversal stops at the first segment it
+        // cannot find, so `Zzz.Nope.nope` is answered with `Zzz`.
+        let firstSegment = target.Split('.')[0]
+
+        if output.Trim() = "" then
+          failures <- (label, "said nothing") :: failures
+        elif not (output.Contains firstSegment) then
+          failures <- (label, output.Split('\n')[0]) :: failures
+
+      if not (List.isEmpty failures) then
+        let detail =
+          failures
+          |> List.rev
+          |> List.map (fun (c, why) -> $"  dark {c} <missing> -> {why}")
+          |> String.concat "\n"
+
+        Tests.failtestf
+          "commands that don't say what they couldn't find:\n%s"
+          detail
+    })
+
+
 let tests =
   testSequenced
   <| testList
@@ -922,4 +1175,10 @@ let tests =
       testTracesArity1Catchalls
       testTracesRouteEmptyRejection
       testTracesFindEscapesLikeWildcards
-      testTracesTruncatedStillShowsRoot ]
+      testTracesTruncatedStillShowsRoot
+      // Command sweeps
+      everyExclusionIsReal
+      everyCommandAnswersHelp
+      everyCommandRefusesABogusArgument
+      aDashLedArgumentIsNeverAName
+      missingTargetsAreNamed ]

--- a/packages/darklang/cli/conflicts.dark
+++ b/packages/darklang/cli/conflicts.dark
@@ -295,7 +295,12 @@ let execute (state: AppState) (args: List<String>) : AppState =
 
       $"OK — {c.location} will be {theirs}, not {mine}   (syncs to your peers)")
 
-  | _ ->
+  // Printing help alone reads as an answer: `conflicts zzznope` looked exactly like
+  // `conflicts --help`, so a typo passed for a command that ran and found nothing.
+  | bad :: _ ->
+    Stdlib.printLine
+      (Stdlib.Cli.UI.Colors.error $"conflicts does not understand `{bad}`.")
+
     Stdlib.printLine (help state)
     state
 

--- a/packages/darklang/cli/core.dark
+++ b/packages/darklang/cli/core.dark
@@ -76,6 +76,46 @@ type AppState =
 let locationStr (state: AppState) : String =
   Packages.formatLocation state.packageData.currentLocation
 
+/// Refuse arguments a command does not understand, naming the first and the rest.
+///
+/// A command that picks out its flags with `List.member` and drops the rest answers
+/// a typo as though you had typed nothing: `dark commits zzznope` listed main's
+/// commits, which reads as an answer about `zzznope`. Returns whether it refused, so
+/// the caller stops.
+let refuseUnknownArgs
+  (command: String)
+  (understood: String)
+  (isKnown: String -> Bool)
+  (args: List<String>)
+  : Bool =
+  let unknown = args |> Stdlib.List.filter (fun a -> Stdlib.Bool.not (isKnown a))
+
+  match unknown with
+  | [] -> false
+  | bad :: _ ->
+    Stdlib.printLine
+      (Stdlib.Cli.UI.Colors.error $"{command} does not understand `{bad}`.")
+
+    Stdlib.printLine (Stdlib.Cli.UI.Colors.hint $"  {understood}")
+    true
+
+
+/// Refuse a dash-led argument where a name belongs.
+///
+/// A leading dash means someone mistyped a flag; it is never a name anyone meant
+/// to use. Taken as one it creates a branch called `--frce` that then has to be
+/// found and archived.
+let refuseDashLedName (kind: String) (name: String) : Bool =
+  if Stdlib.String.startsWith name "-" then
+    Stdlib.printLine
+      (Stdlib.Cli.UI.Colors.error
+        $"\"{name}\" starts with a dash, so it's a flag rather than a {kind} name.")
+
+    true
+  else
+    false
+
+
 /// Takes the command list rather than calling `Registry.allCommands ()` itself: `initState` needs both the
 /// list and the options, and building the list is 60 records of 6 fields including 3 fn refs each. Calling it
 /// twice per process start was pure duplicate work, on every invocation including `dark version`.

--- a/packages/darklang/cli/packages/deprecate.dark
+++ b/packages/darklang/cli/packages/deprecate.dark
@@ -137,8 +137,20 @@ let execute (state: Cli.AppState) (args: List<String>) : Cli.AppState =
     Stdlib.printLine (help state)
     state
 
-  | (Some _, None, _) ->
-    Stdlib.printLine (Stdlib.Cli.UI.Colors.error "Error: Missing target (location or hash)")
+  // The first positional is the KIND, so a lone dotted name lands here. Reporting
+  // only the missing target sends you looking for an argument you already gave.
+  | (Some itemType, None, _) ->
+    match Propagate.itemKindFromString itemType with
+    | Some _ ->
+      Stdlib.printLine
+        (Stdlib.Cli.UI.Colors.error
+          $"Error: Missing target (location or hash) after '{itemType}'")
+    | None ->
+      Stdlib.printLine
+        (Stdlib.Cli.UI.Colors.error
+          ($"Error: '{itemType}' is not a valid item kind. "
+           ++ "Expected fn, type, or value."))
+
     state
 
   | (_, _, None) ->

--- a/packages/darklang/cli/packages/hash.dark
+++ b/packages/darklang/cli/packages/hash.dark
@@ -34,7 +34,10 @@ let execute (state: Cli.AppState) (args: List<String>) : Cli.AppState =
         Stdlib.printLine $"{kindStr} {formatHash hash long}"
         state
       | None ->
-        Stdlib.printLine (Stdlib.Cli.UI.Colors.error "Not found at this location")
+        let looked =
+          PrettyPrinter.ProgramTypes.PackageLocation.packageLocation location
+
+        Stdlib.printLine (Stdlib.Cli.UI.Colors.error $"Not found: {looked}")
         state
 
 let help (_state: Cli.AppState) : String =

--- a/packages/darklang/cli/packages/tree.dark
+++ b/packages/darklang/cli/packages/tree.dark
@@ -149,22 +149,19 @@ let execute (state: AppState) (args: List<String>): AppState =
       || (a == "--include-deprecated")
       || (Stdlib.String.startsWith a "--depth=")
 
-    let unknownFlags =
-      args
-      |> Stdlib.List.filter (fun a ->
-        (Stdlib.String.startsWith a "--") && (Stdlib.Bool.not (knownFlag a)))
+    // A bare word here is the path, so only flags are checked.
+    let known =
+      (fun a -> (Stdlib.Bool.not (Stdlib.String.startsWith a "--")) || (knownFlag a))
 
-    match unknownFlags with
-    | bad :: _ ->
-      Stdlib.printLine
-        (Stdlib.Cli.UI.Colors.error $"tree does not understand `{bad}`.")
-
-      Stdlib.printLine
-        (Stdlib.Cli.UI.Colors.hint
-          "  flags: --depth=N, --toc, --include-deprecated")
-
+    if
+      Cli.refuseUnknownArgs
+        "tree"
+        "flags: --depth=N, --toc, --include-deprecated"
+        known
+        args
+    then
       state
-    | [] ->
+    else
 
     // Refused, not ignored: falling back to the current location answers a different
     // question, and says nothing about the path you gave.

--- a/packages/darklang/cli/packages/undo.dark
+++ b/packages/darklang/cli/packages/undo.dark
@@ -49,8 +49,19 @@ let execute (state: Cli.AppState) (args: List<String>) : Cli.AppState =
     Stdlib.printLine (help state)
     state
 
-  | [itemType] ->
-    Stdlib.printLine (Stdlib.Cli.UI.Colors.error "Error: Missing name argument")
+  // `undo` takes a KIND then a name, so a lone dotted name is read as the kind.
+  // Saying only "missing name" sends you looking for an argument you already gave.
+  | [ itemType ] ->
+    match Propagate.itemKindFromString itemType with
+    | Some _ ->
+      Stdlib.printLine
+        (Stdlib.Cli.UI.Colors.error
+          $"Error: Missing name argument after '{itemType}'")
+    | None ->
+      Stdlib.printLine
+        (Stdlib.Cli.UI.Colors.error
+          ($"Error: '{itemType}' is not a valid item kind. "
+           ++ "Expected fn, type, or value."))
     Stdlib.printLine ""
     Stdlib.printLine "Usage: undo <fn|type|value> <name> [--yes|-y]"
     state

--- a/packages/darklang/cli/scm/branch.dark
+++ b/packages/darklang/cli/scm/branch.dark
@@ -152,6 +152,10 @@ let execute (state: AppState) (args: List<String>) : AppState =
     state
 
   | [ "create"; name ] ->
+    if Cli.refuseDashLedName "branch" name then
+      state
+    else
+
     let newBranch = SCM.Branch.create name state.currentBranchId
     Stdlib.printLine (Stdlib.Cli.UI.Colors.success $"Created and switched to branch '{name}'")
     if state.nonInteractive then
@@ -204,6 +208,10 @@ let execute (state: AppState) (args: List<String>) : AppState =
     state
 
   | [ "rename"; oldName; newName ] ->
+    if Cli.refuseDashLedName "branch" newName then
+      state
+    else
+
     match SCM.Branch.getByName oldName with
     | Some b ->
       match SCM.Branch.rename b.id newName with

--- a/packages/darklang/cli/scm/discard.dark
+++ b/packages/darklang/cli/scm/discard.dark
@@ -2,6 +2,16 @@ module Darklang.Cli.SCM.Discard
 
 
 let execute (state: AppState) (args: List<String>) : AppState =
+  let known =
+    (fun a -> (a == "--yes") || (a == "-y"))
+
+  let understood =
+    "flags: --yes (-y). Discards all uncommitted work; `undo <name>` takes one."
+
+  if Cli.refuseUnknownArgs "discard" understood known args then
+    state
+  else
+
   let branchId = state.currentBranchId
 
   let autoConfirm =

--- a/packages/darklang/cli/scm/log.dark
+++ b/packages/darklang/cli/scm/log.dark
@@ -41,6 +41,20 @@ let renderDetailed (c: SCM.PackageOps.Commit) (isAncestor: Bool) (long: Bool) : 
   Stdlib.printLine ""
 
 let execute (state: AppState) (args: List<String>) : AppState =
+  let known =
+    (fun a ->
+      (Stdlib.String.startsWith a "--")
+      || (match Stdlib.Int.parse a with
+          | Ok _ -> true
+          | Error _ -> false))
+
+  let understood =
+    "flags: --detailed, --full, --long; or a number of commits to show"
+
+  if Cli.refuseUnknownArgs "commits" understood known args then
+    state
+  else
+
   let branchId = state.currentBranchId
   let detailed =
     (Stdlib.List.member args "--detailed") || (Stdlib.List.member args "--full")

--- a/packages/darklang/cli/scm/merge.dark
+++ b/packages/darklang/cli/scm/merge.dark
@@ -2,6 +2,13 @@ module Darklang.Cli.SCM.Merge
 
 
 let execute (state: AppState) (args: List<String>) : AppState =
+  let known =
+    (fun a -> (a == "--dry-run") || (a == "-n"))
+
+  if Cli.refuseUnknownArgs "merge" "flags: --dry-run (-n)" known args then
+    state
+  else
+
   let dryRun =
     (Stdlib.List.member args "--dry-run") || (Stdlib.List.member args "-n")
 

--- a/packages/darklang/cli/scm/rebase.dark
+++ b/packages/darklang/cli/scm/rebase.dark
@@ -2,6 +2,13 @@ module Darklang.Cli.SCM.Rebase
 
 
 let execute (state: AppState) (args: List<String>) : AppState =
+  let known =
+    (fun a -> (a == "--status") || (a == "-s"))
+
+  if Cli.refuseUnknownArgs "rebase" "flags: --status (-s)" known args then
+    state
+  else
+
   let showStatus =
     (Stdlib.List.member args "--status") || (Stdlib.List.member args "-s")
 

--- a/packages/darklang/cli/scm/review/app.dark
+++ b/packages/darklang/cli/scm/review/app.dark
@@ -710,6 +710,13 @@ let printAllBranches () : Unit =
 
 
 let execute (cliState: Darklang.Cli.AppState) (args: List<String>) : Darklang.Cli.AppState =
+  let known =
+    (fun a -> a == "--all")
+
+  if Cli.refuseUnknownArgs "review" "flags: --all" known args then
+    cliState
+  else
+
   let branchId = cliState.currentBranchId
   let showAll = Stdlib.List.member args "--all"
 

--- a/packages/darklang/cli/scm/showCommit.dark
+++ b/packages/darklang/cli/scm/showCommit.dark
@@ -27,7 +27,8 @@ let execute (state: AppState) (args: List<String>) : AppState =
         match matching with
         | [ c ] -> LanguageTools.ProgramTypes.hashToString c.hash
         | [] ->
-          Stdlib.printLine (Stdlib.Cli.UI.Colors.error "No matching commit found.")
+          Stdlib.printLine
+            (Stdlib.Cli.UI.Colors.error $"No commit matches `{commitHashStr}`.")
           commitHashStr
         | _ ->
           Stdlib.printLine (Stdlib.Cli.UI.Colors.error "Multiple commits match that prefix. Be more specific.")


### PR DESCRIPTION
Nine commands took an argument they had no use for and answered as though you'd typed nothing.

```
before   dark commits zzznope   ->  Commits on main (1, newest first): ...
after                           ->  commits does not understand `zzznope`.
```

`dark merge zzznope` said "Cannot merge main branch", a fact about where you're standing rather than about what you asked. `dark conflicts zzznope` printed help, indistinguishable from `--help`.

`tree` already refused unknown flags, so that wording moves into a shared `Cli.refuseUnknownArgs`; `commits`, `merge`, `rebase`, `review`, `discard` and `conflicts` are new callers.

A dash-led argument was also taken as a name: `dark branch create --frce` created a branch called `--frce`, and `rename` accepted one. Those two write the name they're given; `--help` is intercepted centrally and never reached this.

Three more didn't say what they couldn't find. `hash` and `show` name it now. `undo` and `deprecate` reported a missing argument when one was given -- the first positional is the item kind, so a lone dotted name landed there.

Two sweeps in `CliTraces.Tests.fs` cover all of it, driven off the command registry rather than a list, so a command added later is swept without anyone remembering. Commands that must not run go in `notSweepable` with a reason, and a stale name there fails its own test.

`AGENTS.md` gains the four-shape sweep as a method, and the trap that `run-backend-tests` doesn't compile: an `.fs` change you haven't built is absent from the run and looks exactly like a pass.