### PR TITLE
More SCM and Sync follow-ups

### DIFF
--- a/backend/src/Builtins/Builtins.Http.Server/Libs/HttpServer.fs
+++ b/backend/src/Builtins/Builtins.Http.Server/Libs/HttpServer.fs
@@ -275,7 +275,13 @@ let private handleRequest
           do! ctx.Response.OutputStream.WriteAsync(msg, 0, msg.Length)
         | Ok reqBody ->
           let reqHeaders = extractHeaders ctx.Request
-          let rawUrl = ctx.Request.Url.ToString()
+          // `Url.ToString()` decodes and `queryParams` decodes again, so a `%26` in a value became
+          // a real `&` and split into a second parameter. `RawUrl` is path+query as sent; the
+          // absolute form is rebuilt around it.
+          let rawUrl =
+            match ctx.Request.RawUrl with
+            | null -> ctx.Request.Url.ToString()
+            | raw -> $"{ctx.Request.Url.Scheme}://{ctx.Request.Url.Authority}{raw}"
           let url =
             if canonicalizeFromForwardedProto then
               canonicalizeUrlFromForwardedProto rawUrl reqHeaders

--- a/backend/src/LibDB/Config.fs
+++ b/backend/src/LibDB/Config.fs
@@ -9,6 +9,7 @@ open System.Threading.Tasks
 open FSharp.Control.Tasks
 
 open Fumble
+open Microsoft.Data.Sqlite
 open LibDB.Sqlite
 
 open Prelude
@@ -26,22 +27,82 @@ let secretPrefix = "sync.secret."
 let isSecretKey (key : string) : bool = key.StartsWith secretPrefix
 
 
-/// The value for `key`, or None if unset.
+/// Secret-prefixed keys, in a file of their own beside the store.
+///
+/// Being a separate FILE is the mechanism: `Stdlib.Sqlite` declares only `package-read` for a
+/// statement whose path is the store, so a plain SELECT on `config_v0` read the write secret past
+/// `configGet`'s guard. A blocklist on the SQL text would be leakier -- a table name can be quoted,
+/// aliased or reached through a view.
+///
+/// From the LIVE store path, so a test that repoints LibDB gets that instance's credentials.
+/// Not covered by `dark backups`, which snapshots the store alone.
+let credentialsPath () : string =
+  let dir =
+    match System.IO.Path.GetDirectoryName(currentDbPath : string) with
+    | null
+    | "" -> "."
+    | d -> d
+  System.IO.Path.Combine(dir, "credentials.db")
+
+let private credentialsConnString () : string =
+  $"Data Source={credentialsPath ()};Mode=ReadWriteCreate;Cache=Private;Pooling=true"
+
+/// Open the credential store, creating file and table on first use. Not a migration: nothing else
+/// opens this file, and a store with no secret has no reason to carry an empty one.
+let private credentialsConn () : SqliteConnection =
+  let conn = new SqliteConnection(credentialsConnString ())
+  conn.Open()
+  use cmd = conn.CreateCommand()
+  cmd.CommandText <-
+    "CREATE TABLE IF NOT EXISTS credentials_v0 (key TEXT PRIMARY KEY, value TEXT NOT NULL)"
+  cmd.ExecuteNonQuery() |> ignore<int>
+  conn
+
+let private getCredential (key : string) : string option =
+  use conn = credentialsConn ()
+  use cmd = conn.CreateCommand()
+  cmd.CommandText <- "SELECT value FROM credentials_v0 WHERE key = @key"
+  cmd.Parameters.AddWithValue("@key", key) |> ignore<SqliteParameter>
+  match cmd.ExecuteScalar() with
+  | null -> None
+  | v -> Some(string v)
+
+let private setCredential (key : string) (value : string) : unit =
+  use conn = credentialsConn ()
+  use cmd = conn.CreateCommand()
+  cmd.CommandText <-
+    "INSERT INTO credentials_v0 (key, value) VALUES (@key, @value)
+     ON CONFLICT(key) DO UPDATE SET value = @value"
+  cmd.Parameters.AddWithValue("@key", key) |> ignore<SqliteParameter>
+  cmd.Parameters.AddWithValue("@value", value) |> ignore<SqliteParameter>
+  cmd.ExecuteNonQuery() |> ignore<int>
+
+
+/// The value for `key`, or None if unset. Secret keys come from the credential store, everything
+/// else from `config_v0`; callers do not choose.
 let get (key : string) : Task<string option> =
