### PR TITLE
Some gaps in the stdlib

### DIFF
--- a/backend/testfiles/execution/stdlib/http.dark
+++ b/backend/testfiles/execution/stdlib/http.dark
@@ -151,6 +151,32 @@ module QueryParams =
       { url = "/s?a=1?b=2"; headers = []; body = Stdlib.Blob.empty })) = [ ("a", "1?b=2") ]
 
 
+module RequestHeader =
+  // Case-insensitive, as HTTP requires: one stored casing, three asked-for casings.
+  (Stdlib.Http.Request.header
+    (Stdlib.Http.Request
+      { url = "/"; headers = [ ("Authorization", "Bearer t") ]; body = Stdlib.Blob.empty })
+    "authorization") = Stdlib.Option.Option.Some "Bearer t"
+
+  (Stdlib.Http.Request.header
+    (Stdlib.Http.Request
+      { url = "/"; headers = [ ("authorization", "Bearer t") ]; body = Stdlib.Blob.empty })
+    "AUTHORIZATION") = Stdlib.Option.Option.Some "Bearer t"
+
+  (Stdlib.Http.Request.header
+    (Stdlib.Http.Request
+      { url = "/"; headers = [ ("X-Thing", "v") ]; body = Stdlib.Blob.empty })
+    "x-other") = Stdlib.Option.Option.None
+
+  // A repeated header is legal. The first wins, which is what `queryParam` does too.
+  (Stdlib.Http.Request.header
+    (Stdlib.Http.Request
+      { url = "/"
+        headers = [ ("Accept", "one"); ("accept", "two") ]
+        body = Stdlib.Blob.empty })
+    "Accept") = Stdlib.Option.Option.Some "one"
+
+
 module ParseHeaders =
   Stdlib.Http.parseHeaders "x: y" = Stdlib.Dict.fromListOverwritingDuplicates [ ("x", "y") ]
 

--- a/backend/testfiles/execution/stdlib/httpserver.dark
+++ b/backend/testfiles/execution/stdlib/httpserver.dark
@@ -1,0 +1,25 @@
+// `Stdlib.HttpServer`'s pure helpers. The `.test` files under `backend/testfiles/http-server/`
+// drive `serve` end to end; these cover the pieces it is built from, which nothing reached
+// before.
+
+module GetMethod =
+  // The method rides in `x-http-method`, and the header name is matched case-insensitively,
+  // so a client that capitalises it differently still gets its method honoured.
+  (Stdlib.HttpServer.getMethod (
+    Stdlib.Http.Request
+      { url = "/"; headers = [ ("x-http-method", "POST") ]; body = Stdlib.Blob.empty })) =
+    "POST"
+
+  (Stdlib.HttpServer.getMethod (
+    Stdlib.Http.Request
+      { url = "/"; headers = [ ("X-Http-Method", "DELETE") ]; body = Stdlib.Blob.empty })) =
+    "DELETE"
+
+  // No header at all means GET, which is what a browser sends.
+  (Stdlib.HttpServer.getMethod (
+    Stdlib.Http.Request { url = "/"; headers = []; body = Stdlib.Blob.empty })) = "GET"
+
+  // An unrelated header is not the method.
+  (Stdlib.HttpServer.getMethod (
+    Stdlib.Http.Request
+      { url = "/"; headers = [ ("Accept", "text/html") ]; body = Stdlib.Blob.empty })) = "GET"

--- a/backend/testfiles/execution/stdlib/list.dark
+++ b/backend/testfiles/execution/stdlib/list.dark
@@ -317,6 +317,14 @@ Stdlib.List.unique [ 1L; 1L; 1L; 1L ] = [ 1L ]
 Stdlib.List.unique [ 7L; 42L; 7L; 2L; 10L ] = [ 2L; 7L; 10L; 42L ]
 Stdlib.List.unique [] = []
 
