### PR TITLE
Add `Stdlib.HttpServer.get` and `post` helpers

### DIFF
--- a/backend/testfiles/execution/stdlib/httpserver.dark
+++ b/backend/testfiles/execution/stdlib/httpserver.dark
@@ -23,3 +23,17 @@ module GetMethod =
   (Stdlib.HttpServer.getMethod (
     Stdlib.Http.Request
       { url = "/"; headers = [ ("Accept", "text/html") ]; body = Stdlib.Blob.empty })) = "GET"
+
+module Routes =
+  // `get`/`post` build the Handler a record literal would, so a route table reads as routes.
+  ((Stdlib.HttpServer.get "/ping" (fun req ->
+      Stdlib.Http.Response
+        { statusCode = 200L; headers = []; body = Stdlib.Blob.empty })).route) = "/ping"
+
+  ((Stdlib.HttpServer.get "/ping" (fun req ->
+      Stdlib.Http.Response
+        { statusCode = 200L; headers = []; body = Stdlib.Blob.empty })).method) = "GET"
+
+  ((Stdlib.HttpServer.post "/ops" (fun req ->
+      Stdlib.Http.Response
+        { statusCode = 200L; headers = []; body = Stdlib.Blob.empty })).method) = "POST"

--- a/packages/darklang/internal/dark-packages/dark-packages.dark
+++ b/packages/darklang/internal/dark-packages/dark-packages.dark
@@ -104,7 +104,7 @@ let pingHandlerFn (req: HttpRequest) : HttpResponse =
   Stdlib.Http.responseWithText "pong" 200
 
 val pingHandler =
-  Handler { route = "/ping"; method = "GET"; handler = pingHandlerFn }
+  Stdlib.HttpServer.get "/ping" pingHandlerFn
 
 
 let opsPostHandlerFn (req: HttpRequest) : HttpResponse =
@@ -120,7 +120,7 @@ let opsPostHandlerFn (req: HttpRequest) : HttpResponse =
     Stdlib.Http.badRequest "Invalid request body. Expected JSON list of PackageOp."
 
 val opsPostHandler =
-  Handler { route = "/ops"; method = "POST"; handler = opsPostHandlerFn }
+  Stdlib.HttpServer.post "/ops" opsPostHandlerFn
 
 
 let opsGetHandlerFn (req: HttpRequest) : HttpResponse =
@@ -135,7 +135,7 @@ let opsGetHandlerFn (req: HttpRequest) : HttpResponse =
       Stdlib.Http.responseWithJson json 200
 
 val opsGetHandler =
-  Handler { route = "/ops"; method = "GET"; handler = opsGetHandlerFn }
+  Stdlib.HttpServer.get "/ops" opsGetHandlerFn
 
 
 let statsHandlerFn (req: HttpRequest) : HttpResponse =
@@ -201,7 +201,7 @@ let searchHandlerFn (req: HttpRequest) : HttpResponse =
               Stdlib.Http.responseWithJson json 200
 
 val searchHandler =
-  Handler { route = "/search"; method = "GET"; handler = searchHandlerFn }
+  Stdlib.HttpServer.get "/search" searchHandlerFn
 
 
 /// `/:location` — interpret the single path segment as a dotted name. For a
@@ -319,7 +319,7 @@ let typeGetHandlerFn (req: HttpRequest) : HttpResponse =
     | None -> Stdlib.Http.notFound ()
 
 val typeGetHandler =
-  Handler { route = typeGetRoute; method = "GET"; handler = typeGetHandlerFn }
+  Stdlib.HttpServer.get typeGetRoute typeGetHandlerFn
 
 
 val typeGetWithLocationRoute = "/type/get/with-location/:hash"

--- a/packages/darklang/stdlib/httpserver.dark
+++ b/packages/darklang/stdlib/httpserver.dark
@@ -9,6 +9,15 @@ type Handler =
     handler: Http.Request -> Http.Response }
 
 
+/// A GET route, so a handler table reads as routes rather than record boilerplate.
+let get (route: String) (fn: Http.Request -> Http.Response) : Handler =
+  Handler { route = route; method = "GET"; handler = fn }
+
+/// A POST route. See <fn Stdlib.HttpServer.get>.
+let post (route: String) (fn: Http.Request -> Http.Response) : Handler =
+  Handler { route = route; method = "POST"; handler = fn }
+
+
 /// Result of matching a route pattern against a request path
 type RouteMatch =
   { matched: Bool


### PR DESCRIPTION
Routes were written like this:

    Handler { route = "/ping"; method = "GET"; handler = pingHandler }

which buries the two things you actually look for, the path and the verb, inside record syntax, and leaves the method as a string nothing checks. Now:

    Stdlib.HttpServer.get "/ping" pingHandler