-  Sql.query "SELECT value FROM config_v0 WHERE key = @key"
-  |> Sql.parameters [ "key", Sql.string key ]
-  |> Sql.executeRowOptionAsync (fun read -> read.string "value")
+  if isSecretKey key then
+    Task.FromResult(getCredential key)
+  else
+    Sql.query "SELECT value FROM config_v0 WHERE key = @key"
+    |> Sql.parameters [ "key", Sql.string key ]
+    |> Sql.executeRowOptionAsync (fun read -> read.string "value")
 
 /// Set `key` to `value` (upsert).
 let set (key : string) (value : string) : Task<unit> =
   task {
-    let! (_ : int) =
-      Sql.query
-        """
-        INSERT INTO config_v0 (key, value) VALUES (@key, @value)
-        ON CONFLICT(key) DO UPDATE SET value = @value
-        """
-      |> Sql.parameters [ "key", Sql.string key; "value", Sql.string value ]
-      |> Sql.executeNonQueryAsync
+    if isSecretKey key then
+      setCredential key value
+    else
+      let! (_ : int) =
+        Sql.query
+          """
+          INSERT INTO config_v0 (key, value) VALUES (@key, @value)
+          ON CONFLICT(key) DO UPDATE SET value = @value
+          """
+        |> Sql.parameters [ "key", Sql.string key; "value", Sql.string value ]
+        |> Sql.executeNonQueryAsync
+      ()
+
     return ()
   }

--- a/backend/src/LibDB/Releases.fs
+++ b/backend/src/LibDB/Releases.fs
@@ -187,6 +187,33 @@ let steps : List<Step> =
       run =
         fun () -> addColumnIfMissing "conflicts" "part" "TEXT NOT NULL DEFAULT ''" }
 
+    // The write secret out of the store, into the credential database beside it. A plain SELECT on
+    // `config_v0` used to read it with a grant every install has; see `LibDB.Config.credentialsPath`.
+    //
+    // Copy first, delete only what copied: a store that still has the row is recoverable, one that
+    // lost it means re-running `dark connect --secret`.
+    { name = "20260909_000003_secrets_leave_the_store"
+      run =
+        fun () ->
+          if tableExists "config_v0" then
+            let rows =
+              (Sql.query
+                "SELECT key, value FROM config_v0 WHERE key LIKE 'sync.secret.%'"
+               |> Sql.executeAsync (fun read ->
+                 (read.string "key", read.string "value")))
+                .Result
+
+            for (key, value) in rows do
+              Config.set key value |> Async.AwaitTask |> Async.RunSynchronously
+
+              Sql.query "DELETE FROM config_v0 WHERE key = @key"
+              |> Sql.parameters [ "key", Sql.string key ]
+              |> Sql.executeStatementSync
+
+            if not (List.isEmpty rows) then
+              print
+                $"  release: moved {List.length rows} write secret(s) out of the store into credentials.db" }
+
     // NEW STEPS GO ABOVE THIS LINE -- `scripts/migrations/new` appends here, and edits nothing else.
     ]
 

--- a/backend/testfiles/execution/stdlib/http.dark
+++ b/backend/testfiles/execution/stdlib/http.dark
@@ -150,6 +150,19 @@ module QueryParams =
     Stdlib.Http.Request
       { url = "/s?a=1?b=2"; headers = []; body = Stdlib.Blob.empty })) = [ ("a", "1?b=2") ]
 
+  // An encoded separator stays inside its value. The server hands over the RAW url so `urlDecode`
+  // here is the only decoder; decoded twice, `%26` becomes a real `&` and this reads as two.
+  (Stdlib.Http.Request.queryParams (
+    Stdlib.Http.Request
+      { url = "/s?owner=a%26b"; headers = []; body = Stdlib.Blob.empty }))
+  = [ ("owner", "a&b") ]
+
+  // Same for an encoded `=`: it belongs to the value, not to the key/value split.
+  (Stdlib.Http.Request.queryParam
+    (Stdlib.Http.Request
+      { url = "/s?q=a%3Db"; headers = []; body = Stdlib.Blob.empty })
+    "q") = Stdlib.Option.Option.Some "a=b"
+
 
 module RequestHeader =
   // Case-insensitive, as HTTP requires: one stored casing, three asked-for casings.

