### PR TITLE
Stop a large query killing the process, and validate what goes in a service file

### DIFF
--- a/backend/src/Builtins/Builtins.Matter/Libs/Sqlite.fs
+++ b/backend/src/Builtins/Builtins.Matter/Libs/Sqlite.fs
@@ -104,18 +104,20 @@ let private queryImpl
       use reader = readerObj
       let rows = System.Collections.Generic.List<Dval>()
 
-      let rec loop () : Ply<unit> =
-        uply {
-          let! hasRow = reader.ReadAsync()
-          if hasRow then
-            let cells =
-              [ for i in 0 .. reader.FieldCount - 1 ->
-                  (reader.GetName i, Value.toDT (reader.GetValue i)) ]
-            rows.Add(Dval.dict Value.knownType cells)
-            return! loop ()
-        }
+      // Iterative, not recursive. Reading rows by recursing costs a stack frame per ROW, so a
+      // result set in the tens of thousands overflows the stack and kills the process -- not a
+      // catchable error, and nothing a caller can do about it.
+      let mutable hasRow = true
 
-      do! loop ()
+      while hasRow do
+        let! more = reader.ReadAsync()
+        hasRow <- more
+
+        if more then
+          let cells =
+            [ for i in 0 .. reader.FieldCount - 1 ->
+                (reader.GetName i, Value.toDT (reader.GetValue i)) ]
+          rows.Add(Dval.dict Value.knownType cells)
       let listDval =
         Dval.list (KTDict(ValueType.Known Value.knownType)) (List.ofSeq rows)
       return Dval.resultOk rowsKT KTString listDval

--- a/packages/darklang/cli/apps/service.dark
+++ b/packages/darklang/cli/apps/service.dark
@@ -37,6 +37,18 @@ let daemonCommand (app: Model.App) : String =
     (Stdlib.Cli.Daemon.launcher ()) ++ " eval '" ++ entrypoint ++ " \"" ++ app.slug ++ "\"'"
   | Foreground _ -> ""
 
+/// Can this string go into a unit file or a plist without changing its structure?
+///
+/// A newline ends a systemd directive and starts the next one, so a name carrying one writes
+/// whatever follows it as its own directive. `<` and `&` do the same to the plist. Nothing that
+/// belongs in an app name or an entrypoint contains any of them.
+let isSafeForUnitFile (s: String) : Bool =
+  Stdlib.Bool.not (
+    (Stdlib.String.contains s "\n")
+    || (Stdlib.String.contains s "\r")
+    || (Stdlib.String.contains s "<")
+    || (Stdlib.String.contains s "&"))
+
 let systemdUnit (app: Model.App) : String =
   $"[Unit]\nDescription={app.name} (Dark app)\n\n[Service]\nExecStart={daemonCommand app}\nRestart=on-failure\n\n[Install]\nWantedBy=default.target\n"
 
@@ -49,6 +61,12 @@ let enable (app: Model.App) : EnableResult =
     EnableResult.Failed $"invalid app slug '{app.slug}'"
   else if Stdlib.Bool.not (Model.isDaemon app.target) then
     EnableResult.Failed $"'{app.slug}' is a foreground app — only daemons can auto-start"
+  // Checked here rather than at the interpolation, so both platforms are covered by one guard and
+  // nothing gets written when it fails.
+  else if Stdlib.Bool.not (isSafeForUnitFile app.name) then
+    EnableResult.Failed $"'{app.slug}' has a name that can't go in a service file"
+  else if Stdlib.Bool.not (isSafeForUnitFile (daemonCommand app)) then
+    EnableResult.Failed $"'{app.slug}' has an entrypoint that can't go in a service file"
   else
     match platform () with
     | Unsupported ->


### PR DESCRIPTION
Two unrelated fixes, both small.

`Stdlib.Sqlite.query` read rows by recursing, one stack frame per row, so a result set in the tens of thousands overflowed the stack. That kills the process outright -- it isn't a catchable error, and there's nothing a caller can do about it. Reading them in a loop instead: 50,000 rows died before, 200,000 return fine now.

Separately, `apps enable` wrote a systemd unit or a launchd plist by interpolating the app name and entrypoint straight in, with only the slug validated. A newline ends a systemd directive and starts the next one; `<` and `&` do the same to a plist. That isn't reachable today, since the app catalog is code rather than data, but a function that writes a service file shouldn't be built this way. It now refuses before writing, in one place that covers both platforms.