+// `dedup` keeps the FIRST occurrence where it was. Compare the `unique` cases just above:
+// same input, sorted output. That difference is the whole reason it exists.
+Stdlib.List.dedup [ 7L; 42L; 7L; 2L; 10L ] = [ 7L; 42L; 2L; 10L ]
+Stdlib.List.dedup [ 1L; 1L; 1L; 1L ] = [ 1L ]
+Stdlib.List.dedup [ 1L; 2L; 3L; 4L ] = [ 1L; 2L; 3L; 4L ]
+Stdlib.List.dedup [] = []
+Stdlib.List.dedup [ "b"; "a"; "b"; "a" ] = [ "b"; "a" ]
+
 module Zipping =
   // TODO: more tests, with values of more complex types
   Stdlib.List.unzip [ (1L, 10L); (2L, 20L); (3L, 30L) ] = ([ 1L; 2L; 3L ], [ 10L; 20L; 30L ])

--- a/backend/testfiles/execution/stdlib/sqlite.dark
+++ b/backend/testfiles/execution/stdlib/sqlite.dark
@@ -13,6 +13,28 @@ module CreateRead =
    let _ = Stdlib.Sqlite.execP db "INSERT INTO t (id, name) VALUES (@p0, @p1)" [ "2"; "bob" ]
    Stdlib.Sqlite.column db "SELECT name FROM t ORDER BY id" "name") = [ "o'brien"; "bob" ]
 
+// A BLOB column comes back as `Bytes`, and `asBytes` is how you get it out. The `Value`
+// type carries blobs through rather than stringifying them; without an accessor a caller
+// matches the case by hand, which is where a stringified blob comes from.
+module Blobs =
+  (let db = "/tmp/dark-test-sqlite-blob.db"
+   let _ = Stdlib.Sqlite.exec db "DROP TABLE IF EXISTS t"
+   let _ = Stdlib.Sqlite.exec db "CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT)"
+   let _ = Stdlib.Sqlite.execP db "INSERT INTO t (id, name) VALUES (@p0, @p1)" [ "1"; "hi" ]
+
+   match Stdlib.Sqlite.query db "SELECT CAST(name AS BLOB) AS b FROM t" with
+   | Ok [ row ] ->
+     match Stdlib.Dict.get row "b" with
+     | Some v ->
+       Stdlib.Sqlite.asBytes v
+       |> Stdlib.Option.map (fun b -> Stdlib.String.fromBytesWithReplacement (Stdlib.Blob.toList b))
+     | None -> Stdlib.Option.Option.None
+   | _ -> Stdlib.Option.Option.None) = Stdlib.Option.Option.Some "hi"
+
+  // A TEXT cell is not a blob, and asking for one says so rather than coercing.
+  Stdlib.Sqlite.asBytes (Stdlib.Sqlite.Value.Text "hi") = Stdlib.Option.Option.None
+
+
 // UPDATE + DELETE — final state after renaming id=1 and removing id=2 is just ["updated"].
 module UpdateDelete =
   (let db = "/tmp/dark-test-sqlite-b.db"

--- a/packages/darklang/stdlib/http.dark
+++ b/packages/darklang/stdlib/http.dark
@@ -111,6 +111,29 @@ module Request =
           (Stdlib.Http.urlDecode key,
            Stdlib.Http.urlDecode (Stdlib.String.join valueParts "=")))
 
+  /// The value of <param key>, matched case-INSENSITIVELY, as HTTP requires: a client
+  /// may send `Authorization`, `authorization` or `AUTHORIZATION` and all three mean the
+  /// same header. A case-sensitive lookup reads as "the client didn't send it", which for
+  /// an auth check refuses a request that was perfectly well formed.
+  ///
+  /// The first match wins. A repeated header is legal and means a list, which no caller
+  /// here wants yet; taking the first is the same choice <fn queryParam> makes.
+  let header
+    (req: Stdlib.Http.Request)
+    (key: String)
+    : Stdlib.Option.Option<String> =
+    let wanted = Stdlib.String.toLowercase key
+
+    req.headers
+    |> Stdlib.List.filterMap (fun pair ->
+      let (k, v) = pair
+
+      if (Stdlib.String.toLowercase k) == wanted then
+        Stdlib.Option.Option.Some v
+      else
+        Stdlib.Option.Option.None)
+    |> Stdlib.List.head
+
   let queryParam
     (req: Stdlib.Http.Request)
     (key: String)