--- a/backend/tests/Tests/CliJson.Tests.fs
+++ b/backend/tests/Tests/CliJson.Tests.fs
@@ -191,9 +191,19 @@ let propagateKeepsItsShapeWhenThereIsNothingToChoose =
         do! hasKeys state [ "propagate"; "--json" ] [ "choices" ]
       })
 
+/// `findings: []` means "nothing is wrong" only when nothing stopped a detector from looking.
 let constraintsKeepsItsShape =
   cliTest "constraints --json keeps its keys" (fun state ->
-    hasKeys state [ "constraints"; "--json" ] [ "findings" ])
+    task {
+      do! hasKeys state [ "constraints"; "--json" ] [ "findings"; "blocked" ]
+
+      let! root = parsed state [ "constraints"; "--json" ]
+
+      Expect.equal
+        (root.GetProperty("blocked").ValueKind)
+        System.Text.Json.JsonValueKind.Array
+        "blocked is an array, empty in the normal case rather than absent"
+    })
 
 let depsAnswersBothDirections =
   cliTestOnMain "deps --json answers with both directions" (fun state ->

--- a/backend/tests/Tests/CliTestHarness.fs
+++ b/backend/tests/Tests/CliTestHarness.fs
@@ -91,6 +91,13 @@ let buildState () : Task<RT.ExecutionState> =
           isBundledPackageFn = fun (RT.Hash h) -> bundled.Contains h }
   }
 
+/// How long one CLI command may take before the test says so.
+///
+/// A command reading stdin with nobody there waits rather than fails, with `Console.SetOut`
+/// redirected, so the hang is silent and the log names no culprit. Generous on purpose: this turns
+/// "forever" into a named failure, it does not police speed.
+let private runCliTimeout = System.TimeSpan.FromMinutes 2.0
+
 /// Invoke the CLI dispatch with the given args (e.g. `["traces"; "list"]`) and return
 /// the trimmed captured stdout, with `Console.Out` redirected to a `StringWriter` for
 /// the duration. The surrounding `testSequenced` keeps the process-global
@@ -108,7 +115,22 @@ let runCli (state : RT.ExecutionState) (args : string list) : Task<string> =
     let originalOut = System.Console.Out
     try
       System.Console.SetOut(captured)
-      let! result = Exe.executeFunction state fnName [] (NEList.singleton argsDval)
+      let execution = Exe.executeFunction state fnName [] (NEList.singleton argsDval)
+
+      // Bounds the WAIT, not the work: the call is not cancellable, so it finishes into a
+      // StringWriter nobody reads while the test fails with the command's name.
+      let! finished = Task.WhenAny(execution, Task.Delay runCliTimeout)
+
+      if not (System.Object.ReferenceEquals(finished, execution :> Task)) then
+        System.Console.SetOut(originalOut)
+
+        return
+          Tests.failtestf
+            "runCli timed out after %A: dark %s"
+            runCliTimeout
+            (String.concat " " args)
+
+      let! result = execution
       // `Stdlib.printLine` queues to a background thread; drain before
       // reading the StringWriter or we capture nothing.
       NonBlockingConsole.wait ()

--- a/backend/tests/Tests/Config.Tests.fs
+++ b/backend/tests/Tests/Config.Tests.fs
@@ -13,6 +13,7 @@ open Prelude
 open TestUtils.TestUtils
 
 module Config = LibDB.Config
+open LibDB.Sqlite
 
 let tests =
   testList
@@ -33,4 +34,37 @@ let tests =
         do! Config.set "test.config.k2" "b"
         let! v = Config.get "test.config.k2"
         Expect.equal v (Some "b") "the later value wins"
