### PR TITLE
Consolidate CLI Confirmations

### DIFF
--- a/packages/darklang/cli/installation/system.dark
+++ b/packages/darklang/cli/installation/system.dark
@@ -197,14 +197,14 @@ let updateIfAvailable (currentVersion: String) (host: Stdlib.Cli.Host.Host) (aut
     if currentVersion == "local-binary" then
       let choice =
         if autoConfirm then
-          "y"
+          true
         else
           Stdlib.printLine "You're currently running a locally-installed binary (from development)."
           Stdlib.printLine $"Latest official release is {latestVersion}."
-          Stdlib.printLine "Update to the official release? (y/n): "
-          (Stdlib.Cli.Stdin.readLine ()) |> Stdlib.String.trim
 
-      if choice == "y" || choice == "Y" then
+          Cli.Prompt.confirmExplicit false "Update to the official release? (y/n): "
+
+      if choice then
         match Download.installOrUpdateLatestRelease host with
         | Ok _ -> Stdlib.Result.Result.Ok($"Successfully updated to official release {latestVersion}")
         | Error e -> Stdlib.Result.Result.Error e
@@ -226,14 +226,9 @@ let updateIfAvailable (currentVersion: String) (host: Stdlib.Cli.Host.Host) (aut
 /// Uninstall the CLI with user confirmation
 /// If autoConfirm is true, skips confirmation prompt
 let uninstallWithConfirmation (host: Stdlib.Cli.Host.Host) (autoConfirm: Bool) : Stdlib.Result.Result<String, String> =
-  let response =
-    if autoConfirm then
-      "y"
-    else
-      Stdlib.printLine "Are you sure you want to uninstall the CLI? (y/n): "
-      Stdlib.Cli.Stdin.readLine ()
-
-  if response == "y" || response == "Y" then
+  if Cli.Prompt.confirmExplicit
+       autoConfirm
+       "Are you sure you want to uninstall the CLI? (y/n): " then
     Stdlib.printLine "Uninstalling..."
     match Uninstall.runUninstall host with
     | Ok _ -> Stdlib.Result.Result.Ok("Uninstall complete")

--- a/packages/darklang/cli/packages/deprecate.dark
+++ b/packages/darklang/cli/packages/deprecate.dark
@@ -240,13 +240,9 @@ let execute (state: Cli.AppState) (args: List<String>) : Cli.AppState =
             state
           else
             let proceed =
-              if parsed.autoConfirm then
-                true
-              else
-                Stdlib.printLine ""
-                Stdlib.print (Stdlib.Cli.UI.Colors.warning "Proceed? (y/n): ")
-                let response = Stdlib.Cli.Stdin.readLine ()
-                (response == "y") || (response == "Y")
+              Cli.Prompt.confirmExplicit
+                parsed.autoConfirm
+                (Stdlib.Cli.UI.Colors.warning "Proceed? (y/n): ")
 
             if proceed then
               let op =

--- a/packages/darklang/cli/prompt.dark
+++ b/packages/darklang/cli/prompt.dark
@@ -1,5 +1,34 @@
 module Darklang.Cli.Prompt
 
+/// Is stdin a terminal? Both confirmations need it, and a builtin gets one wrapper.
+let interactive () : Bool = Builtin.stdinIsInteractive ()
+
+/// Ask a yes/no question. `-y`, an empty answer, and non-interactive stdin all proceed.
+///
+/// CI gets a pty, so this asks, then waits for someone who isn't there. Pass `-y`.
+let confirm (autoConfirm: Bool) (question: String) : Bool =
+  if autoConfirm then
+    true
+  else if Stdlib.Bool.not (interactive ()) then
+    true
+  else
+    Stdlib.printLine question
+    let response = Stdlib.String.trim (Stdlib.Cli.Stdin.readLine ())
+    (response == "") || (response == "y") || (response == "Y")
+
+/// Like <fn confirm>, but an empty answer and non-interactive stdin both mean no. For
+/// commands that throw work away, where a stray Return should not be a yes.
+let confirmExplicit (autoConfirm: Bool) (question: String) : Bool =
+  if autoConfirm then
+    true
+  else if Stdlib.Bool.not (interactive ()) then
+    false
+  else
+    Stdlib.printLine question
+    let response = Stdlib.String.trim (Stdlib.Cli.Stdin.readLine ())
+    (response == "y") || (response == "Y")
+
+
 /// State for prompt-specific fields (text, cursor, history)
 type State =
   { text: String

--- a/packages/darklang/cli/scm/commit.dark
+++ b/packages/darklang/cli/scm/commit.dark
@@ -27,19 +27,13 @@ let parseInclude (args: List<String>) : Stdlib.Option.Option<List<String>> =
     Stdlib.Option.Option.Some names
 
 
-/// Ask a y/n question. `--yes` auto-confirms. An empty answer takes
-/// `defaultYes` (so a "(Y/n)" prompt defaults to yes, "(y/n)" to no).
+/// Ask a y/n question. `--yes` auto-confirms, and `defaultYes` decides what an empty
+/// answer means, so a "(Y/n)" prompt defaults to yes and a "(y/n)" one to no.
 let promptYesNo (question: String) (autoConfirm: Bool) (defaultYes: Bool) : Bool =
-  if autoConfirm then
-    true
+  if defaultYes then
+    Cli.Prompt.confirm autoConfirm question
   else
-    Stdlib.printLine question
-    let response = Stdlib.Cli.Stdin.readLine ()
-
-    if Stdlib.String.isEmpty (Stdlib.String.trim response) then
-      defaultYes
-    else
-      (response == "y") || (response == "Y")
+    Cli.Prompt.confirmExplicit autoConfirm question
 
 
 let printUnresolved (items: List<SCM.UnresolvedCheck.UnresolvedItem>) : Unit =

--- a/packages/darklang/cli/scm/discard.dark
+++ b/packages/darklang/cli/scm/discard.dark
@@ -38,12 +38,9 @@ let execute (state: AppState) (args: List<String>) : AppState =
     Stdlib.printLine ""
 
     let proceed =
-      if autoConfirm then
-        true
-      else
-        Stdlib.printLine (Stdlib.Cli.UI.Colors.warning "This cannot be undone. Proceed? (y/n): ")
-        let response = Stdlib.Cli.Stdin.readLine ()
-        (response == "y") || (response == "Y")
+      Cli.Prompt.confirmExplicit
+        autoConfirm
+        (Stdlib.Cli.UI.Colors.warning "This cannot be undone. Proceed? (y/n): ")
 
     if proceed then
       match SCM.PackageOps.discard branchId with

--- a/packages/darklang/cli/tests/tests-runner.dark
+++ b/packages/darklang/cli/tests/tests-runner.dark
@@ -40,6 +40,7 @@ let allTests (): List<String * TestFunction> =
     ( "Authoring Refuses A Lowercase Module",
       fun () -> testAuthoringRefusesALowercaseModule () )
     ("Not Found Names The Path", fun () -> testNotFoundNamesThePath ())
+    ("Discard Needs An Explicit Yes", fun () -> testDiscardNeedsAnExplicitYes ())
     ( "Tree Refuses What It Cannot Show",
       fun () -> testTreeRefusesWhatItCannotShow () )
     ("View Unknown Flag", fun () -> testViewUnknownFlag ())

--- a/packages/darklang/cli/tests/tests.dark
+++ b/packages/darklang/cli/tests/tests.dark
@@ -1038,3 +1038,30 @@ let testTreeRefusesWhatItCannotShow (): TestResult =
     TestResult.Fail(
       $"flag: {badFlag}, path: {badPath}, two: {twoPaths}, depth shown: {shown withDepth}"
     )
+
+/// `discard` throws the whole draft away, so an unanswerable prompt is not a yes: it
+/// refuses, and the work is still there. `-y` is how a script says yes.
+let testDiscardNeedsAnExplicitYes (): TestResult =
+  let branch = "cli-discard-" ++ (Stdlib.Int.toString (Stdlib.Int.random 1 999999))
+  let run (args: List<String>) : String =
+    runWithCommand (Stdlib.List.append [ "--branch"; branch ] args)
+
+  let _ = runWithCommand [ "branch"; "create"; branch ]
+  let _ = run [ "fn"; "/Tests.Discard.a"; "() : Int64 = 1L" ]
+
+  let refused = run [ "discard" ]
+  let survived = run [ "status" ]
+  let discarded = run [ "discard"; "-y" ]
+  let after = run [ "status" ]
+
+  if
+    Stdlib.String.contains refused "cancelled"
+      && Stdlib.String.contains survived "1 function"
+      && Stdlib.String.contains discarded "Discarded"
+      && Stdlib.Bool.not (Stdlib.String.contains after "1 function")
+  then
+    TestResult.Pass
+  else
+    TestResult.Fail(
+      $"refused: {refused}, survived: {survived}, discarded: {discarded}, after: {after}"
+    )

--- a/packages/darklang/cli/tracing.dark
+++ b/packages/darklang/cli/tracing.dark
@@ -177,22 +177,8 @@ let parseViewOptions
 
 /// Confirm a destructive op. Returns true to proceed, false to bail.
 ///
-/// `--yes` / `-y` skips the prompt. So does stdin that is not a terminal, which covers a
-/// pipe or a redirect. Everyone else is asked — the `rm -i` shape.
-///
-/// "Not a terminal" is narrower than "nobody is watching", and the gap is where things
-/// hang. A CI runner gets a pty, so this asks, and then blocks on a terminal nobody will
-/// ever type into. Anything unattended has to pass `--yes` rather than rely on being
-/// detected.
 let confirmDestructive (autoConfirm: Bool) (action: String) : Bool =
-  if autoConfirm then
-    true
-  else if Stdlib.Bool.not (Builtin.stdinIsInteractive ()) then
-    true
-  else
-    Stdlib.printLine $"{action} (y/n): "
-    let response = Stdlib.Cli.Stdin.readLine ()
-    (response == "y") || (response == "Y")
+  Cli.Prompt.confirm autoConfirm $"{action} (y/n): "
 
 
 let execute (state: Cli.AppState) (args: List<String>) : Cli.AppState =


### PR DESCRIPTION
Six commands asked a yes/no question with their own copy of the logic, and they disagreed: an empty answer meant no in `discard` and `deprecate`, yes in one of `commit`'s prompts, and only `traces delete` checked whether stdin was a terminal before asking.

`Cli.Prompt.confirm` proceeds on an empty answer and on non-interactive stdin; `confirmExplicit` refuses both. Commands that throw work away take the second.

No behaviour change on a pipe or with `-y`.