--- a/packages/darklang/stdlib/httpserver.dark
+++ b/packages/darklang/stdlib/httpserver.dark
@@ -132,15 +132,7 @@ let findHandler
 
 /// Get the HTTP method from a request (from x-http-method header)
 let getMethod (req: Http.Request) : String =
-  let found =
-    req.headers
-    |> List.findFirst (fun pair ->
-      let (key, _) = pair
-      String.toLowercase key == "x-http-method")
-
-  match found with
-  | Some ((_, value)) -> value
-  | None -> "GET"
+  Http.Request.header req "x-http-method" |> Option.withDefault "GET"
 
 
 /// Get the path from a request URL

--- a/packages/darklang/stdlib/list.dark
+++ b/packages/darklang/stdlib/list.dark
@@ -172,6 +172,22 @@ let uniqueBy (list: List<'a>) (fn: 'a -> 'b) : List<'a> =
 let unique (list: List<'a>) : List<'a> = Builtin.listUnique list
 
 
+/// Returns <param list> with duplicates removed, KEEPING THE ORDER: the first occurrence
+/// of each value stays where it was.
+///
+/// <fn unique> sorts and <fn uniqueBy> does not maintain order, so neither can be used
+/// where the order carries meaning. A sequence in hash order looks exactly like one in
+/// authoring order, so getting that wrong surfaces much later, as a caller reading the
+/// wrong element.
+///
+/// Quadratic: it scans what it has kept for each value. Fine for the list lengths that
+/// need ordering; reach for <fn unique> when the order does not matter.
+let dedup (list: List<'a>) : List<'a> =
+  list
+  |> fold [] (fun acc value ->
+    if member acc value then acc else pushBack acc value)
+
+
 /// Returns true if <param list> has no values
 let isEmpty (list: List<'a>) : Bool = Builtin.listIsEmpty list
 

--- a/packages/darklang/stdlib/sqlite.dark
+++ b/packages/darklang/stdlib/sqlite.dark
@@ -18,9 +18,20 @@ let asText (v: Value) : Stdlib.Option.Option<String> =
   | Text s -> Stdlib.Option.Option.Some s
   | _ -> Stdlib.Option.Option.None
 
+/// The Int64 of an <param Int> cell (Some), else None.
 let asInt (v: Value) : Stdlib.Option.Option<Int64> =
   match v with
   | Int i -> Stdlib.Option.Option.Some i
+  | _ -> Stdlib.Option.Option.None
+
+/// The Blob of a <param Bytes> cell (Some), else None -- pull a BLOB column out of a row.
+///
+/// The <type Value> type carries BLOBs through the round-trip rather than stringifying
+/// them, and this is how you get one back out. Without it a caller has to match the case
+/// by hand, which is where a stringified blob comes from.
+let asBytes (v: Value) : Stdlib.Option.Option<Blob> =
+  match v with
+  | Bytes b -> Stdlib.Option.Option.Some b
   | _ -> Stdlib.Option.Option.None
 
 


### PR DESCRIPTION
`Stdlib.List.dedup` removes duplicates and keeps the order, taking the first occurrence of each value. `unique` sorts and `uniqueBy` doesn't preserve order, so neither works where the order carries meaning: a sequence in hash order looks exactly like one in authoring order, so getting it wrong surfaces much later, as a caller reading the wrong element. It's quadratic, and the docstring says so.

`Stdlib.Http.Request.header` looks a header up case-insensitively, as HTTP requires: a client may send `Authorization`, `authorization` or `AUTHORIZATION` and all three mean the same header. The behaviour already existed, hand-rolled inside `HttpServer.getMethod` and nowhere else, so the next caller writes it again and can get it wrong. `getMethod` routes through the helper now and loses eight lines.

`Stdlib.Sqlite.asBytes` pulls a BLOB out of a row, beside the existing `asText` and `asInt`. The `Value` type already promises BLOBs survive the round-trip rather than being stringified, and there was no way to get one back out without matching the case by hand.

`getMethod` had no test -- `wasm-repl-server.dark` uses it and nothing covered it -- so this adds `backend/testfiles/execution/stdlib/httpserver.dark`, the first coverage of that module's pure helpers.