+      }
+
+      // The guarantee: a credential is not in a file Dark is allowed to open. `configGet` refusing
+      // secret keys was never enough, because a plain SELECT on `config_v0` needs only
+      // `package-read`.
+      testTask "a secret round-trips WITHOUT touching config_v0" {
+        let key = Config.secretPrefix + "https://test.example"
+        do! Config.set key "a-test-secret-value"
+
+        let! v = Config.get key
+        Expect.equal
+          v
+          (Some "a-test-secret-value")
+          "the secret is readable through Config.get, which F# uses"
+
+        // The whole point, asserted the way the exploit did it.
+        let! leaked =
+          Sql.query
+            "SELECT COUNT(*) as n FROM config_v0 WHERE key LIKE 'sync.secret.%'"
+          |> Sql.executeRowAsync (fun read -> read.int64 "n")
+
+        Expect.equal
+          leaked
+          0L
+          "no secret-prefixed row is in config_v0, where any package-read grant could select it"
+      }
+
+      testTask "the credential store is not the package store" {
+        // Same path would mean `package-read` reaches it, and the separation is decorative.
+        Expect.notEqual
+          (System.IO.Path.GetFullPath(Config.credentialsPath ()))
+          (System.IO.Path.GetFullPath LibDB.Sqlite.currentDbPath)
+          "credentials live beside the store, never in it"
       } ]

--- a/backend/tests/Tests/MultiInstanceDark.Tests.fs
+++ b/backend/tests/Tests/MultiInstanceDark.Tests.fs
@@ -460,7 +460,7 @@ let supersededReportsCheckAuthorship =
                AND substr(op_blob, 9, 1) = X'0B'"
         let! (policies : string) =
           darkOn
-            "Darklang.SCM.PackageOps.supersededPolicies () |> Stdlib.List.length |> Stdlib.Int.toString"
+            "Darklang.SCM.PackageOps.supersededPolicies () |> Stdlib.Result.withDefault [] |> Stdlib.List.length |> Stdlib.Int.toString"
         Expect.equal
           policies
           "DString \"0\""
@@ -491,7 +491,7 @@ let supersededReportsCheckAuthorship =
             "module TwoStore.Sup\n\nlet g (x: Int64) : Int64 = x + 2L\n"
         let! (overrides : string) =
           darkOn
-            "Darklang.SCM.PackageOps.supersededOverrides () |> Stdlib.List.length |> Stdlib.Int.toString"
+            "Darklang.SCM.PackageOps.supersededOverrides () |> Stdlib.Result.withDefault [] |> Stdlib.List.length |> Stdlib.Int.toString"
         Expect.equal
           overrides
           "DString \"0\""

--- a/packages/darklang/cli/backups.dark
+++ b/packages/darklang/cli/backups.dark
@@ -96,6 +96,10 @@ let executeRestore (state: AppState) (name: String) (autoConfirm: Bool) : AppSta
   Stdlib.printLine (Stdlib.Cli.UI.Colors.warning $"  RESTORING {name} replaces the store.")
   Cli.printHint "  the store as it is now is copied aside first, so this is undoable."
 
+  // Credentials are deliberately not in a backup: it is a file people copy around. The cost is
+  // this sentence, because a restore onto a fresh machine cannot bring the secret back.
+  Cli.printHint "  a backup holds no credentials; re-set a relay secret with `dark connect <url> --secret ...`"
+
   let confirmed =
     Cli.Prompt.confirmExplicit autoConfirm (Stdlib.Cli.UI.Colors.warning "\n  Restore it? [y/N]: ")
 

--- a/packages/darklang/cli/constraints.dark
+++ b/packages/darklang/cli/constraints.dark
@@ -110,17 +110,37 @@ let kindArgChecked (args: List<String>) : Stdlib.Result.Result<Unit, String> =
 
 
 let executeJson (state: AppState) (args: List<String>) : AppState =
-  let findings = SCM.Constraints.pending () |> (fun fs -> selectKind fs args)
+  let detected = SCM.Constraints.pending ()
+  let findings = selectKind detected.findings args
   let body = findings |> Stdlib.List.map toJson |> (fun ls -> Stdlib.String.join ls ",")
-  Stdlib.printLine $"{{\"findings\":[{body}]}}"
+
+  // Add-only, normally `[]`. Without it an agent reads "we didn't look" as "nothing to see".
+  let blocked =
+    detected.blocked
+    |> Stdlib.List.map (fun b -> Stdlib.Json.serialize<String> b)
+    |> (fun ls -> Stdlib.String.join ls ",")
+
+  Stdlib.printLine $"{{\"findings\":[{body}],\"blocked\":[{blocked}]}}"
   state
 
 
 let executeList (state: AppState) (args: List<String>) : AppState =
