### PR TITLE
Fix three wrong messages in the CLI

### DIFF
--- a/backend/src/LibConfig/Config.fs
+++ b/backend/src/LibConfig/Config.fs
@@ -36,4 +36,5 @@ let dbName =
   | Some s -> s
   | None -> "data.db"
 
-let dbPath = $"{runDir}/{dbName}"
+// `runDir` already ends in a separator, so no slash here. This path gets printed.
+let dbPath = $"{runDir}{dbName}"

--- a/backend/tests/Tests/CliTraces.Tests.fs
+++ b/backend/tests/Tests/CliTraces.Tests.fs
@@ -1031,6 +1031,32 @@ let private everyCommandRefusesABogusArgument =
             detail
       })
 
+/// An empty grant is not a grant, and must not report that it is.
+let private capsRefusesAnEmptyGrant =
+  cliTest
+    "`caps grant` with no spec is refused rather than reported as granted"
+    (fun state ->
+      task {
+        let! refused = runCli state [ "caps"; "grant"; "" ]
+
+        Expect.stringContains
+          refused
+          "usage: caps grant"
+          "it should say how to use it"
+
+        Expect.isFalse
+          (refused.Contains "granted")
+          "and must not report a grant that did not happen"
+
+        // The guard must not swallow the working path.
+        let! granted = runCli state [ "caps"; "grant"; "http-client"; "GET" ]
+        Expect.stringContains granted "granted" "a real spec is still granted"
+
+        let! _ = runCli state [ "caps"; "clear" ]
+        ()
+      })
+
+
 /// A dash-led argument is a mistyped flag, never a name.
 ///
 /// `create` and `rename` are the two that WRITE the name they are given, so they are the two
@@ -1178,6 +1204,7 @@ let tests =
       testTracesTruncatedStillShowsRoot
       // Command sweeps
       everyExclusionIsReal
+      capsRefusesAnEmptyGrant
       everyCommandAnswersHelp
       everyCommandRefusesABogusArgument
       aDashLedArgumentIsNeverAName

--- a/packages/darklang/cli/apps/examples.dark
+++ b/packages/darklang/cli/apps/examples.dark
@@ -1,8 +1,8 @@
-/// Reference example apps — one of each kind:
+/// Reference example apps -- one of each kind:
 ///   - `heartbeat`, a daemon: claims a pidfile (via `Stdlib.Cli.Daemon`) and logs a beat every interval
 ///     until `apps stop` SIGTERMs it.
 ///   - `TextEdit`, a foreground app: `Stdlib.Cli.UI.TextField` surfaced standalone via the generic
-///     `Cli.Component` adapter — shows how a self-contained component becomes an app in a few lines.
+///     `Cli.Component` adapter -- shows how a self-contained component becomes an app in a few lines.
 module Darklang.Cli.Apps.Examples
 
 // One beat: log the time + pid, sleep the interval, recurse. `remaining` is a very large step count
@@ -19,7 +19,7 @@ let beat (name: String) (intervalMs: Int) (remaining: Int) : Int =
 
 // The daemon entrypoint: claim the pidfile (recording THIS detached process's pid), then beat forever.
 // Invoked as `Darklang.Cli.Apps.Examples.heartbeat "heartbeat"` by `apps start`. The interval is read
-// from config (`apps.<name>.intervalMs`, default 5000) — daemons take their config from cli-config.json,
+// from config (`apps.<name>.intervalMs`, default 5000) -- daemons take their config from cli-config.json,
 // not argv.
 let heartbeat (name: String) : Int =
   let intervalMs = Config.getInt ("apps." ++ name ++ ".intervalMs") 5000
@@ -64,7 +64,7 @@ module TextEdit =
     Component.launch cliState component Stdlib.Cli.UI.TextField.empty
 
   let help (_state: Cli.AppState) : String =
-    "A tiny text editor (demo) — type, Enter or Esc to exit."
+    "A tiny text editor (demo) -- type, Enter or Esc to exit."
 
   let complete
     (_state: Cli.AppState)

