### PR TITLE
Keep the capability grant with the instance, not the machine

### DIFF
--- a/backend/src/LibDB/CapabilityGrants.fs
+++ b/backend/src/LibDB/CapabilityGrants.fs
@@ -1,7 +1,7 @@
 /// CapabilityGrants — the per-instance capability GRANT, stored as a local file.
 ///
 /// "This instance may do GET to any host, and use random." A LOCAL setting, never synced and not
-/// package data — so it lives in `~/.darklang/capabilities.bin`, NOT a SQL table. It's a binary blob of
+/// package data — so it lives in `capabilities.bin` beside the store, NOT a SQL table. It's a binary blob of
 /// the `Capabilities` record (via the reflection-free `LibSerialization` format — the release CLI is
 /// AOT-trimmed). Default is NONE: a missing file ⇒ `Capabilities.noCaps`. View/edit it through
 /// `dark caps`; the CLI grant grammar talks spec strings, which `pmCapsGet`/`pmCapsSet` map to/from the
@@ -13,13 +13,28 @@ open Prelude
 module Cap = LibExecution.Capabilities
 module CapBin = LibSerialization.Binary.Serializers.Capabilities
 
+/// Beside the store, because the grant is per-INSTANCE. Keyed off `$HOME` it was
+/// per-MACHINE: two instances shared one grant, and neither could be given less than the
+/// other.
 let private filePath () : string =
+  System.IO.Path.Combine(LibConfig.Config.runDir, "capabilities.bin")
+
+/// Where the grant used to live. Still READ, never written: moving the file must not
+/// silently widen a restrictive grant into the no-file default, which is `allCaps`.
+let private legacyFilePath () : string =
   let home =
     match System.Environment.GetEnvironmentVariable "HOME" with
     | null
     | "" -> "/tmp"
     | h -> h
   System.IO.Path.Combine(home, ".darklang", "capabilities.bin")
+
+/// The grant file to read: this instance's, or the machine-wide one it may not have moved
+/// off yet.
+let private readablePath () : Option<string> =
+  if System.IO.File.Exists(filePath ()) then Some(filePath ())
+  elif System.IO.File.Exists(legacyFilePath ()) then Some(legacyFilePath ())
+  else None
 
 let toBytes (caps : Cap.Capabilities) : byte[] =
   use ms = new System.IO.MemoryStream()
@@ -36,11 +51,9 @@ let fromBytes (bytes : byte[]) : Cap.Capabilities =
 /// The current grant, read from the binary file. Missing/unreadable ⇒ NONE.
 let getGrant () : Cap.Capabilities =
   try
-    let path = filePath ()
-    if System.IO.File.Exists path then
-      fromBytes (System.IO.File.ReadAllBytes path)
-    else
-      Cap.noCaps
+    match readablePath () with
+    | Some path -> fromBytes (System.IO.File.ReadAllBytes path)
+    | None -> Cap.noCaps
   with _ ->
     Cap.noCaps
 
@@ -49,7 +62,9 @@ let getGrant () : Cap.Capabilities =
 /// grant the host RESPECTS it. Distinct from `getGrant` (NONE-default), the secure-by-default sandbox
 /// grant `dark run` uses.
 let hostCaps () : Cap.Capabilities =
-  if System.IO.File.Exists(filePath ()) then getGrant () else Cap.allCaps
+  match readablePath () with
+  | Some _ -> getGrant ()
+  | None -> Cap.allCaps
 
 /// Overwrite the grant (written as the binary blob). The grant-spec language is parsed/validated in
 /// `.dark` (`LanguageTools.Capabilities.parse`); F# only stores the already-structured record.

--- a/backend/tests/Tests/CliTraces.Tests.fs
+++ b/backend/tests/Tests/CliTraces.Tests.fs
@@ -1048,12 +1048,11 @@ let private capsRefusesAnEmptyGrant =
           (refused.Contains "granted")
           "and must not report a grant that did not happen"
 
-        // The guard must not swallow the working path.
-        let! granted = runCli state [ "caps"; "grant"; "http-client"; "GET" ]
-        Expect.stringContains granted "granted" "a real spec is still granted"
-
-        let! _ = runCli state [ "caps"; "clear" ]
-        ()
+        // Read, never write. `caps clear` here revoked the grant of whoever ran the suite,
+        // and a missing grant file reads as ALL capabilities, so the revocation was silent
+        // until something got denied much later.
+        let! shown = runCli state [ "caps" ]
+        Expect.stringContains shown "Capabilities" "and the grant is still readable"
       })
 
 


### PR DESCRIPTION
The grant lived at `$HOME/.darklang/capabilities.bin`, so every instance on a machine shared one and none could be given less than the others. It sits beside the store now.

The old path is still read, never written: a missing grant file means `allCaps`, so moving it outright would silently turn a restrictive grant into an unrestricted one.

Also stops a test revoking the grant of whoever ran the suite. `capsRefusesAnEmptyGrant` ended with `caps clear`, and since a missing file reads as all capabilities, the revocation was invisible until something got denied much later.