-  match SCM.Constraints.pending () |> (fun fs -> selectKind fs args) with
+  let detected = SCM.Constraints.pending ()
+
+  // Before the findings: "no constraints" is a claim about what was checked.
+  let _ =
+    detected.blocked
+    |> Stdlib.List.iter (fun b ->
+      Cli.printErr $"couldn't check everything: {b}")
+
+  match selectKind detected.findings args with
   | [] ->
     // Says what was CHECKED, not just that nothing turned up, and short enough for a narrow terminal.
-    Cli.printOk "no constraints: nothing has drifted off its current version."
+    if Stdlib.List.isEmpty detected.blocked then
+      Cli.printOk "no constraints: nothing has drifted off its current version."
+    else
+      Cli.printOk "nothing found by the checks that DID run."
+
     state
   | findings ->
     Cli.printOk (Cli.Text.plural (Stdlib.List.length findings) "constraint")
@@ -154,9 +174,9 @@ let selectTargets
   // `detectAll` re-runs detection so a prefix can match a finding that has never been listed; `pending`
   // is enough for `--all`, which means "everything currently outstanding".
   if Stdlib.List.member ids "--all" then
-    (SCM.Constraints.pending (), [])
+    ((SCM.Constraints.pending ()).findings, [])
   else
-    let all = SCM.Constraints.detectAll ()
+    let all = (SCM.Constraints.detectAll ()).findings
 
     // Findings are printed as `#1d8740cd`, so a pasted id arrives with the `#`. Accept what we print.
     let normalize (i: String) : String =

--- a/packages/darklang/scm/constraints.dark
+++ b/packages/darklang/scm/constraints.dark
@@ -240,61 +240,65 @@ let ackedIds () : List<String> =
 /// The `Finding` fields are the stale-usage ones reused: `dependency` is the location ITSELF, because the
 /// thing whose version moved is this name rather than something it calls. That is the one field here that
 /// reads oddly, and it is why `line` in the CLI prints this kind separately.
-let detectSupersededDecisions () : List<Finding> =
+let detectSupersededDecisions () : Stdlib.Result.Result<List<Finding>, String> =
   SCM.PackageOps.supersededOverrides ()
-  |> Stdlib.List.map (fun entry ->
-    let (loc, chosen, live) = entry
+  |> Stdlib.Result.map (fun entries ->
+    entries
+    |> Stdlib.List.map (fun entry ->
+      let (loc, chosen, live) = entry
 
-    // The item's REAL kind, from the live binding: a hardcoded Fn feeds `--json` the wrong kind for a
-    // decision on a type or value.
-    let kind =
-      SCM.Propagation.kindAt loc
-      |> Stdlib.Option.withDefault LanguageTools.ProgramTypes.ItemKind.Fn
+      // The item's REAL kind, from the live binding: a hardcoded Fn feeds `--json` the wrong kind for a
+      // decision on a type or value.
+      let kind =
+        SCM.Propagation.kindAt loc
+        |> Stdlib.Option.withDefault LanguageTools.ProgramTypes.ItemKind.Fn
 
-    Finding
-      { kind = Kind.DecisionSuperseded
-        id = findingId loc loc chosen
-        usage = loc
-        usageKind = kind
-        dependency = loc
-        dependencyKind = kind
-        detail =
-          FindingDetail.Versions(
-            LanguageTools.ProgramTypes.Hash.Hash chosen,
-            LanguageTools.ProgramTypes.Hash.Hash live
-          ) })
+      Finding
+        { kind = Kind.DecisionSuperseded
+          id = findingId loc loc chosen
+          usage = loc
+          usageKind = kind
+          dependency = loc
+          dependencyKind = kind
+          detail =
+            FindingDetail.Versions(
+              LanguageTools.ProgramTypes.Hash.Hash chosen,
+              LanguageTools.ProgramTypes.Hash.Hash live
+            ) }))
 
 
 /// A propagation choice of yours that a peer's later choice replaced. The silent half of
 /// last-writer-wins, made visible; see `SCM.PackageOps.supersededPolicies` for why only a peer counts.
-let detectSupersededPolicies () : List<Finding> =
+let detectSupersededPolicies () : Stdlib.Result.Result<List<Finding>, String> =
   SCM.PackageOps.supersededPolicies ()
