### PR TITLE
Tell people what to resize the terminal to, and gate the workbench

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -306,6 +306,12 @@ nested functions require them.
 The interactive CLI (`run-cli` with no args) needs a real TTY. Use `expect`:
 
     ./scripts/run-in-docker expect scripts/testing/test-interactive.expect
+    ./scripts/run-in-docker expect scripts/testing/test-workbench.expect
+
+`run-cli` with no args opens the WORKBENCH, so that second one covers the default experience:
+switching views, resize, the too-small guard, and quitting cleanly. None of it is reachable from
+the test suite -- the views render fine when called directly; what needs a terminal is the keyboard,
+the alternate screen and SIGWINCH.
 
 Telemetry lands in `rundir/logs/telemetry.jsonl`. Full guide: `docs interactive-testing`.
 

--- a/packages/darklang/cli/workbench/frame-assembly.dark
+++ b/packages/darklang/cli/workbench/frame-assembly.dark
@@ -229,13 +229,22 @@ let viewAtSize (state: State) (size: Stdlib.Cli.Tui.Size) : Stdlib.Cli.Tui.View 
 
   let spans =
     if tooSmall then
-      let msg = "terminal too small - resize to at least 56x12"
+      // Two lines, because one was 44 columns wide and the guard fires from 24. The canvas clips at the
+      // width, so the single-line version lost its tail -- and the tail was the size you needed, which is
+      // the only thing the message is for. Both lines fit in 24.
       let screen =
         Stdlib.Cli.UI.Layout.Region { top = 1; left = 1; rows = size.height; cols = size.width }
+
+      let centred (text: String) (row: Int) : List<Stdlib.Cli.UI.Layout.Span> =
+        let col =
+          Stdlib.Int.max 0 (Stdlib.Int.divide (size.width - (Stdlib.String.displayWidth text)) 2)
+        Stdlib.Cli.UI.Layout.at screen row col (Stdlib.Cli.UI.Colors.dimText text)
+
       let row = Stdlib.Int.max 0 (Stdlib.Int.divide size.height 2)
-      let col =
-        Stdlib.Int.max 0 (Stdlib.Int.divide (size.width - (Stdlib.String.displayWidth msg)) 2)
-      Stdlib.Cli.UI.Layout.at screen row col (Stdlib.Cli.UI.Colors.dimText msg)
+
+      Stdlib.List.flatten
+        [ centred "terminal too small" (Stdlib.Int.max 0 (row - 1))
+          centred "resize to at least 56x12" row ]
     else
       renderFull state size
 

--- a/scripts/testing/test-workbench.expect
+++ b/scripts/testing/test-workbench.expect
@@ -1,0 +1,75 @@
+#!/usr/bin/expect -f
+#
+# The workbench under a real TTY.
+#
+# `dark` with no arguments opens the workbench, so this is the default experience, and none of it is
+# reachable from the test suite: the views can be rendered directly, but keyboard handling, the
+# alternate screen and resize need a terminal.
+#
+# Every step asserts. Two things about asserting against this program, both learned the hard way:
+#
+#   1. The screen is redrawn as a DIFF, so text already on screen is not sent again. Every assertion
+#      below names something only the view being switched to draws, or follows a resize, which
+#      repaints the whole frame and so re-emits what is already there.
+#   2. Views are switched by their digit in the sidebar.
+
+set timeout 45
+log_user 0
+
+proc fail {msg} {
+  puts "FAIL: $msg"
+  exit 1
+}
+
+proc want {pattern what} {
+  expect {
+    -re $pattern { puts "  ok: $what" }
+    timeout { fail "timed out waiting for $what" }
+    eof { fail "process exited while waiting for $what" }
+  }
+}
+
+spawn ./backend/Build/out/Cli/Debug/net10.0/Cli
+
+# 1. it opens on the workbench rather than the classic prompt
+want "(?i)recent commits" "the workbench on startup"
+
+# 2. switching views actually draws the view, not just a moved sidebar marker
+send "2"
+want "(?i)(darklang/|builtins)" "the Code view"
+
+send "3"
+want "(?i)(working tree clean|nothing to commit)" "the Changes view"
+
+# 3. below a usable size the workbench degrades to a message rather than a garbled frame, and the
+#    message has to carry the size you need. The guard fires from 24 columns, so a single 44-column
+#    line loses its tail to the clip -- and the tail is the only part that tells you what to do.
+stty rows 24 columns 40 < $spawn_out(slave,name)
+exec kill -WINCH [exp_pid]
+want "terminal too small" "the too-small guard"
+want "56x12" "the size you need, not clipped off the end of it"
+
+# 4. and it comes back: growing the terminal repaints the whole frame
+stty rows 30 columns 100 < $spawn_out(slave,name)
+exec kill -WINCH [exp_pid]
+want "(?i)(working tree clean|nothing to commit)" "a full repaint once the terminal is big enough again"
+
+# 5. a view further down the list still draws after all of that
+send "8"
+want "(?i)for-ai" "the Docs view"
+
+# 6. quitting leaves cleanly. A non-zero status would mean the alternate screen was left on a throw.
+send "q"
+expect {
+  eof { }
+  timeout { fail "q did not exit the workbench" }
+}
+
+set waitval [wait]
+set exitcode [lindex $waitval 3]
+if {$exitcode != 0} {
+  fail "exited $exitcode, not 0"
+}
+
+puts "workbench TTY session OK"
+exit 0


### PR DESCRIPTION
The workbench's "too small" message was one 44-column line, and the guard that shows it fires from 24 columns. So the canvas clipped the tail -- and the tail was "56x12", the only part that tells you what to do:

    before, at 40 columns:  terminal too small - resize to at least
    after:                  terminal too small
                            resize to at least 56x12

Both lines fit in 24, which is where the guard starts.

The rest is a TTY gate for the workbench. `dark` with no arguments opens it, so it's the default experience, and nothing covered it: the views render fine when called directly, and what actually needs a terminal is the keyboard, the alternate screen and SIGWINCH. It walks three views, resizes below the threshold and back, and checks the process exits 0.

Reverting the message fix makes it fail on exactly that assertion, which is how I know it is worth having.