--- a/packages/darklang/cli/apps/views/core.dark
+++ b/packages/darklang/cli/apps/views/core.dark
@@ -20,11 +20,11 @@ type ViewEntry =
 let allViews () : List<ViewEntry> =
   [ ViewEntry
       { name = "AI Chats"
-        description = "Monitor AI coding threads — status, cost, tokens"
+        description = "Monitor AI coding threads -- status, cost, tokens"
         kind = ViewKind.AiChats }
     ViewEntry
       { name = "Package Stats"
-        description = "Package tree statistics — counts by kind and owner"
+        description = "Package tree statistics -- counts by kind and owner"
         kind = ViewKind.PackageStats }
     ViewEntry
       { name = "UI Components"

--- a/packages/darklang/cli/auth/login.dark
+++ b/packages/darklang/cli/auth/login.dark
@@ -56,7 +56,7 @@ let help (_state: AppState) : String =
     "  login              List available accounts"
     "  login <name>       Log in as that account"
     ""
-    "Logging in unblocks `commit` and other authoring actions — it records"
+    "Logging in unblocks `commit` and other authoring actions -- it records"
     "who authors each change (serving needs no login). `logout` clears it." ]
   |> Stdlib.String.join "\n"
 

--- a/packages/darklang/cli/caps/command.dark
+++ b/packages/darklang/cli/caps/command.dark
@@ -165,6 +165,16 @@ let execute (state: Cli.AppState) (args: List<String>) : Cli.AppState =
   // `caps grant <spec…>` — e.g. `grant http-client GET`, `grant file write ~/x`, `grant random`
   | "grant" :: specWords ->
     let spec = Stdlib.String.join specWords " "
+
+    // An empty spec parses as a no-op, and reporting a grant that did not happen is worse
+    // than an error on a capability surface. `caps set` refuses its empty form too.
+    if (Stdlib.String.trim spec) == "" then
+      Stdlib.printLine
+        (Stdlib.Cli.UI.Colors.error
+          "usage: caps grant <spec> -- e.g. `caps grant http-client GET`. `caps help` has the grammar.")
+      state
+    else
+
     match Command.grantSpec spec with
     | Ok() -> Stdlib.printLine (Stdlib.Cli.UI.Colors.success $"✓ granted  {spec}")
     | Error bad ->

--- a/packages/darklang/cli/http/serve.dark
+++ b/packages/darklang/cli/http/serve.dark
@@ -126,8 +126,11 @@ let execute (state: Cli.AppState) (args: List<String>) : Cli.AppState =
               [ $"Using router: {parsed.routerPath}"
                 $"Max body bytes: {maxBytesStr}"
                 ""
-                Stdlib.Cli.UI.Colors.success $"Listening on http://localhost:{portStr}" ]
+                Stdlib.Cli.UI.Colors.success
+                  $"Listening on http://localhost:{portStr}, and on every interface" ]
 
+            // It binds `http://*:port`. Saying "localhost" read as local-only, and there is
+            // no flag to change what it binds because there does not need to be.
             let tail =
               [ Stdlib.Cli.UI.Colors.hint "  Requests print here as they arrive (method, path, status, duration)."
                 "Press Ctrl+C to stop"

--- a/packages/darklang/stdlib/cli/daemon.dark
+++ b/packages/darklang/stdlib/cli/daemon.dark
@@ -6,7 +6,7 @@
 /// Built on the POSIX stdlib: pidfile via `Cli.File`, signal-0 liveness via
 /// `Posix.isProcessRunning`, detached launch + SIGTERM via `Process`/`Posix`.
 /// 
-/// The launcher is the running executable itself (`getCurrentExecutablePath`) — no env var.
+/// The launcher is the running executable itself (`getCurrentExecutablePath`) -- no env var.
 module Darklang.Stdlib.Cli.Daemon
 
 
@@ -60,7 +60,7 @@ let recordedPid (name: String) : Stdlib.Option.Option<Int> =
     Stdlib.Option.Option.None
 
 
-// Alive? pidfile present AND that pid is a running process (signal-0) — so a stale pidfile (daemon
+// Alive? pidfile present AND that pid is a running process (signal-0) -- so a stale pidfile (daemon
 // killed without cleanup) correctly reads as not running.
 let isRunning (name: String) : Bool =
   match recordedPid name with
@@ -75,7 +75,7 @@ let statusLine (name: String) : String =
     if Posix.isProcessRunning pid then
       $"{name}: running (pid {Stdlib.Int.toString pid})"
     else
-      $"{name}: stale (pid {Stdlib.Int.toString pid} not running — `stop` clears it)"
+      $"{name}: stale (pid {Stdlib.Int.toString pid} not running -- `stop` clears it)"
   | None -> $"{name}: stopped"
 
 
@@ -103,7 +103,7 @@ let stop (name: String) : Stdlib.Result.Result<String, String> =
 
 // ── launch ──
 
-// The executable to re-invoke for the detached child — the `dark` binary currently running. No env var:
+// The executable to re-invoke for the detached child -- the `dark` binary currently running. No env var:
 // `getCurrentExecutablePath` is what the installer already uses to find itself.
 let launcher () : String =
   Stdlib.Cli.Sys.currentExecutablePath ()
@@ -114,7 +114,7 @@ let launcher () : String =
 // appends to the daemon's logfile. The entrypoint must `claimPidfile name` first.
 let launchDetached (name: String) (expr: String) : Stdlib.Result.Result<Unit, String> =
   // Create the run dir up front: the shell redirect below (and the pidfile) need it to exist, and
-  // `claimPidfile` only mkdirs it from inside the child — too late for this redirect on a fresh machine.
+  // `claimPidfile` only mkdirs it from inside the child -- too late for this redirect on a fresh machine.
   let _ = Posix.mkdirRecursive (runDir ())
 
   let cmd =
@@ -151,7 +151,7 @@ let waitUntilRunning
       waitUntilRunning name (tries - 1)
 
 
-// Launch a named daemon detached, running `expr`, then VERIFY it actually came up — returns the live pid
+// Launch a named daemon detached, running `expr`, then VERIFY it actually came up -- returns the live pid
 // or an error if it never claimed its pidfile (instead of falsely reporting success the instant the
 // shell forks). Refuses if it's already running.
 let start (name: String) (expr: String) : Stdlib.Result.Result<Int, String> =


### PR DESCRIPTION
dark serve said Listening on http://localhost:PORT while binding http://*:PORT. It says both now: Listening on http://localhost:9097, and on every interface.

caps grant with an empty spec printed ✓ granted and changed nothing. Refused now, like caps set already refuses its empty form.

Config.dbPath printed the store path with a doubled slash: runDir already ends in a separator.

Also swaps em-dashes for -- in four files of CLI output, but not the two where it's a column separator rather than punctuation.