-  |> Stdlib.List.map (fun entry ->
-    let (loc, mine, now, by) = entry
-    // A policy row carries no kind, so ask what the name IS: main-scoped is right here, since a
-    // policy names a live binding. Fn only when nothing is bound (the finding still reads).
-    let kind =
-      match Stdlib.Sqlite.queryP
-              (SCM.localDb ())
-              "SELECT item_type FROM locations
-               WHERE owner = @p0 AND modules = @p1 AND name = @p2
-                 AND unlisted_at IS NULL AND source <> 'unbind' LIMIT 1"
-              [ loc.owner, (Stdlib.String.join loc.modules "."), loc.name ]
-      with
-      | Ok [ row ] ->
-        (match Stdlib.Sqlite.textField row "item_type" with
-         | Some t -> Deps.kindOf t
-         | None -> LanguageTools.ProgramTypes.ItemKind.Fn)
-      | _ -> LanguageTools.ProgramTypes.ItemKind.Fn
+  |> Stdlib.Result.map (fun entries ->
+    entries
+    |> Stdlib.List.map (fun entry ->
+      let (loc, mine, now, by) = entry
+      // A policy row carries no kind, so ask what the name IS: main-scoped is right here, since a
+      // policy names a live binding. Fn only when nothing is bound (the finding still reads).
+      let kind =
+        match Stdlib.Sqlite.queryP
+                (SCM.localDb ())
+                "SELECT item_type FROM locations
+                 WHERE owner = @p0 AND modules = @p1 AND name = @p2
+                   AND unlisted_at IS NULL AND source <> 'unbind' LIMIT 1"
+                [ loc.owner, (Stdlib.String.join loc.modules "."), loc.name ]
+        with
+        | Ok [ row ] ->
+          (match Stdlib.Sqlite.textField row "item_type" with
+           | Some t -> Deps.kindOf t
+           | None -> LanguageTools.ProgramTypes.ItemKind.Fn)
+        | _ -> LanguageTools.ProgramTypes.ItemKind.Fn
 
-    Finding
-      { kind = Kind.DecisionSuperseded
-        id = findingId loc loc $"policy|{by}"
-        usage = loc
-        usageKind = kind
-        dependency = loc
-        dependencyKind = kind
-        detail = FindingDetail.PolicyReplaced(mine, now, by) })
+      Finding
+        { kind = Kind.DecisionSuperseded
+          id = findingId loc loc $"policy|{by}"
+          usage = loc
+          usageKind = kind
+          dependency = loc
+          dependencyKind = kind
+          detail = FindingDetail.PolicyReplaced(mine, now, by) }))
 
 
 /// The same finding, for what the BRANCH binds.
@@ -350,15 +354,37 @@ let detectOutdatedUsagesOn (branchId: Uuid) : List<Finding> =
     |> Stdlib.List.flatten
 
 
-let detectAll () : List<Finding> =
+/// Everything detection turned up, and everything it could not look at.
+///
+/// Two of these detectors read the op log, and a failed read used to come back empty. A caller that
+/// prints "no constraints" has to be able to tell that from "nothing found".
+type Detection =
+  { findings: List<Finding>
+    /// One sentence per detector that could not run. Empty is the normal case.
+    blocked: List<String> }
+
+let detectAll () : Detection =
   // The ack lifecycle, the ids, the CLI and the `dark status` count are all kind-agnostic, so a kind
   // appends here and needs nothing else. The one thing that is NOT kind-agnostic is pin-suppression, in
   // `pending` below.
-  Stdlib.List.flatten
-    [ detectOutdatedUsages ()
-      detectOutdatedUsagesOn (PackageOps.currentBranch ())
-      detectSupersededDecisions ()
-      detectSupersededPolicies () ]
+  let (decisions, decisionsBlocked) =
+    match detectSupersededDecisions () with
+    | Ok fs -> (fs, [])
+    | Error e -> ([], [ e ])
+
+  let (policies, policiesBlocked) =
+    match detectSupersededPolicies () with
+    | Ok fs -> (fs, [])
+    | Error e -> ([], [ e ])
+
+  Detection
+    { findings =
+        Stdlib.List.flatten
+          [ detectOutdatedUsages ()
+            detectOutdatedUsagesOn (PackageOps.currentBranch ())
+            decisions
+            policies ]
+      blocked = Stdlib.List.append decisionsBlocked policiesBlocked }
 
 
 /// The findings a human still has to look at: detection minus the two ways of having already answered.
@@ -368,26 +394,31 @@ let detectAll () : List<Finding> =
 ///
 /// `dark status` calls this on every invocation, so it reads each table ONCE rather than per finding --
 /// `shouldFollow` re-queries `propagation_policy` every time it is asked.
-let pending () : List<Finding> =
+let pending () : Detection =
   let ackedSet =
     ackedIds ()
     |> Stdlib.List.map (fun a -> (a, true))
     |> Stdlib.Dict.fromListOverwritingDuplicates
 
   let choices = Propagation.allChoices ()
+  let detected = detectAll ()
 
-  detectAll ()
-  |> Stdlib.List.filter (fun s ->
-    let isAcked =
-      match Stdlib.Dict.get ackedSet s.id with
-      | Some _ -> true
-      | None -> false
+  // Blockers pass through: an ack answers a finding, and a detector that never ran produced none.
+  Detection
+    { findings =
+        detected.findings
+        |> Stdlib.List.filter (fun s ->
+          let isAcked =
+            match Stdlib.Dict.get ackedSet s.id with
+            | Some _ -> true
+            | None -> false
 
-    let isPinned =
-      pinSuppresses s.kind
-      && (Propagation.shouldFollowIn choices s.usage |> Stdlib.Bool.not)
+          let isPinned =
+            pinSuppresses s.kind
+            && (Propagation.shouldFollowIn choices s.usage |> Stdlib.Bool.not)
 
-    (isAcked || isPinned) |> Stdlib.Bool.not)
+          (isAcked || isPinned) |> Stdlib.Bool.not)
+      blocked = detected.blocked }
 
 
 /// Record "I've seen this one, leave it" -- as an OP, so the ack travels. An ack that lives only on the

--- a/packages/darklang/scm/draft.dark
+++ b/packages/darklang/scm/draft.dark
@@ -40,7 +40,7 @@ let read (unit: Unit) : Picture =
       repoints = SCM.PackageOps.draftRepoints bindings
       leftBehind = SCM.PackageOps.draftLeftBehind bindings
       conflicts = SCM.Conflicts.pending ()
-      constraints = Stdlib.List.length (SCM.Constraints.pending ())
+      constraints = Stdlib.List.length (SCM.Constraints.pending ()).findings
       ops = SCM.PackageOps.draftOpCount () }
 
 /// Just the counts, for the hot path.
@@ -63,7 +63,7 @@ type Counts =
 let counts (unit: Unit) : Counts =
   let bindings = SCM.PackageOps.draftBindings ()
   let propagated = SCM.PackageOps.propagatedNames ()
-  let pendingConstraints = SCM.Constraints.pending ()
+  let pendingConstraints = (SCM.Constraints.pending ()).findings
   let draftNames =
     bindings |> Stdlib.List.map (fun b -> SCM.Conflicts.fqn b.owner b.modules b.name)
   let fromDraft =

--- a/packages/darklang/scm/packageOpsDraft.dark
+++ b/packages/darklang/scm/packageOpsDraft.dark
@@ -209,21 +209,24 @@ let decisionKey (loc: LanguageTools.ProgramTypes.PackageLocation) : String =
 /// an owner". A choice you changed yourself is not reported: that is not a surprise.
 ///
 /// Returns (location, the policy you chose, the policy in force now, who replaced it).
+///
+/// A `Result` because "none" and "could not look" are different answers. A failed query used to read
+/// as an empty list, so `dark constraints` reported no drift when it had not checked.
 let supersededPolicies
   ()
-  : List<(LanguageTools.ProgramTypes.PackageLocation * LanguageTools.ProgramTypes.PropagationPolicy * LanguageTools.ProgramTypes.PropagationPolicy * String)> =
-  let anyPolicies =
+  : Stdlib.Result.Result<List<(LanguageTools.ProgramTypes.PackageLocation * LanguageTools.ProgramTypes.PropagationPolicy * LanguageTools.ProgramTypes.PropagationPolicy * String)>, String> =
+  match
     Stdlib.Sqlite.scalarInt
       (localDb ())
       // Not 'unset' rows: clearing a choice leaves a tombstone (see the fold), and a store whose
       // every choice has been cleared has no choices.
       "SELECT COUNT(*) AS n FROM propagation_policy WHERE policy <> 'unset'"
       "n"
-    |> Stdlib.Option.withDefault 0L
-
-  if anyPolicies == 0L then
-    []
-  else
+  with
+  | None ->
+    Stdlib.Result.Result.Error "couldn't count propagation choices (the store did not answer)"
+  | Some 0L -> Stdlib.Result.Result.Ok []
+  | Some _ ->
     match
       Stdlib.Sqlite.query
         (localDb ())
@@ -232,7 +235,8 @@ let supersededPolicies
          FROM package_ops p
          WHERE p.effective = 1 ORDER BY p.origin_ts, p.rowid"
     with
-    | Error _ -> []
+    | Error e ->
+      Stdlib.Result.Result.Error $"couldn't read the op log for superseded choices: {e}"
     | Ok rows ->
       // Per name: the last choice YOU made with nobody having replaced it yet, then whether a later one
       // arrived from a peer with a different answer.
@@ -280,6 +284,7 @@ let supersededPolicies
       |> Stdlib.List.filter (fun entry ->
         let (_loc, mine, now, by) = entry
         (by != "") && (mine != now))
+      |> Stdlib.Result.Result.Ok
 
 
 /// Where a human's OVERRIDE was later undone by an ordinary edit.
@@ -295,17 +300,20 @@ let supersededPolicies
 ///
 /// Guarded on the `conflicts` projection first, which is small and usually empty of overrides, so the
 /// op-log decode below costs nothing on the common path.
-let supersededOverrides () : List<(LanguageTools.ProgramTypes.PackageLocation * String * String)> =
-  let anyOverrides =
+/// A `Result` for the same reason as <fn supersededPolicies>: a failed query is not "none".
+let supersededOverrides
+  ()
+  : Stdlib.Result.Result<List<(LanguageTools.ProgramTypes.PackageLocation * String * String)>, String> =
+  match
     Stdlib.Sqlite.scalarInt
       (localDb ())
       "SELECT COUNT(*) AS n FROM conflicts WHERE status = 'overridden'"
       "n"
-    |> Stdlib.Option.withDefault 0L
-
-  if anyOverrides == 0L then
-    []
-  else
+  with
+  | None ->
+    Stdlib.Result.Result.Error "couldn't count overridden conflicts (the store did not answer)"
+  | Some 0L -> Stdlib.Result.Result.Ok []
+  | Some _ ->
     match
       Stdlib.Sqlite.query
         (localDb ())
@@ -314,7 +322,8 @@ let supersededOverrides () : List<(LanguageTools.ProgramTypes.PackageLocation * 
          FROM package_ops
          WHERE effective = 1 ORDER BY origin_ts, rowid"
     with
-    | Error _ -> []
+    | Error e ->
+      Stdlib.Result.Result.Error $"couldn't read the op log for superseded overrides: {e}"
     | Ok rows ->
       // Fold the log in order, remembering per location: the hash the last LOCAL override chose, and
       // the hash bound now. Order is the fold's own (origin_ts, rowid), so "later" means what the fold
@@ -369,6 +378,7 @@ let supersededOverrides () : List<(LanguageTools.ProgramTypes.PackageLocation * 
       |> Stdlib.List.filter (fun entry ->
         let (_loc, chosen, live) = entry
         chosen != live)
+      |> Stdlib.Result.Result.Ok
 
 
 /// The at-rest type check over what the DRAFT holds, on <param branchId>.


### PR DESCRIPTION
misc things from a long list I have locally

- **the relay write secret was readable from Dark.** it lived in `config_v0`, and `configGet` refuses secret keys, but Dark reaches sqlite directly too and a query against the store only needs `package-read` (which every install has, since `dark status` is Dark). `SELECT length(value) FROM config_v0 WHERE key LIKE 'sync.secret.%'` returned `Some(39)`. credentials moved to `credentials.db` beside the store; that's not the store path, so the same query now needs `allow native` and gets refused.
- **`dark constraints` said "nothing has drifted" when it hadn't looked.** two detectors read the op log and a failed read came back as `[]`. they return a `Result` now, and `--json` grew a `blocked` key.
- **`?owner=a%26b` arrived as two parameters.** the server handed Dark a url `Url.ToString()` had already decoded, then `queryParams` decoded it again. built from `RawUrl` now.
- **a hung CLI command killed the suite silently.** `runCli` had no timeout and `Console.SetOut` is redirected while a command runs, so a command waiting on stdin produced no output, no error, no name in the log. two minutes, then it names the command.